### PR TITLE
Add pages for LikeCoin PoCs

### DIFF
--- a/common/enums/route.ts
+++ b/common/enums/route.ts
@@ -33,6 +33,9 @@ type ROUTE_KEY =
   | 'AUTH_SIGNUP'
   | 'AUTH_FORGET'
   | 'OAUTH_AUTHORIZE'
+  | 'OAUTH_CALLBACK_SUCCESS'
+  | 'OAUTH_CALLBACK_FAILURE'
+  | 'OAUTH_LIKECOIN_POLLING'
   | 'MISC_ABOUT'
   | 'MISC_FAQ'
   | 'MISC_TOS'
@@ -194,6 +197,23 @@ export const ROUTES: Array<{
     key: 'OAUTH_AUTHORIZE',
     href: '/OAuthAuthorize',
     as: '/oauth/authorize'
+  },
+  {
+    key: 'OAUTH_CALLBACK_SUCCESS',
+    href: '/OAuthCallbackSuccess',
+    as: '/oauth/:provider/success'
+  },
+  {
+    key: 'OAUTH_CALLBACK_FAILURE',
+    href: '/OAuthCallbackFailure',
+    as: '/oauth/:provider/failure'
+  },
+
+  // temporary endpoint
+  {
+    key: 'OAUTH_LIKECOIN_POLLING',
+    href: '/OAuthLikeCoinPolling',
+    as: '/oauth/likecoin/polling'
   },
 
   // Misc

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "matters-web",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/pages/OAuthCallbackFailure.tsx
+++ b/pages/OAuthCallbackFailure.tsx
@@ -1,0 +1,3 @@
+import OAuthCallbackFailure from '~/views/OAuth/Callback/Failure'
+
+export default () => <OAuthCallbackFailure />

--- a/pages/OAuthCallbackSuccess.tsx
+++ b/pages/OAuthCallbackSuccess.tsx
@@ -1,0 +1,3 @@
+import OAuthCallbackSuccess from '~/views/OAuth/Callback/Success'
+
+export default () => <OAuthCallbackSuccess />

--- a/pages/OAuthLikeCoinPolling.tsx
+++ b/pages/OAuthLikeCoinPolling.tsx
@@ -1,0 +1,3 @@
+import OAuthLikeCoinPolling from '~/views/OAuth/LikeCoinPolling'
+
+export default () => <OAuthLikeCoinPolling />

--- a/views/OAuth/Callback/Failure/index.tsx
+++ b/views/OAuth/Callback/Failure/index.tsx
@@ -1,0 +1,16 @@
+import { withRouter, WithRouterProps } from 'next/router'
+
+import { getQuery } from '~/common/utils'
+
+const OAuthCallbackFailure: React.FC<WithRouterProps> = ({ router }) => {
+  const provider = getQuery({ router, key: 'provider' })
+  const code = getQuery({ router, key: 'code' })
+
+  return (
+    <span>
+      {provider} failure: {code}
+    </span>
+  )
+}
+
+export default withRouter(OAuthCallbackFailure)

--- a/views/OAuth/Callback/Success/index.tsx
+++ b/views/OAuth/Callback/Success/index.tsx
@@ -1,0 +1,11 @@
+import { withRouter, WithRouterProps } from 'next/router'
+
+import { getQuery } from '~/common/utils'
+
+const OAuthCallbackSuccess: React.FC<WithRouterProps> = ({ router }) => {
+  const provider = getQuery({ router, key: 'provider' })
+
+  return <span>{provider} success</span>
+}
+
+export default withRouter(OAuthCallbackSuccess)

--- a/views/OAuth/LikeCoinPolling/index.tsx
+++ b/views/OAuth/LikeCoinPolling/index.tsx
@@ -1,0 +1,57 @@
+import gql from 'graphql-tag'
+import getConfig from 'next/config'
+import { useState } from 'react'
+import { Query, QueryResult } from 'react-apollo'
+
+import { Button } from '~/components'
+
+const {
+  publicRuntimeConfig: { OAUTH_URL }
+} = getConfig()
+
+const VIEWER_LIKER_ID = gql`
+  query ViewerLikerId {
+    viewer {
+      id
+      likerId
+    }
+  }
+`
+
+const OAuthLikeCoinPolling = () => {
+  const [polling, setPolling] = useState(false)
+
+  return (
+    <Query
+      query={VIEWER_LIKER_ID}
+      pollInterval={polling ? 1000 : undefined}
+      errorPolicy="none"
+      fetchPolicy="network-only"
+      skip={!process.browser}
+    >
+      {({ data, loading }: QueryResult) => {
+        const viewer = data && data.viewer
+        const likerId = viewer && viewer.likerId
+
+        return (
+          <Button
+            htmlType="button"
+            bgColor="green"
+            disabled={polling || likerId}
+            onClick={() => {
+              const url = `${OAUTH_URL}/likecoin`
+              window.open(url, '_blank')
+              setPolling(true)
+            }}
+          >
+            {!polling && !likerId && <span>綁定 Liker ID</span>}
+            {polling && !likerId && <span>請稍候</span>}
+            {likerId && <span>你已綁定 LikeCoin 帳號：{likerId}</span>}
+          </Button>
+        )
+      }}
+    </Query>
+  )
+}
+
+export default OAuthLikeCoinPolling


### PR DESCRIPTION
**Endpoints**

* `/oauth/:provider/success` 
* `/oauth/:provider/failure`
* `/oauth/likecoin/polling` (for PoC stage, will be deleted after this stage)
