### PR TITLE
fix(responsive-image): fix `changetExt` can't correctly handle URL that no extension

### DIFF
--- a/src/common/enums/fileTypes.ts
+++ b/src/common/enums/fileTypes.ts
@@ -2,7 +2,6 @@ export const ACCEPTED_UPLOAD_IMAGE_TYPES: string[] = [
   'image/gif',
   'image/png',
   'image/jpeg',
-  'image/svg+xml',
   'image/webp',
 ]
 

--- a/src/common/utils/url.ts
+++ b/src/common/utils/url.ts
@@ -34,16 +34,16 @@ interface ToSizedImageURLProps {
 
 const PROCESSED_PREFIX = 'processed'
 
-export const changeExt = ({ url, ext }: { url: string; ext?: 'webp' }) => {
-  const list = url.split('.')
+export const changeExt = ({ key, ext }: { key: string; ext?: 'webp' }) => {
+  const list = key.split('.')
   const hasExt = list.length > 1
   const newExt = ext || list.slice(-1)[0] || ''
 
   if (hasExt) {
-    return url.replace(/\.[^.]+$/, `.${newExt}`)
+    return key.replace(/\.[^.]+$/, `.${newExt}`)
   }
 
-  return `${url}.${ext || ''}`
+  return `${key}${ext ? '.' + ext : ''}`
 }
 
 export const toSizedImageURL = ({ url, size, ext }: ToSizedImageURLProps) => {
@@ -53,8 +53,9 @@ export const toSizedImageURL = ({ url, size, ext }: ToSizedImageURLProps) => {
     return url
   }
 
-  const extedUrl = changeExt({ url, ext })
+  const key = url.replace(assetDomain, ``)
+  const extedUrl = changeExt({ key, ext })
   const prefix = size ? '/' + PROCESSED_PREFIX + '/' + size : ''
 
-  return extedUrl.replace(assetDomain, `${assetDomain}${prefix}`)
+  return assetDomain + prefix + extedUrl
 }


### PR DESCRIPTION
e.g. https://assets.matters.news/avatar/265e9aad-e5a6-479d-828b-6848f088ca61/img-6740-jpg