### PR TITLE
fix(share): encode share link

### DIFF
--- a/src/components/ArticleDigest/FooterActions/index.tsx
+++ b/src/components/ArticleDigest/FooterActions/index.tsx
@@ -66,7 +66,7 @@ const FooterActions = ({
         <BookmarkButton article={article} inCard={inCard} />
         <ShareButton
           title={title}
-          path={path.as}
+          path={encodeURI(path.as)}
           iconColor="grey"
           inCard={inCard}
         />

--- a/src/components/Dialogs/ShareDialog/Copy.tsx
+++ b/src/components/Dialogs/ShareDialog/Copy.tsx
@@ -21,8 +21,8 @@ const Copy = ({ link }: { link: string }) => {
         </Button>
       </CopyToClipboard>
 
-      <CopyToClipboard text={decodeURI(link)}>
-        <input ref={inputRef} type="text" value={decodeURI(link)} readOnly />
+      <CopyToClipboard text={link}>
+        <input ref={inputRef} type="text" value={link} readOnly />
       </CopyToClipboard>
 
       <style jsx>{styles}</style>

--- a/src/views/Me/DraftDetail/PublishState/PublishedState.tsx
+++ b/src/views/Me/DraftDetail/PublishState/PublishedState.tsx
@@ -31,7 +31,7 @@ const PublishedState = ({ draft }: { draft: PublishStateDraft }) => {
   return (
     <ShareDialog
       title={draft.article.title}
-      path={path.as}
+      path={encodeURI(path.as)}
       description={
         <>
           <p>


### PR DESCRIPTION
Encode share link since Twitter still can't recognize CJK character.

related discussion: https://mattersnews.slack.com/archives/GA0R09FHN/p1594904307003200


**Note:** base branch is `update/tos`, and will deploy together. 