### PR TITLE
feat(oauth): separate api for oauth

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -6,11 +6,12 @@
 #
 ###
 
-NEXT_PUBLIC_SITE_DOMAIN=https://web-develop.matters.news
-NEXT_PUBLIC_ASSET_DOMAIN=https://assets-develop.matters.news
+NEXT_PUBLIC_SITE_DOMAIN=web-develop.matters.news
+NEXT_PUBLIC_ASSET_DOMAIN=assets-develop.matters.news
 NEXT_PUBLIC_API_URL=https://server-develop.matters.news/graphql
-NEXT_PUBLIC_WS_URL=wss://server-develop.matters.news/graphql
-NEXT_PUBLIC_OAUTH_URL=https://server-develop.matters.news/oauth
+NEXT_PUBLIC_OAUTH_URL=https://auth-server-develop.matters.news/oauth
+NEXT_PUBLIC_OAUTH_API_URL=https://auth-server-develop.matters.news/graphql
+NEXT_PUBLIC_OAUTH_SITE_DOMAIN=auth-develop.matters.news
 NEXT_PUBLIC_SEGMENT_KEY=3gE20MjzN9qncFqlKV0pDvNO7Cp2gWU3
 NEXT_PUBLIC_FB_APP_ID=823885921293850
 NEXT_PUBLIC_SENTRY_DSN=https://409be482d1da4670879048d7d943c38e@sentry.matters.one/2

--- a/.env.local.example
+++ b/.env.local.example
@@ -5,11 +5,12 @@
 #
 ###
 
-NEXT_PUBLIC_SITE_DOMAIN=https://web-develop.matters.news
-NEXT_PUBLIC_ASSET_DOMAIN=https://assets-develop.matters.news
+NEXT_PUBLIC_SITE_DOMAIN=web-develop.matters.news
+NEXT_PUBLIC_ASSET_DOMAIN=assets-develop.matters.news
 NEXT_PUBLIC_API_URL=https://server-develop.matters.news/graphql
-NEXT_PUBLIC_WS_URL=wss://server-develop.matters.news/graphql
-NEXT_PUBLIC_OAUTH_URL=https://server-develop.matters.news/oauth
+NEXT_PUBLIC_OAUTH_URL=https://auth-server-develop.matters.news/oauth
+NEXT_PUBLIC_OAUTH_API_URL=https://auth-server-develop.matters.news/graphql
+NEXT_PUBLIC_OAUTH_SITE_DOMAIN=auth-develop.matters.news
 NEXT_PUBLIC_SEGMENT_KEY=3gE20MjzN9qncFqlKV0pDvNO7Cp2gWU3
 NEXT_PUBLIC_FB_APP_ID=823885921293850
 NEXT_PUBLIC_SENTRY_DSN=

--- a/.env.prod
+++ b/.env.prod
@@ -6,11 +6,12 @@
 #
 ###
 
-NEXT_PUBLIC_SITE_DOMAIN=https://matters.news
-NEXT_PUBLIC_ASSET_DOMAIN=https://assets.matters.news
+NEXT_PUBLIC_SITE_DOMAIN=matters.news
+NEXT_PUBLIC_ASSET_DOMAIN=assets.matters.news
 NEXT_PUBLIC_API_URL=https://server.matters.news/graphql
-NEXT_PUBLIC_WS_URL=wss://server.matters.news/graphql
-NEXT_PUBLIC_OAUTH_URL=https://server.matters.news/oauth
+NEXT_PUBLIC_OAUTH_URL=https://auth-server.matters.news/oauth
+NEXT_PUBLIC_OAUTH_API_URL=https://auth-server.matters.news/graphql
+NEXT_PUBLIC_OAUTH_SITE_DOMAIN=auth.matters.news
 NEXT_PUBLIC_SEGMENT_KEY=Yk2ao5JvhOCyvCh9SCVBT1iTN4kfTpy7
 NEXT_PUBLIC_FB_APP_ID=1415638158583454
 NEXT_PUBLIC_SENTRY_DSN=https://7f664c71fc9b4ee2bbe75fdf766b6228@sentry.matters.one/3

--- a/src/common/utils/url.ts
+++ b/src/common/utils/url.ts
@@ -47,7 +47,9 @@ export const changeExt = ({ key, ext }: { key: string; ext?: 'webp' }) => {
 }
 
 export const toSizedImageURL = ({ url, size, ext }: ToSizedImageURLProps) => {
-  const assetDomain = process.env.NEXT_PUBLIC_ASSET_DOMAIN || ''
+  const assetDomain = process.env.NEXT_PUBLIC_ASSET_DOMAIN
+    ? `https://${process.env.NEXT_PUBLIC_ASSET_DOMAIN}`
+    : ''
   const isOutsideLink = url.indexOf(assetDomain) < 0
   const isGIF = /gif/i.test(url)
 

--- a/src/components/Editor/Article/index.tsx
+++ b/src/components/Editor/Article/index.tsx
@@ -64,7 +64,11 @@ const ArticleEditor: FC<Props> = ({ draft, update, upload }) => {
           siteDomain="matters.news"
           theme="bubble"
           titleDefaultValue={title || ''}
-          uploadAssetDomain={process.env.NEXT_PUBLIC_ASSET_DOMAIN || ''}
+          uploadAssetDomain={
+            process.env.NEXT_PUBLIC_ASSET_DOMAIN
+              ? `https://${process.env.NEXT_PUBLIC_ASSET_DOMAIN}`
+              : ''
+          }
         />
       </div>
       <style jsx>{themeStyles}</style>

--- a/src/components/Head/index.tsx
+++ b/src/components/Head/index.tsx
@@ -38,10 +38,10 @@ export const Head: React.FC<HeadProps> = (props) => {
       ? `${props.keywords.join(',')},matters,matters.news,創作有價`
       : 'matters,matters.news,創作有價',
     url: props.path
-      ? `${process.env.NEXT_PUBLIC_SITE_DOMAIN}${props.path}`
+      ? `//${process.env.NEXT_PUBLIC_SITE_DOMAIN}${props.path}`
       : router.asPath
-      ? `${process.env.NEXT_PUBLIC_SITE_DOMAIN}${router.asPath}`
-      : process.env.NEXT_PUBLIC_SITE_DOMAIN,
+      ? `//${process.env.NEXT_PUBLIC_SITE_DOMAIN}${router.asPath}`
+      : '//' + process.env.NEXT_PUBLIC_SITE_DOMAIN,
     image: props.image || IMAGE_INTRO,
   }
   const canonicalUrl = head.url?.split('#')[0].split('?')[0]


### PR DESCRIPTION
In these changes, API requests will point to `NEXT_PUBLIC_OAUTH_API_URL ` (auth-server.matters.news) if the current host is `NEXT_PUBLIC_OAUTH_SITE_DOMAIN ` (auth.matters.news).

Related PR: https://github.com/thematters/matters-server/pull/1436
Related Issue: https://github.com/thematters/developer-resource/issues/26