### PR TITLE
Remove optimisticResponse to fix the state polling

### DIFF
--- a/src/views/Me/DraftDetail/PublishButton/PublishDialog/PublishContent.tsx
+++ b/src/views/Me/DraftDetail/PublishButton/PublishDialog/PublishContent.tsx
@@ -27,16 +27,7 @@ const PUBLISH_ARTICLE = gql`
 const PublishContent: React.FC<PublishContentProps> = ({ closeDialog }) => {
   const router = useRouter()
   const id = getQuery({ router, key: 'draftId' })
-  const [publish] = useMutation<PublishArticle>(PUBLISH_ARTICLE, {
-    optimisticResponse: {
-      publishArticle: {
-        id,
-        scheduledAt: new Date(Date.now() + 1000).toISOString(),
-        publishState: 'pending' as any,
-        __typename: 'Draft',
-      },
-    },
-  })
+  const [publish] = useMutation<PublishArticle>(PUBLISH_ARTICLE)
 
   const onPublish = async () => {
     publish({ variables: { id } })


### PR DESCRIPTION
With `optimisticResponse`, we start polling immediately, but the server response of `draft.publishState` may still be `unpublish`, and it will cause the dialog never show.