### PR TITLE
Bugfixes: Lazy load responses

### DIFF
--- a/src/views/ArticleDetail/index.tsx
+++ b/src/views/ArticleDetail/index.tsx
@@ -132,7 +132,7 @@ const ArticleDetail = () => {
   const features = useContext(FeaturesContext)
   const isLargeUp = useResponsive('lg-up')
   const [fixedWall, setFixedWall] = useState(false)
-  const [showResponses, setShowResponses] = useState(false)
+  // const [showResponses, setShowResponses] = useState(false)
 
   // ssr data
   const { data, loading, error } = useQuery<ArticleDetailType>(
@@ -295,12 +295,12 @@ const ArticleDetail = () => {
 
           {features.payment && <DynamicDonation mediaHash={mediaHash} />}
 
-          <Waypoint
+          {/* <Waypoint
             bottomOffset={-200}
             onEnter={() => {
               setShowResponses(true)
             }}
-          />
+          /> */}
 
           {(collectionCount > 0 || isAuthor) && (
             <section className="block">
@@ -316,7 +316,8 @@ const ArticleDetail = () => {
             }}
           />
 
-          {!shouldShowWall && showResponses && (
+          {!shouldShowWall && (
+            // showResponses &&
             <section className="block">
               <DynamicResponse />
             </section>

--- a/src/views/Home/Feed/index.tsx
+++ b/src/views/Home/Feed/index.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from '@apollo/react-hooks'
 import { NetworkStatus } from 'apollo-client'
 import gql from 'graphql-tag'
-import { useContext, useEffect } from 'react'
+import { useContext } from 'react'
 
 import {
   ArticleDigestFeed,
@@ -150,21 +150,9 @@ const MainFeed = ({ feedSortType: sortBy }: { feedSortType: SortByType }) => {
     fetchMore: fetchMoreMainFeed,
     networkStatus,
     refetch,
-    client,
   } = useQuery<HottestFeed | NewestFeed>(queries[sortBy], {
     notifyOnNetworkStatusChange: true,
   })
-
-  // prefetch other queries
-  useEffect(() => {
-    Object.keys(queries)
-      .filter((s) => s !== sortBy)
-      .map((s) => {
-        client.query({
-          query: queries[s as SortByType],
-        })
-      })
-  }, [])
 
   const connectionPath = 'viewer.recommendation.feed'
   const result = data?.viewer?.recommendation.feed


### PR DESCRIPTION
* Revert lazy load responses; <sup>[1]</sup>
* Remove prefetch home feeds; <sup>[2]</sup>


<sup>[1]</sup> https://mattersnews.slack.com/archives/GA0R09FHN/p1591669611000500
<sup>[2]</sup> We expect that the position of the viewport should be scroll to top when switching to a feed for the first time, but since feeds are prefetched, there aren't `<Spinner>` shown to force user scroll to top now. @guoliu 