### PR TITLE
ci(deployment): skip waiting for eb deployment in dev env

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -101,6 +101,7 @@ jobs:
           region: ap-southeast-1
           deployment_package: deploy.zip
           use_existing_version_if_available: true
+          wait_for_deployment: false
 
       # === `master` branch ===
       - name: Upload Assets (production)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "matters-web",
-  "version": "3.8.0",
+  "version": "3.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
This change could save some runner minutes.