### PR TITLE
Fix LikeCoinDialog was auto closed

### DIFF
--- a/src/components/Buttons/Write/index.tsx
+++ b/src/components/Buttons/Write/index.tsx
@@ -111,6 +111,11 @@ export const WriteButton = ({ allowed, isLarge, forbidden }: Props) => {
           }
         } catch (error) {
           const [messages, codes] = parseFormSubmitErrors(error, lang)
+
+          if (!messages[codes[0]]) {
+            return null
+          }
+
           window.dispatchEvent(
             new CustomEvent(ADD_TOAST, {
               detail: {

--- a/src/components/Dialogs/LikeCoinDialog/index.tsx
+++ b/src/components/Dialogs/LikeCoinDialog/index.tsx
@@ -47,11 +47,7 @@ export const LikeCoinDialog: React.FC<LikeCoinDialogProps> = ({
         )}
 
         {step === 'setup' && (
-          <SetupLikeCoin
-            purpose="dialog"
-            submitCallback={close}
-            closeDialog={close}
-          />
+          <SetupLikeCoin purpose="dialog" closeDialog={close} />
         )}
       </Dialog>
     </>

--- a/src/components/Forms/SendCode/index.tsx
+++ b/src/components/Forms/SendCode/index.tsx
@@ -78,6 +78,11 @@ export const SendCodeButton: React.FC<SendCodeButtonProps> = ({
       }
     } catch (error) {
       const [messages, codes] = parseFormSubmitErrors(error, lang)
+
+      if (!messages[codes[0]]) {
+        return
+      }
+
       window.dispatchEvent(
         new CustomEvent(ADD_TOAST, {
           detail: {

--- a/src/components/GlobalDialogs/TermAlertDialog/index.tsx
+++ b/src/components/GlobalDialogs/TermAlertDialog/index.tsx
@@ -49,6 +49,11 @@ const TermContent: React.FC<TermContentProps> = ({ closeDialog }) => {
         closeDialog()
       } catch (error) {
         const [messages, codes] = parseFormSubmitErrors(error, lang)
+
+        if (!messages[codes[0]]) {
+          return
+        }
+
         window.dispatchEvent(
           new CustomEvent(ADD_TOAST, {
             detail: {

--- a/src/components/SetupLikeCoin/Binding/index.tsx
+++ b/src/components/SetupLikeCoin/Binding/index.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from '@apollo/react-hooks'
 import gql from 'graphql-tag'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import { Dialog, Spinner, Translate } from '~/components'
 
@@ -36,19 +36,21 @@ const Binding: React.FC<Props> = ({ prevStep, nextStep, windowRef }) => {
   })
   const likerId = data?.viewer?.liker.likerId
 
-  if (likerId) {
-    nextStep()
+  useEffect(() => {
+    if (likerId) {
+      nextStep()
 
-    if (windowRef) {
-      windowRef.close()
+      if (windowRef) {
+        windowRef.close()
+      }
+
+      return
     }
 
-    return null
-  }
-
-  if (error) {
-    setPolling(false)
-  }
+    if (error) {
+      setPolling(false)
+    }
+  })
 
   return (
     <>


### PR DESCRIPTION
* Fix `<LikeCoinDialog>` was auto closed that caused by providing `submitCallback`; 
* Put polling logic of `<SetupLikeCoin.Binding>` inside `useEffect`;
* Skip error toasting by ReCaptcha;
