### PR TITLE
unsubscribePush before trying to logout

### DIFF
--- a/src/components/GlobalDialogs/TermAlertDialog/index.tsx
+++ b/src/components/GlobalDialogs/TermAlertDialog/index.tsx
@@ -64,9 +64,14 @@ const TermContent: React.FC<TermContentProps> = ({ closeDialog }) => {
 
   const onLogout = async () => {
     try {
+      await unsubscribePush()
+    } catch (e) {
+      console.error(e)
+    }
+
+    try {
       await logout()
 
-      await unsubscribePush()
       // await clearPersistCache()
 
       closeDialog()

--- a/src/components/Layout/NavMenu/Bottom.tsx
+++ b/src/components/Layout/NavMenu/Bottom.tsx
@@ -30,6 +30,12 @@ const NavMenuBottom: React.FC<NavMenuBottomProps> = ({ isInSideDrawerNav }) => {
   const viewer = useContext(ViewerContext)
   const onClickLogout = async () => {
     try {
+      await unsubscribePush()
+    } catch (e) {
+      console.error(e)
+    }
+
+    try {
       await logout()
 
       analytics.trackEvent(ANALYTICS_EVENTS.LOG_OUT, { id: viewer.id })
@@ -43,7 +49,6 @@ const NavMenuBottom: React.FC<NavMenuBottomProps> = ({ isInSideDrawerNav }) => {
         })
       )
 
-      await unsubscribePush()
       // await clearPersistCache()
 
       redirectToTarget()


### PR DESCRIPTION
In previous fixes (#1042), `unsubscribePush` will be called after logged out, but the `ToggleSubscribePush` mutation is authentication-required.