### PR TITLE
Set "unsafe-perm" as true to fix eb deploy issue

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+unsafe-perm=true


### PR DESCRIPTION
https://elasticbeanstalk-ap-southeast-1-903380195283.s3.ap-southeast-1.amazonaws.com/resources/environments/logs/tail/e-qgiimrpfq6/i-0b14442c268d2935f/TailLogs-1570609377636.out?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20191009T082259Z&X-Amz-SignedHeaders=host&X-Amz-Expires=86400&X-Amz-Credential=AKIAJ2SGL3KAXZMQ2ZHQ%2F20191009%2Fap-southeast-1%2Fs3%2Faws4_request&X-Amz-Signature=b0408ec6f0c785dd9ac95f27529da2999a47bbb5a3209e7729dc0bc05d751e41


https://github.com/ember-fastboot/fastboot-aws/issues/4