### PR TITLE
feat(feed): disable a/b testing for hottest feed

### DIFF
--- a/src/views/Home/Feed/index.tsx
+++ b/src/views/Home/Feed/index.tsx
@@ -88,12 +88,11 @@ const MainFeed = ({ feedSortType: sortBy, viewMode }: MainFeedProps) => {
   /**
    * Data Fetching
    */
-  const query = FEED_ARTICLES_PUBLIC[sortBy]
+  let query = FEED_ARTICLES_PUBLIC[sortBy]
 
-  // split out group b if in hottest feed and user is logged in
-  // if (isHottestFeed && (!viewer.id || viewer.info.group !== 'b')) {
-  //   query = FEED_ARTICLES_PUBLIC.valued
-  // }
+  if (isHottestFeed && viewer.id) {
+    query = FEED_ARTICLES_PUBLIC.valued
+  }
 
   // public data
   const {


### PR DESCRIPTION
In this PR, A/B testing for the hottest feed of homepage will be disabled, which means all users will query articles from  `article_activity_materialized` table.

 @jiahe82  @jeremyOk 