### PR TITLE
fix(onboarding-tasks): store init state separately based on viewer id

### DIFF
--- a/src/common/enums/events.ts
+++ b/src/common/enums/events.ts
@@ -19,8 +19,5 @@ export const OPEN_RESET_PASSWORD_DIALOG = 'openPassword'
 export const CLOSE_ACTIVE_DIALOG = 'closeActiveDialog'
 export const OPEN_LIKE_COIN_DIALOG = 'openLikeCoinDialog'
 
-// Account
-export const ACCOUNT_LOGOUT = 'accountLogout'
-
 // Onboarding Tasks
 export const ONBOARDING_TASKS_HIDE = 'onboardingTasksHide'

--- a/src/common/utils/resolvers/clientPreference.ts
+++ b/src/common/utils/resolvers/clientPreference.ts
@@ -14,7 +14,7 @@ const clientPreferenceResolver = (_: any) => {
     },
     routeHistory: [],
     onboardingTasks: {
-      enabled: true,
+      enabled: false,
       __typename: 'OnboardingTasks',
     },
   }

--- a/src/components/GlobalDialogs/TermAlertDialog/index.tsx
+++ b/src/components/GlobalDialogs/TermAlertDialog/index.tsx
@@ -13,11 +13,7 @@ import {
 import { useMutation } from '~/components/GQL'
 import USER_LOGOUT from '~/components/GQL/mutations/userLogout'
 
-import {
-  ACCOUNT_LOGOUT,
-  ADD_TOAST,
-  STORAGE_KEY_AUTH_TOKEN,
-} from '~/common/enums'
+import { ADD_TOAST, STORAGE_KEY_AUTH_TOKEN } from '~/common/enums'
 import { parseFormSubmitErrors, storage, unsubscribePush } from '~/common/utils'
 
 import styles from './styles.css'
@@ -84,7 +80,6 @@ const TermContent: React.FC<TermContentProps> = ({ closeDialog }) => {
     try {
       await logout().then(() => {
         storage.remove(STORAGE_KEY_AUTH_TOKEN)
-        window.dispatchEvent(new CustomEvent(ACCOUNT_LOGOUT, {}))
       })
 
       // await clearPersistCache()

--- a/src/components/Layout/NavMenu/Bottom.tsx
+++ b/src/components/Layout/NavMenu/Bottom.tsx
@@ -10,12 +10,7 @@ import {
 import { useMutation } from '~/components/GQL'
 import USER_LOGOUT from '~/components/GQL/mutations/userLogout'
 
-import {
-  ACCOUNT_LOGOUT,
-  ADD_TOAST,
-  PATHS,
-  STORAGE_KEY_AUTH_TOKEN,
-} from '~/common/enums'
+import { ADD_TOAST, PATHS, STORAGE_KEY_AUTH_TOKEN } from '~/common/enums'
 import { redirectToTarget, storage, unsubscribePush } from '~/common/utils'
 
 import { UserLogout } from '~/components/GQL/mutations/__generated__/UserLogout'
@@ -36,7 +31,6 @@ const NavMenuBottom: React.FC<NavMenuBottomProps> = ({ isInSideDrawerNav }) => {
     try {
       await logout().then(() => {
         storage.remove(STORAGE_KEY_AUTH_TOKEN)
-        window.dispatchEvent(new CustomEvent(ACCOUNT_LOGOUT, {}))
       })
 
       window.dispatchEvent(

--- a/src/components/Root/index.tsx
+++ b/src/components/Root/index.tsx
@@ -94,14 +94,20 @@ const Root = ({
           if (result?.data?.viewer) {
             setPrivateViewer(result?.data?.viewer)
           }
+
+          // mark private fetched as true
+          setPrivateFetched(true)
         },
-        error: (e) => console.error,
+        error: (e) => {
+          // mark private fetched as true
+          setPrivateFetched(true)
+
+          console.error(e)
+        },
       })
     } catch (e) {
       console.error(e)
     }
-
-    setPrivateFetched(true)
   }
 
   useEffect(() => {


### PR DESCRIPTION
* Remove clear state on logout since it's stored separately
* Fix `setPrivateFetched` 
