### PR TITLE
Fix unpacking result throwing empty message.

### DIFF
--- a/src/components/Buttons/Write/index.tsx
+++ b/src/components/Buttons/Write/index.tsx
@@ -90,8 +90,8 @@ export const WriteButton = ({ allowed, isLarge }: Props) => {
       onClick={async () => {
         try {
           analytics.trackEvent(ANALYTICS_EVENTS.CLICK_WRITE_BUTTON)
-          const { data } = await putDraft()
-          const { slug, id } = data?.putDraft || {}
+          const result = await putDraft()
+          const { slug, id } = result?.data?.putDraft || {}
 
           if (slug && id) {
             const path = toPath({ page: 'draftDetail', slug, id })


### PR DESCRIPTION
### Note
Spotted this coding pattern could trigger multiple error toasts.

```
try {
  const { data } = await API()
} catch (error) {
  window.dispatchEvent('')
}
```

- First error toast comes from GQL (e.g. `unauthed`).
- Second one comes from `catch` because there is no returned data from API. In this case, deconstructuring `const { data } = ` would fail.