### PR TITLE
Fix <LikeCoinDialog> auto closed on Liker ID finish setup

### DIFF
--- a/src/components/Buttons/Write/index.tsx
+++ b/src/components/Buttons/Write/index.tsx
@@ -5,14 +5,13 @@ import {
   IconPen,
   IconSpinner,
   LanguageContext,
-  LikeCoinDialog,
   TextIcon,
   Translate,
 } from '~/components'
 import { useMutation } from '~/components/GQL'
 import CREATE_DRAFT from '~/components/GQL/mutations/createDraft'
 
-import { ADD_TOAST, TEXT } from '~/common/enums'
+import { ADD_TOAST, OPEN_LIKE_COIN_DIALOG, TEXT } from '~/common/enums'
 import {
   analytics,
   parseFormSubmitErrors,
@@ -70,9 +69,12 @@ export const WriteButton = ({ allowed, isLarge, forbidden }: Props) => {
 
   if (!allowed) {
     return (
-      <LikeCoinDialog>
-        {({ open }) => <BaseWriteButton onClick={open} isLarge={isLarge} />}
-      </LikeCoinDialog>
+      <BaseWriteButton
+        onClick={() =>
+          window.dispatchEvent(new CustomEvent(OPEN_LIKE_COIN_DIALOG, {}))
+        }
+        isLarge={isLarge}
+      />
     )
   }
 

--- a/src/components/Comment/FooterActions/index.tsx
+++ b/src/components/Comment/FooterActions/index.tsx
@@ -1,9 +1,9 @@
 import gql from 'graphql-tag'
 import { useContext } from 'react'
 
-import { LikeCoinDialog, Translate, ViewerContext } from '~/components'
+import { Translate, ViewerContext } from '~/components'
 
-import { ADD_TOAST, TextId } from '~/common/enums'
+import { ADD_TOAST, OPEN_LIKE_COIN_DIALOG, TextId } from '~/common/enums'
 
 import CreatedAt, { CreatedAtControls } from '../CreatedAt'
 import DownvoteButton from './DownvoteButton'
@@ -69,10 +69,8 @@ const BaseFooterActions = ({
   hasCreatedAt,
   inCard = false,
 
-  openLikeCoinDialog,
-
   ...replyButtonProps
-}: FooterActionsProps & { openLikeCoinDialog: () => void }) => {
+}: FooterActionsProps) => {
   const viewer = useContext(ViewerContext)
 
   const { state, article } = comment
@@ -94,7 +92,8 @@ const BaseFooterActions = ({
   let onClick
 
   if (viewer.shouldSetupLikerID) {
-    onClick = openLikeCoinDialog
+    onClick = () =>
+      window.dispatchEvent(new CustomEvent(OPEN_LIKE_COIN_DIALOG, {}))
   } else if (viewer.isOnboarding && article.author.id !== viewer.id) {
     onClick = () => addToast('failureCommentOnboarding')
   } else if (viewer.isArchived || viewer.isFrozen) {
@@ -136,11 +135,7 @@ const BaseFooterActions = ({
 }
 
 const FooterActions = (props: FooterActionsProps) => (
-  <LikeCoinDialog>
-    {({ open: openLikeCoinDialog }) => (
-      <BaseFooterActions {...props} openLikeCoinDialog={openLikeCoinDialog} />
-    )}
-  </LikeCoinDialog>
+  <BaseFooterActions {...props} />
 )
 
 FooterActions.fragments = fragments

--- a/src/components/GlobalDialogs/index.tsx
+++ b/src/components/GlobalDialogs/index.tsx
@@ -1,3 +1,5 @@
+import { LikeCoinDialog } from '~/components'
+
 import LoginDialog from './LoginDialog'
 import ResetPasswordDialog from './ResetPasswordDialog'
 import SignUpDialog from './SignUpDialog'
@@ -8,6 +10,7 @@ const GlobalDialogs = () => {
       <LoginDialog />
       <SignUpDialog />
       <ResetPasswordDialog />
+      <LikeCoinDialog allowEventTrigger />
     </>
   )
 }

--- a/src/components/OnboardingTasks/Tasks/index.tsx
+++ b/src/components/OnboardingTasks/Tasks/index.tsx
@@ -4,7 +4,6 @@ import {
   Dialog,
   EmbedShare,
   LanguageContext,
-  LikeCoinDialog,
   RecommendAuthorDialog,
   RecommendTagDialog,
   Translate,
@@ -14,7 +13,12 @@ import {
 import { useMutation } from '~/components/GQL'
 import CREATE_DRAFT from '~/components/GQL/mutations/createDraft'
 
-import { ADD_TOAST, ONBOARDING_TASKS_HIDE, URL_QS } from '~/common/enums'
+import {
+  ADD_TOAST,
+  ONBOARDING_TASKS_HIDE,
+  OPEN_LIKE_COIN_DIALOG,
+  URL_QS,
+} from '~/common/enums'
 import {
   analytics,
   parseFormSubmitErrors,
@@ -81,20 +85,23 @@ const Tasks = () => {
   return (
     <>
       <ul>
-        <LikeCoinDialog>
-          {({ open }) => (
-            <TaskItem
-              title={
-                <Translate
-                  zh_hant="設置 Liker ID 化讚為賞"
-                  zh_hans="设置 Liker ID 化赞为赏"
-                />
-              }
-              done={viewer.onboardingTasks.tasks.likerId}
-              onClick={viewer.onboardingTasks.tasks.likerId ? undefined : open}
+        <TaskItem
+          title={
+            <Translate
+              zh_hant="設置 Liker ID 化讚為賞"
+              zh_hans="设置 Liker ID 化赞为赏"
             />
-          )}
-        </LikeCoinDialog>
+          }
+          done={viewer.onboardingTasks.tasks.likerId}
+          onClick={
+            viewer.onboardingTasks.tasks.likerId
+              ? undefined
+              : () =>
+                  window.dispatchEvent(
+                    new CustomEvent(OPEN_LIKE_COIN_DIALOG, {})
+                  )
+          }
+        />
 
         <RecommendAuthorDialog>
           {({ open }) => (

--- a/src/views/ArticleDetail/AppreciationButton/SetupLikerIdAppreciateButton.tsx
+++ b/src/views/ArticleDetail/AppreciationButton/SetupLikerIdAppreciateButton.tsx
@@ -1,12 +1,15 @@
-import { LikeCoinDialog } from '~/components'
+import { OPEN_LIKE_COIN_DIALOG } from '~/common/enums'
 
 import AppreciateButton from './AppreciateButton'
 
 const SetupLikerIdAppreciateButton = ({ total }: { total: number }) => {
   return (
-    <LikeCoinDialog>
-      {({ open }) => <AppreciateButton onClick={open} total={total} />}
-    </LikeCoinDialog>
+    <AppreciateButton
+      onClick={() =>
+        window.dispatchEvent(new CustomEvent(OPEN_LIKE_COIN_DIALOG, {}))
+      }
+      total={total}
+    />
   )
 }
 

--- a/src/views/ArticleDetail/Donation/index.tsx
+++ b/src/views/ArticleDetail/Donation/index.tsx
@@ -1,6 +1,6 @@
 import gql from 'graphql-tag'
 
-import { DonationDialog, LikeCoinDialog } from '~/components'
+import { DonationDialog } from '~/components'
 
 import DonationButton from './DonationButton'
 import Donators from './Donators'
@@ -26,7 +26,7 @@ const fragments = {
   `,
 }
 
-const BaseDonation = ({ article }: DonationProps) => {
+const Donation = ({ article }: DonationProps) => {
   return (
     <section className="container">
       <DonationButton recipient={article.author} targetId={article.id} />
@@ -35,15 +35,6 @@ const BaseDonation = ({ article }: DonationProps) => {
 
       <style jsx>{styles}</style>
     </section>
-  )
-}
-
-const Donation = ({ article }: DonationProps) => {
-  return (
-    <>
-      <BaseDonation article={article} />
-      <LikeCoinDialog allowEventTrigger />
-    </>
   )
 }
 

--- a/src/views/ArticleDetail/Toolbar/CommentBar/index.tsx
+++ b/src/views/ArticleDetail/Toolbar/CommentBar/index.tsx
@@ -8,7 +8,6 @@ import {
   CardProps,
   CommentFormDialog,
   IconComment,
-  LikeCoinDialog,
   TextIcon,
   Translate,
   useResponsive,
@@ -18,6 +17,7 @@ import {
 import {
   ADD_TOAST,
   CLOSE_ACTIVE_DIALOG,
+  OPEN_LIKE_COIN_DIALOG,
   OPEN_LOGIN_DIALOG,
   PATHS,
   REFETCH_RESPONSES,
@@ -111,11 +111,13 @@ const CommentBar = ({ article }: CommentBarProps) => {
 
   if (viewer.shouldSetupLikerID) {
     return (
-      <LikeCoinDialog>
-        {({ open }) => (
-          <Content {...props} aria-haspopup="true" onClick={open} />
-        )}
-      </LikeCoinDialog>
+      <Content
+        {...props}
+        aria-haspopup="true"
+        onClick={() =>
+          window.dispatchEvent(new CustomEvent(OPEN_LIKE_COIN_DIALOG, {}))
+        }
+      />
     )
   }
 

--- a/src/views/Me/DraftDetail/PublishButton/index.tsx
+++ b/src/views/Me/DraftDetail/PublishButton/index.tsx
@@ -1,12 +1,8 @@
 import { useContext } from 'react'
 
-import {
-  Button,
-  LikeCoinDialog,
-  TextIcon,
-  Translate,
-  ViewerContext,
-} from '~/components'
+import { Button, TextIcon, Translate, ViewerContext } from '~/components'
+
+import { OPEN_LIKE_COIN_DIALOG } from '~/common/enums'
 
 import { PublishDialog } from './PublishDialog'
 
@@ -42,9 +38,12 @@ const PublishButtonWithEffect = ({ disabled }: { disabled?: boolean }) => {
   }
 
   return (
-    <LikeCoinDialog>
-      {({ open }) => <PublishButton open={open} disabled={disabled} />}
-    </LikeCoinDialog>
+    <PublishButton
+      open={() =>
+        window.dispatchEvent(new CustomEvent(OPEN_LIKE_COIN_DIALOG, {}))
+      }
+      disabled={disabled}
+    />
   )
 }
 

--- a/src/views/Me/Settings/Settings/Wallet/index.tsx
+++ b/src/views/Me/Settings/Settings/Wallet/index.tsx
@@ -6,12 +6,12 @@ import {
   Form,
   getErrorCodes,
   IconSpinner,
-  LikeCoinDialog,
   Translate,
   usePullToRefresh,
   ViewerContext,
 } from '~/components'
 
+import { OPEN_LIKE_COIN_DIALOG } from '~/common/enums'
 import { numRound } from '~/common/utils'
 
 import { ViewerLikeInfo } from './__generated__/ViewerLikeInfo'
@@ -50,15 +50,16 @@ const WalletSettings = () => {
 
   return (
     <Form.List groupName={<Translate id="settingsWallet" />}>
-      <LikeCoinDialog>
-        {({ open }) => (
-          <Form.List.Item
-            title="Liker ID"
-            onClick={!likerId ? open : undefined}
-            rightText={likerId || <Translate id="setup" />}
-          />
-        )}
-      </LikeCoinDialog>
+      <Form.List.Item
+        title="Liker ID"
+        onClick={
+          !likerId
+            ? () =>
+                window.dispatchEvent(new CustomEvent(OPEN_LIKE_COIN_DIALOG, {}))
+            : undefined
+        }
+        rightText={likerId || <Translate id="setup" />}
+      />
 
       <Form.List.Item
         title={<Translate zh_hant="我的創作價值" zh_hans="我的创作价值" />}

--- a/src/views/TagDetail/Buttons/AddButton/CreateDraftMenuItem/index.tsx
+++ b/src/views/TagDetail/Buttons/AddButton/CreateDraftMenuItem/index.tsx
@@ -3,7 +3,6 @@ import { useContext } from 'react'
 import {
   IconAddMedium,
   LanguageContext,
-  LikeCoinDialog,
   Menu,
   TextIcon,
   Translate,
@@ -12,7 +11,7 @@ import {
 import { useMutation } from '~/components/GQL'
 import CREATE_DRAFT from '~/components/GQL/mutations/createDraft'
 
-import { ADD_TOAST } from '~/common/enums'
+import { ADD_TOAST, OPEN_LIKE_COIN_DIALOG } from '~/common/enums'
 import {
   analytics,
   parseFormSubmitErrors,
@@ -92,9 +91,11 @@ const CreateDraftButton: React.FC<CreateDraftButtonProps> = ({ tag }) => {
 
   if (viewer.shouldSetupLikerID) {
     return (
-      <LikeCoinDialog>
-        {({ open }) => <BaseCreateDraftButton onClick={open} />}
-      </LikeCoinDialog>
+      <BaseCreateDraftButton
+        onClick={() =>
+          window.dispatchEvent(new CustomEvent(OPEN_LIKE_COIN_DIALOG, {}))
+        }
+      />
     )
   }
 


### PR DESCRIPTION
This issue was caused by `viewer.likerId`'s changing, which will trigger UI update and make dialog auto closes.