### PR TITLE
fix(auth token): retrieve and use auth token from localStorage only during static build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25282,6 +25282,12 @@
         }
       }
     },
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "dev": true
+    },
     "node-forge": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",

--- a/package.json
+++ b/package.json
@@ -144,6 +144,7 @@
     "next-optimized-images": "^2.6.2",
     "nightwatch": "^1.3.7",
     "nightwatch-api": "^3.0.1",
+    "node-fetch": "^2.6.1",
     "postcss-calc": "^7.0.2",
     "postcss-color-function": "^4.1.0",
     "postcss-conditionals": "^2.1.0",

--- a/src/common/utils/withApollo.ts
+++ b/src/common/utils/withApollo.ts
@@ -113,7 +113,7 @@ const authLink = setContext((operation, { headers, ...restCtx }) => {
   }
 
   // Get token from local storage if it's a static-build client
-  if (typeof window !== 'undefined') {
+  if (process.env.NEXT_PUBLIC_BUILD_TYPE === 'static') {
     const token = storage.get(STORAGE_KEY_AUTH_TOKEN)
     if (token && isStaticBuild) {
       headers['x-access-token'] = token


### PR DESCRIPTION
As title.

Also added `node-fetch` to devDependencies, since it's used in `bin/buildFragmentTypes.js`.