### PR TITLE
Restrict editor formats for pasted content

### DIFF
--- a/components/Editor/CommentEditor/index.tsx
+++ b/components/Editor/CommentEditor/index.tsx
@@ -128,6 +128,7 @@ class CommentEditor extends React.Component<Props, State> {
                       onInit: this.onMentionModuleInit
                     }
                   }}
+                  formats={config.foramts}
                   ref={this.reactQuillRef}
                   value={content}
                   placeholder={translate({

--- a/components/Editor/configs/comment.ts
+++ b/components/Editor/configs/comment.ts
@@ -7,3 +7,12 @@ export const modules = {
     ['blockquote', { list: 'ordered' }, { list: 'bullet' }, 'link']
   ]
 }
+
+export const foramts = [
+  'bold',
+  'italic',
+  'underline',
+  'blockquote',
+  'list',
+  'link'
+]

--- a/components/Editor/configs/default.ts
+++ b/components/Editor/configs/default.ts
@@ -47,3 +47,27 @@ export const modules = {
     }
   }
 }
+
+export const foramts = [
+  'bold',
+  'code',
+  'italic',
+  'link',
+  'strike',
+  'script',
+  'underline',
+
+  'header',
+  'blockquote',
+  'list',
+  'code-block',
+
+  'divider',
+  'embedClipboard',
+  'embedCode',
+  'embedVideo',
+  'figcaption',
+  'imageFigure',
+  'mention',
+  'smartBreak'
+]

--- a/components/Editor/index.tsx
+++ b/components/Editor/index.tsx
@@ -141,8 +141,8 @@ class Editor extends React.Component<Props, State> {
             coverAssetId: assets[0]
           }
         : {
-          content: trimLineBreaks(content),
-        }
+            content: trimLineBreaks(content)
+          }
     this.props.onSave(draft)
   }
 
@@ -235,6 +235,7 @@ class Editor extends React.Component<Props, State> {
                       onInit: this.onMentionModuleInit
                     }
                   }}
+                  formats={config.foramts}
                   ref={this.reactQuillRef}
                   value={this.state.content}
                   placeholder={translate({


### PR DESCRIPTION
**Note:** After this PR, custom blot needs to added to `formats` list [[1]](https://github.com/thematters/matters-web/pull/197/files#diff-fcad0382df0066bec21255a15256fde2R11)[[2]](https://github.com/thematters/matters-web/pull/197/files#diff-fe4485795f9366916260a86b5690dedfR51) to activate format.