### PR TITLE
Revise pin input style to suit main browsers.

### DIFF
--- a/src/components/Form/PinInput/styles.css
+++ b/src/components/Form/PinInput/styles.css
@@ -1,14 +1,14 @@
 .pin-input {
-  display: flex;
-  align-items: center;
+  @mixin flex-center-all;
+
   margin: 0 auto;
   padding: 0 var(--spacing-base);
   width: 100%;
 
   & .pin-input-item {
-    flex: 1 1 auto;
-    display: inline-block;
+    display: flex;
 
+    width: 16.6%;
     height: 3rem;
 
     color: var(--color-black);


### PR DESCRIPTION
@robertu7 `flex-basis` seems not overwriting input `width` in Firefox. (weird 🤔) Using `16%` might also achieves dynamic width.
