### PR TITLE
[hotfix - master] Fix "service-worker.js" bad serving in Next.js 9.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,4 @@ tests_output
 
 # misc
 TODO
+service-worker.js*

--- a/next.config.js
+++ b/next.config.js
@@ -169,6 +169,7 @@ module.exports = withPlugins(
         workboxOpts: {
           // https://github.com/hanford/next-offline/issues/35
           importScripts: [URL_PUSH_SW],
+          swDest: '../public/service-worker.js',
           runtimeCaching: [
             {
               urlPattern: '/',

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,7 +9,6 @@ import helmet from 'helmet'
 import MobileDetect from 'mobile-detect'
 import 'module-alias/register'
 import next from 'next'
-import { join } from 'path'
 
 import { ROUTES, toExpressPath } from '~/common/enums'
 
@@ -60,12 +59,6 @@ app
 
     // fallback
     server.get('*', (req, res) => {
-      if (req.path === '/service-worker.js') {
-        const filePath = join('build', req.path)
-        res.setHeader('Service-Worker-Allowed', '/')
-        return app.serveStatic(req, res, filePath)
-      }
-
       return handle(req, res)
     })
 


### PR DESCRIPTION
* Generate `service-worker.js` to `public` will use Next.js's default static file serving feature