### PR TITLE
Declare "ENV" at CI "build" step based on branches

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -26,13 +26,17 @@ steps:
       - npm run test
       - codecov
 
-  - name: build
+  # === CI tasks for `develop` branch ===
+  - name: develop:build
     image: node:11.14.0
     commands:
-      - cp .env.example .env
       - npm run build
+    environment:
+      ENV: development
+    when:
+      branch:
+        - develop
 
-  # === CI tasks for `develop` branch ===
   - name: develop:upload
     image: plugins/s3
     settings:
@@ -48,7 +52,6 @@ steps:
     when:
       branch:
         - develop
-        - feature/dotenv
       event:
         - push
 
@@ -72,6 +75,16 @@ steps:
         - push
 
   # === CI tasks for `master` branch ===
+  - name: prod:build
+    image: node:11.14.0
+    commands:
+      - npm run build
+    environment:
+      ENV: production
+    when:
+      branch:
+        - master
+
   - name: prod:upload
     image: plugins/s3
     settings:
@@ -87,7 +100,6 @@ steps:
     when:
       branch:
         - master
-        - feature/master
       event:
         - push
 
@@ -106,7 +118,6 @@ steps:
       - bash ./bin/eb-deploy.sh prod
     when:
       branch:
-        - feature/master
         - master
       event:
         - push

--- a/next.config.js
+++ b/next.config.js
@@ -16,9 +16,10 @@ const withOffline = require('next-offline')
 const packageJson = require('./package.json')
 
 const isProd = process.env.ENV === 'production'
-const FIREBASE_CONFIG = JSON.parse(
-  Buffer.from(process.env.FIREBASE_CONFIG, 'base64').toString()
-)
+const FIREBASE_CONFIG = process.env.FIREBASE_CONFIG
+  ? JSON.parse(Buffer.from(process.env.FIREBASE_CONFIG, 'base64').toString())
+  : {}
+
 const URL_PUSH_SW = isProd
   ? './firebase-messaging-sw-production.js'
   : './firebase-messaging-sw-develop.js'

--- a/src/common/utils/withApollo.ts
+++ b/src/common/utils/withApollo.ts
@@ -34,7 +34,7 @@ const isProd = ENV === 'production'
 
 // toggle http for local dev
 const agent =
-  API_URL.split(':')[0] === 'http'
+  (API_URL || '').split(':')[0] === 'http'
     ? new http.Agent()
     : new https.Agent({
         rejectUnauthorized: isProd // allow access to https:...matters.news in localhost

--- a/src/views/Me/Settings/Notification/SettingsNotification.tsx
+++ b/src/views/Me/Settings/Notification/SettingsNotification.tsx
@@ -1,7 +1,7 @@
 import gql from 'graphql-tag'
 import { useQuery } from 'react-apollo'
 
-import { Head, PageHeader, Translate } from '~/components'
+import { Head, PageHeader, Spinner, Translate } from '~/components'
 import { useMutation } from '~/components/GQL'
 
 import { TEXT } from '~/common/enums'
@@ -162,11 +162,15 @@ const SettingsNotification = () => {
   const [updateNotification] = useMutation<UpdateViewerNotification>(
     UPDATE_VIEWER_NOTIFICATION
   )
-  const { data } = useQuery<ViewerNotificationSettings>(
+  const { data, loading } = useQuery<ViewerNotificationSettings>(
     VIEWER_NOTIFICATION_SETTINGS
   )
   const settings = data && data.viewer && data.viewer.settings.notification
   const id = data && data.viewer && data.viewer.id
+
+  if (loading) {
+    return <Spinner />
+  }
 
   if (!id || !settings) {
     return null


### PR DESCRIPTION
* Declare `ENV` based on branches (`develop` or `master`) since we `service-worker.js` is generated in `build` stage
* Add spinner to SettingsNotification page