### PR TITLE
Tiny style fix for expandable user description

### DIFF
--- a/src/components/UserProfile/styles.css
+++ b/src/components/UserProfile/styles.css
@@ -73,6 +73,8 @@
 
 .header {
   @mixin flex-start-space-between;
+
+  margin-bottom: var(--spacing-x-tight);
 }
 
 .basic {
@@ -138,7 +140,6 @@
 
 .description {
   position: relative;
-  margin-top: var(--spacing-x-tight);
   color: var(--color-grey-darker);
   font-size: var(--font-size-sm);
   white-space: pre-wrap;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4065233/70978136-2bf2f400-20ea-11ea-832a-2e6b7504475a.png)

exactly same after expanded:

![image](https://user-images.githubusercontent.com/4065233/70978149-31e8d500-20ea-11ea-9608-8006deda6243.png)
