### PR TITLE
Improve error handler

### DIFF
--- a/components/GQL/GraphqlErrorHandler.tsx
+++ b/components/GQL/GraphqlErrorHandler.tsx
@@ -56,9 +56,8 @@ export const MutationErrorHandler = ({
       const mutationResult = await mutateFn(options)
       return mutationResult
     } catch (err) {
-      checkError(err)
+      throw err
     }
-    return Promise.resolve()
   }
 
   return <>{children(mutateWithCatch, result)}</>


### PR DESCRIPTION
### Changes ###
- Remove line 59 `checkError` since it will always be
 executed at line 51
- Throw error so children can catch and cope it with different ways