### PR TITLE
Fix modal out-side-click

### DIFF
--- a/components/Hook/index.ts
+++ b/components/Hook/index.ts
@@ -1,3 +1,4 @@
 export * from './useEventListener'
 export * from './useNativeEventListener'
 export * from './useInterval'
+export * from './useOutsideClick'

--- a/components/Hook/useOutsideClick.ts
+++ b/components/Hook/useOutsideClick.ts
@@ -1,0 +1,26 @@
+import { useEffect } from 'react'
+
+export const useOutsideClick = (
+  node: React.RefObject<HTMLElement>,
+  action: any
+) => {
+  useEffect(() => {
+    if (!action) {
+      return undefined
+    }
+
+    const listener = (event: any) => {
+      if (!node.current || node.current.contains(event.target as Node)) {
+        return undefined
+      }
+      action(event)
+    }
+    document.addEventListener('mousedown', listener)
+    document.addEventListener('touchstart', listener)
+
+    return () => {
+      document.removeEventListener('mousedown', listener)
+      document.removeEventListener('touchstart', listener)
+    }
+  }, [node, action])
+}

--- a/components/Modal/Container/index.tsx
+++ b/components/Modal/Container/index.tsx
@@ -1,9 +1,9 @@
 // External modules
 import classNames from 'classnames'
-import { FC, useContext, useState } from 'react'
+import { FC, useContext, useRef, useState } from 'react'
 
 import { LanguageContext } from '~/components'
-import { useNativeEventListener } from '~/components/Hook'
+import { useNativeEventListener, useOutsideClick } from '~/components/Hook'
 import ModalHeader from '~/components/Modal/Header'
 
 import { KEYCODES, TEXT } from '~/common/enums'
@@ -41,8 +41,8 @@ const Container: FC<ContainerProps> = ({
       layout === 'small'
   })
 
+  const node = useRef(null)
   const { lang } = useContext(LanguageContext)
-  const [node, setNode] = useState<HTMLElement | null>(null)
   const [closeable, setCloseable] = useState(defaultCloseable)
   const [modalClass, setModalClass] = useState<string>(modalBaseClass)
 
@@ -64,29 +64,21 @@ const Container: FC<ContainerProps> = ({
     close()
   }
 
-  const handleOnOutsideClick = (event: any) => {
+  const handleOnOutsideClick = () => {
     if (!closeable) {
-      return undefined
-    }
-
-    if (
-      !node ||
-      node.contains(event.target) ||
-      (event.button && event.button !== 0)
-    ) {
       return undefined
     }
     close()
   }
 
   useNativeEventListener('keydown', handleOnEsc)
-  useNativeEventListener('click', handleOnOutsideClick)
+  useOutsideClick(node, handleOnOutsideClick)
 
   return (
     <div className={overlayClass}>
       <div style={{ width: '100%' }}>
         <div className="l-row">
-          <div ref={setNode} className={modalClass}>
+          <div ref={node} className={modalClass}>
             <div className="container">
               {title && (
                 <ModalHeader closeable={closeable} title={interpret(title)} />


### PR DESCRIPTION
### Changes ###
- Use `useRef` to store ref instead of using `useState`
- Create `useOutsideClick` hook and replace `useEventListener('click', action)` with it