### PR TITLE
Fix  "Can't find field cursor on object" 

### DIFF
--- a/components/DraftDigest/Components/DeleteButton.tsx
+++ b/components/DraftDigest/Components/DeleteButton.tsx
@@ -19,7 +19,6 @@ const ME_DRADTS = gql`
       id
       drafts(input: { first: null }) @connection(key: "viewerDrafts") {
         edges {
-          cursor
           node {
             id
           }


### PR DESCRIPTION
Skip query `cursor` to fix  `Can't find field cursor on object` in `<DeleteButton>` update of mutation since we haven't query this field in [`<DraftList>`](https://github.com/thematters/matters-web/blob/develop/views/Me/DraftDetail/Sidebar/DraftList/index.tsx#L16)