### PR TITLE
Fix permission error of navigator.share

### DIFF
--- a/src/components/Dialogs/ShareDialog/index.tsx
+++ b/src/components/Dialogs/ShareDialog/index.tsx
@@ -38,7 +38,7 @@ const BaseShareDialog = ({
   shareLink,
   children,
 }: BaseShareDialogProps) => {
-  const [showDialog, setShowDialog] = useState(false)
+  const [showDialog, setShowDialog] = useState(true)
   const open = () => setShowDialog(true)
   const close = () => setShowDialog(false)
 


### PR DESCRIPTION
The previous fix with `useEffect` will cause permission error:

```
NotAllowedError: The request is not allowed by the user agent or the platform in the current context, possibly because the user denied permission.
```