### PR TITLE
refactor(error): ignore default error catching for form mutations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14922,17 +14922,29 @@
       "dev": true
     },
     "formik": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/formik/-/formik-2.2.6.tgz",
-      "integrity": "sha512-Kxk2zQRafy56zhLmrzcbryUpMBvT0tal5IvcifK5+4YNGelKsnrODFJ0sZQRMQboblWNym4lAW3bt+tf2vApSA==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/formik/-/formik-2.1.7.tgz",
+      "integrity": "sha512-n1wviIh0JsvHqj9PufNvOV+fS7mFwh9FfMxxTMnTrKR/uVYMS06DKaivXBlJdDF0qEwTcPHxSmIQ3deFHL3Hsg==",
       "requires": {
         "deepmerge": "^2.1.1",
         "hoist-non-react-statics": "^3.3.0",
         "lodash": "^4.17.14",
         "lodash-es": "^4.17.14",
         "react-fast-compare": "^2.0.1",
+        "scheduler": "^0.18.0",
         "tiny-warning": "^1.0.2",
         "tslib": "^1.10.0"
+      },
+      "dependencies": {
+        "scheduler": {
+          "version": "0.18.0",
+          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.18.0.tgz",
+          "integrity": "sha512-agTSHR1Nbfi6ulI0kYNK0203joW2Y5W4po4l+v03tOoiJKpTBbxpNhWDvqc/4IcOw+KLmSiQLTasZ4cab2/UWQ==",
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1"
+          }
+        }
       }
     },
     "forwarded": {

--- a/src/components/ArticleDigest/DropdownActions/ArchiveArticle/Dialog.tsx
+++ b/src/components/ArticleDigest/DropdownActions/ArchiveArticle/Dialog.tsx
@@ -1,7 +1,6 @@
 import gql from 'graphql-tag'
 
-import { Dialog, Translate, useDialogSwitch } from '~/components'
-import { useMutation } from '~/components/GQL'
+import { Dialog, Translate, useDialogSwitch, useMutation } from '~/components'
 import updateUserArticles from '~/components/GQL/updates/userArticles'
 
 import { ADD_TOAST } from '~/common/enums'

--- a/src/components/ArticleDigest/DropdownActions/ExtendButton.tsx
+++ b/src/components/ArticleDigest/DropdownActions/ExtendButton.tsx
@@ -7,9 +7,9 @@ import {
   Menu,
   TextIcon,
   Translate,
+  useMutation,
   ViewerContext,
 } from '~/components'
-import { useMutation } from '~/components/GQL'
 
 import { ADD_TOAST } from '~/common/enums'
 import { routerPush, toPath, translate } from '~/common/utils'

--- a/src/components/ArticleDigest/DropdownActions/RemoveTagButton.tsx
+++ b/src/components/ArticleDigest/DropdownActions/RemoveTagButton.tsx
@@ -1,8 +1,14 @@
 import gql from 'graphql-tag'
 import _isArray from 'lodash/isArray'
 
-import { IconRemove24, Menu, TextIcon, Translate, useRoute } from '~/components'
-import { useMutation } from '~/components/GQL'
+import {
+  IconRemove24,
+  Menu,
+  TextIcon,
+  Translate,
+  useMutation,
+  useRoute,
+} from '~/components'
 import updateTagArticlesCount from '~/components/GQL/updates/tagArticlesCount'
 
 import { REFETCH_TAG_DETAIL_ARTICLES } from '~/common/enums'

--- a/src/components/ArticleDigest/DropdownActions/SetTagSelectedButton.tsx
+++ b/src/components/ArticleDigest/DropdownActions/SetTagSelectedButton.tsx
@@ -1,7 +1,13 @@
 import gql from 'graphql-tag'
 
-import { IconAdd24, Menu, TextIcon, Translate, useRoute } from '~/components'
-import { useMutation } from '~/components/GQL'
+import {
+  IconAdd24,
+  Menu,
+  TextIcon,
+  Translate,
+  useMutation,
+  useRoute,
+} from '~/components'
 
 import { ADD_TOAST } from '~/common/enums'
 

--- a/src/components/ArticleDigest/DropdownActions/SetTagUnselectedButton.tsx
+++ b/src/components/ArticleDigest/DropdownActions/SetTagUnselectedButton.tsx
@@ -2,8 +2,14 @@ import gql from 'graphql-tag'
 import _filter from 'lodash/filter'
 import _get from 'lodash/get'
 
-import { IconUnPin24, Menu, TextIcon, Translate, useRoute } from '~/components'
-import { useMutation } from '~/components/GQL'
+import {
+  IconUnPin24,
+  Menu,
+  TextIcon,
+  Translate,
+  useMutation,
+  useRoute,
+} from '~/components'
 
 import { ADD_TOAST } from '~/common/enums'
 

--- a/src/components/ArticleDigest/DropdownActions/StickyButton.tsx
+++ b/src/components/ArticleDigest/DropdownActions/StickyButton.tsx
@@ -1,7 +1,13 @@
 import gql from 'graphql-tag'
 
-import { IconPin24, IconUnPin24, Menu, TextIcon, Translate } from '~/components'
-import { useMutation } from '~/components/GQL'
+import {
+  IconPin24,
+  IconUnPin24,
+  Menu,
+  TextIcon,
+  Translate,
+  useMutation,
+} from '~/components'
 import updateUserArticles from '~/components/GQL/updates/userArticles'
 
 import { StickyButtonArticle } from './__generated__/StickyButtonArticle'

--- a/src/components/BlockUser/Button/index.tsx
+++ b/src/components/BlockUser/Button/index.tsx
@@ -4,8 +4,8 @@ import {
   Menu,
   TextIcon,
   Translate,
+  useMutation,
 } from '~/components'
-import { useMutation } from '~/components/GQL'
 import TOGGLE_BLOCK_USER from '~/components/GQL/mutations/toggleBlockUser'
 
 import { ADD_TOAST } from '~/common/enums'

--- a/src/components/BlockUser/Dialog/index.tsx
+++ b/src/components/BlockUser/Dialog/index.tsx
@@ -1,5 +1,4 @@
-import { Dialog, Translate, useDialogSwitch } from '~/components'
-import { useMutation } from '~/components/GQL'
+import { Dialog, Translate, useDialogSwitch, useMutation } from '~/components'
 import TOGGLE_BLOCK_USER from '~/components/GQL/mutations/toggleBlockUser'
 
 import { ADD_TOAST } from '~/common/enums'

--- a/src/components/Buttons/Bookmark/Subscribe.tsx
+++ b/src/components/Buttons/Bookmark/Subscribe.tsx
@@ -6,9 +6,9 @@ import {
   IconBookmark16,
   IconSize,
   Translate,
+  useMutation,
   ViewerContext,
 } from '~/components'
-import { useMutation } from '~/components/GQL'
 import CLIENT_PREFERENCE from '~/components/GQL/queries/clientPreference'
 
 import { ADD_TOAST } from '~/common/enums'

--- a/src/components/Buttons/Bookmark/Unsubscribe.tsx
+++ b/src/components/Buttons/Bookmark/Unsubscribe.tsx
@@ -5,9 +5,9 @@ import {
   IconBookmarked16,
   IconSize,
   Translate,
+  useMutation,
   ViewerContext,
 } from '~/components'
-import { useMutation } from '~/components/GQL'
 
 import { ADD_TOAST } from '~/common/enums'
 

--- a/src/components/Buttons/Follow/Follow.tsx
+++ b/src/components/Buttons/Follow/Follow.tsx
@@ -7,8 +7,8 @@ import {
   ButtonWidth,
   TextIcon,
   Translate,
+  useMutation,
 } from '~/components'
-import { useMutation } from '~/components/GQL'
 import TOGGLE_FOLLOW_USER from '~/components/GQL/mutations/toggleFollowUser'
 import updateUserFollowerCount from '~/components/GQL/updates/userFollowerCount'
 import updateViewerFolloweeCount from '~/components/GQL/updates/viewerFolloweeCount'

--- a/src/components/Buttons/Follow/Unfollow.tsx
+++ b/src/components/Buttons/Follow/Unfollow.tsx
@@ -8,8 +8,8 @@ import {
   ButtonWidth,
   TextIcon,
   Translate,
+  useMutation,
 } from '~/components'
-import { useMutation } from '~/components/GQL'
 import TOGGLE_FOLLOW_USER from '~/components/GQL/mutations/toggleFollowUser'
 import updateUserFollowerCount from '~/components/GQL/updates/userFollowerCount'
 import updateViewerFolloweeCount from '~/components/GQL/updates/viewerFolloweeCount'

--- a/src/components/Buttons/UnblockUser/index.tsx
+++ b/src/components/Buttons/UnblockUser/index.tsx
@@ -1,8 +1,7 @@
 import gql from 'graphql-tag'
 import _isNil from 'lodash/isNil'
 
-import { Button, TextIcon, Translate } from '~/components'
-import { useMutation } from '~/components/GQL'
+import { Button, TextIcon, Translate, useMutation } from '~/components'
 import TOGGLE_BLOCK_USER from '~/components/GQL/mutations/toggleBlockUser'
 
 import { ADD_TOAST } from '~/common/enums'

--- a/src/components/Buttons/Write/index.tsx
+++ b/src/components/Buttons/Write/index.tsx
@@ -7,18 +7,12 @@ import {
   LanguageContext,
   TextIcon,
   Translate,
+  useMutation,
 } from '~/components'
-import { useMutation } from '~/components/GQL'
 import CREATE_DRAFT from '~/components/GQL/mutations/createDraft'
 
 import { ADD_TOAST, OPEN_LIKE_COIN_DIALOG, TEXT } from '~/common/enums'
-import {
-  analytics,
-  parseFormSubmitErrors,
-  routerPush,
-  toPath,
-  translate,
-} from '~/common/utils'
+import { analytics, routerPush, toPath, translate } from '~/common/utils'
 
 import { CreateDraft } from '~/components/GQL/mutations/__generated__/CreateDraft'
 
@@ -82,44 +76,27 @@ export const WriteButton = ({ allowed, isLarge, forbidden }: Props) => {
     <BaseWriteButton
       isLarge={isLarge}
       onClick={async () => {
-        try {
-          if (forbidden) {
-            window.dispatchEvent(
-              new CustomEvent(ADD_TOAST, {
-                detail: {
-                  color: 'red',
-                  content: <Translate id="FORBIDDEN_BY_STATE" />,
-                },
-              })
-            )
-            return
-          }
-
-          analytics.trackEvent('click_button', {
-            type: 'write',
-          })
-          const result = await putDraft()
-          const { slug, id } = result?.data?.putDraft || {}
-
-          if (slug && id) {
-            const path = toPath({ page: 'draftDetail', slug, id })
-            routerPush(path.href)
-          }
-        } catch (error) {
-          const [messages, codes] = parseFormSubmitErrors(error, lang)
-
-          if (!messages[codes[0]]) {
-            return null
-          }
-
+        if (forbidden) {
           window.dispatchEvent(
             new CustomEvent(ADD_TOAST, {
               detail: {
                 color: 'red',
-                content: messages[codes[0]],
+                content: <Translate id="FORBIDDEN_BY_STATE" />,
               },
             })
           )
+          return
+        }
+
+        analytics.trackEvent('click_button', {
+          type: 'write',
+        })
+        const result = await putDraft()
+        const { slug, id } = result?.data?.putDraft || {}
+
+        if (slug && id) {
+          const path = toPath({ page: 'draftDetail', slug, id })
+          routerPush(path.href)
         }
       }}
       loading={loading}

--- a/src/components/Comment/DropdownActions/CollapseComment/Dialog.tsx
+++ b/src/components/Comment/DropdownActions/CollapseComment/Dialog.tsx
@@ -1,7 +1,6 @@
 import gql from 'graphql-tag'
 
-import { Dialog, Translate, useDialogSwitch } from '~/components'
-import { useMutation } from '~/components/GQL'
+import { Dialog, Translate, useDialogSwitch, useMutation } from '~/components'
 
 import { ADD_TOAST } from '~/common/enums'
 

--- a/src/components/Comment/DropdownActions/DeleteComment/Dialog.tsx
+++ b/src/components/Comment/DropdownActions/DeleteComment/Dialog.tsx
@@ -1,7 +1,6 @@
 import gql from 'graphql-tag'
 
-import { Dialog, Translate, useDialogSwitch } from '~/components'
-import { useMutation } from '~/components/GQL'
+import { Dialog, Translate, useDialogSwitch, useMutation } from '~/components'
 
 import { ADD_TOAST } from '~/common/enums'
 

--- a/src/components/Comment/DropdownActions/PinButton.tsx
+++ b/src/components/Comment/DropdownActions/PinButton.tsx
@@ -1,7 +1,13 @@
 import gql from 'graphql-tag'
 
-import { IconPin24, IconUnPin24, Menu, TextIcon, Translate } from '~/components'
-import { useMutation } from '~/components/GQL'
+import {
+  IconPin24,
+  IconUnPin24,
+  Menu,
+  TextIcon,
+  Translate,
+  useMutation,
+} from '~/components'
 import TOGGLE_PIN_COMMENT from '~/components/GQL/mutations/togglePinComment'
 
 import { TogglePinComment } from '~/components/GQL/mutations/__generated__/TogglePinComment'

--- a/src/components/Comment/DropdownActions/UncollapseButton.tsx
+++ b/src/components/Comment/DropdownActions/UncollapseButton.tsx
@@ -1,7 +1,12 @@
 import gql from 'graphql-tag'
 
-import { IconExpand16, Menu, TextIcon, Translate } from '~/components'
-import { useMutation } from '~/components/GQL'
+import {
+  IconExpand16,
+  Menu,
+  TextIcon,
+  Translate,
+  useMutation,
+} from '~/components'
 
 import { UncollapseComment } from './__generated__/UncollapseComment'
 

--- a/src/components/Comment/FooterActions/DownvoteButton/index.tsx
+++ b/src/components/Comment/FooterActions/DownvoteButton/index.tsx
@@ -1,7 +1,12 @@
 import gql from 'graphql-tag'
 
-import { Button, IconDownVote16, IconDownVoted16, TextIcon } from '~/components'
-import { useMutation } from '~/components/GQL'
+import {
+  Button,
+  IconDownVote16,
+  IconDownVoted16,
+  TextIcon,
+  useMutation,
+} from '~/components'
 import {
   UNVOTE_COMMENT,
   VOTE_COMMENT,

--- a/src/components/Comment/FooterActions/UpvoteButton/index.tsx
+++ b/src/components/Comment/FooterActions/UpvoteButton/index.tsx
@@ -1,7 +1,12 @@
 import gql from 'graphql-tag'
 
-import { Button, IconUpVote16, IconUpVoted16, TextIcon } from '~/components'
-import { useMutation } from '~/components/GQL'
+import {
+  Button,
+  IconUpVote16,
+  IconUpVoted16,
+  TextIcon,
+  useMutation,
+} from '~/components'
 import {
   UNVOTE_COMMENT,
   VOTE_COMMENT,

--- a/src/components/Context/Language/LanguageContext.tsx
+++ b/src/components/Context/Language/LanguageContext.tsx
@@ -1,8 +1,7 @@
 import gql from 'graphql-tag'
 import { createContext, useContext, useState } from 'react'
 
-import { Translate, ViewerContext } from '~/components'
-import { useMutation } from '~/components/GQL'
+import { Translate, useMutation, ViewerContext } from '~/components'
 
 import { ADD_TOAST, DEFAULT_LANG } from '~/common/enums'
 import { langConvert } from '~/common/utils'

--- a/src/components/Dialogs/AppreciatorsDialog/Content.tsx
+++ b/src/components/Dialogs/AppreciatorsDialog/Content.tsx
@@ -4,12 +4,12 @@ import gql from 'graphql-tag'
 import {
   Dialog,
   InfiniteList,
+  QueryError,
   RowRendererProps,
   Spinner,
   Translate,
   useResponsive,
 } from '~/components'
-import { QueryError } from '~/components/GQL'
 import { UserDigest } from '~/components/UserDigest'
 
 import { analytics, mergeConnections } from '~/common/utils'

--- a/src/components/Dialogs/CommentFormDialog/CommentForm/index.tsx
+++ b/src/components/Dialogs/CommentFormDialog/CommentForm/index.tsx
@@ -3,8 +3,7 @@ import gql from 'graphql-tag'
 import dynamic from 'next/dynamic'
 import { useState } from 'react'
 
-import { Button, Dialog, Spinner, Translate } from '~/components'
-import { useMutation } from '~/components/GQL'
+import { Button, Dialog, Spinner, Translate, useMutation } from '~/components'
 import CLIENT_PREFERENCE from '~/components/GQL/queries/clientPreference'
 
 import { ADD_TOAST, TEXT, TextId } from '~/common/enums'

--- a/src/components/Dialogs/DonatorsDialog/Content.tsx
+++ b/src/components/Dialogs/DonatorsDialog/Content.tsx
@@ -3,12 +3,12 @@ import { useQuery } from '@apollo/react-hooks'
 import {
   Dialog,
   InfiniteList,
+  QueryError,
   RowRendererProps,
   Spinner,
   Translate,
   useResponsive,
 } from '~/components'
-import { QueryError } from '~/components/GQL'
 import { UserDigest } from '~/components/UserDigest'
 
 import { analytics, mergeConnections } from '~/common/utils'

--- a/src/components/Dialogs/LikeCoinDialog/SetupLikeCoin/Generating/index.tsx
+++ b/src/components/Dialogs/LikeCoinDialog/SetupLikeCoin/Generating/index.tsx
@@ -1,8 +1,7 @@
 import gql from 'graphql-tag'
 import { useEffect } from 'react'
 
-import { Dialog, Spinner, Translate } from '~/components'
-import { useMutation } from '~/components/GQL'
+import { Dialog, Spinner, Translate, useMutation } from '~/components'
 
 import { GenerateLikerId } from './__generated__/GenerateLikerId'
 

--- a/src/components/Dialogs/MigrationDialog/Upload.tsx
+++ b/src/components/Dialogs/MigrationDialog/Upload.tsx
@@ -1,8 +1,13 @@
 import VisuallyHidden from '@reach/visually-hidden'
 import { useContext } from 'react'
 
-import { Dialog, LoginButton, Translate, ViewerContext } from '~/components'
-import { useMutation } from '~/components/GQL'
+import {
+  Dialog,
+  LoginButton,
+  Translate,
+  useMutation,
+  ViewerContext,
+} from '~/components'
 import MIGRATION from '~/components/GQL/mutations/migration'
 
 import {

--- a/src/components/Dialogs/RecommendAuthorDialog/Feed.tsx
+++ b/src/components/Dialogs/RecommendAuthorDialog/Feed.tsx
@@ -4,6 +4,7 @@ import { useContext, useEffect } from 'react'
 import {
   EmptyWarning,
   List,
+  QueryError,
   ShuffleButton,
   Spinner,
   Translate,
@@ -11,7 +12,6 @@ import {
   UserDigest,
   ViewerContext,
 } from '~/components'
-import { QueryError } from '~/components/GQL'
 
 import { RECOMMEND_AUTHORS } from './gql'
 import styles from './styles.css'

--- a/src/components/Dialogs/RecommendTagDialog/Feed.tsx
+++ b/src/components/Dialogs/RecommendTagDialog/Feed.tsx
@@ -5,6 +5,7 @@ import { useContext, useEffect } from 'react'
 import {
   EmptyWarning,
   List,
+  QueryError,
   ShuffleButton,
   Spinner,
   TagDigest,
@@ -12,7 +13,6 @@ import {
   usePublicQuery,
   ViewerContext,
 } from '~/components'
-import { QueryError } from '~/components/GQL'
 
 import { HOTTEST_TAGS, SELECTED_TAGS } from './gql'
 import styles from './styles.css'

--- a/src/components/Dialogs/TagAdoptionDialog/index.tsx
+++ b/src/components/Dialogs/TagAdoptionDialog/index.tsx
@@ -1,5 +1,10 @@
-import { Dialog, Translate, useDialogSwitch, useRoute } from '~/components'
-import { useMutation } from '~/components/GQL'
+import {
+  Dialog,
+  Translate,
+  useDialogSwitch,
+  useMutation,
+  useRoute,
+} from '~/components'
 import UPDATE_TAG_SETTING from '~/components/GQL/mutations/updateTagSetting'
 
 import { ADD_TOAST } from '~/common/enums'
@@ -50,29 +55,25 @@ const BaseDialog = ({ children }: Props) => {
             bgColor="green"
             loading={loading}
             onClick={async () => {
-              try {
-                const result = await update({
-                  variables: { input: { id, type: 'adopt' } },
-                })
+              const result = await update({
+                variables: { input: { id, type: 'adopt' } },
+              })
 
-                if (!result) {
-                  throw new Error('tag adoption failed')
-                }
-
-                window.dispatchEvent(
-                  new CustomEvent(ADD_TOAST, {
-                    detail: {
-                      color: 'green',
-                      content: (
-                        <Translate zh_hant="認領成功" zh_hans="认领成功" />
-                      ),
-                      duration: 2000,
-                    },
-                  })
-                )
-              } catch (error) {
-                throw error
+              if (!result) {
+                throw new Error('tag adoption failed')
               }
+
+              window.dispatchEvent(
+                new CustomEvent(ADD_TOAST, {
+                  detail: {
+                    color: 'green',
+                    content: (
+                      <Translate zh_hant="認領成功" zh_hans="认领成功" />
+                    ),
+                    duration: 2000,
+                  },
+                })
+              )
             }}
           >
             <Translate zh_hant="即刻主理" zh_hans="即刻主理" />

--- a/src/components/Dialogs/TagDialog/Content.tsx
+++ b/src/components/Dialogs/TagDialog/Content.tsx
@@ -11,8 +11,8 @@ import {
   Menu,
   Spinner,
   Translate,
+  useMutation,
 } from '~/components'
-import { useMutation } from '~/components/GQL'
 import SEARCH_TAGS from '~/components/GQL/queries/searchTags'
 
 import { ADD_TOAST, ASSET_TYPE, ENTITY_TYPE } from '~/common/enums'
@@ -133,7 +133,9 @@ const TagDialogContent: React.FC<BaseTagDialogContentProps> = ({
   description,
   closeDialog,
 }) => {
-  const [update] = useMutation<PutTag>(PUT_TAG)
+  const [update] = useMutation<PutTag>(PUT_TAG, undefined, {
+    showToast: false,
+  })
   const { lang } = useContext(LanguageContext)
   const isEditing = id && content
 

--- a/src/components/Dialogs/TagEditorDialog/List/index.tsx
+++ b/src/components/Dialogs/TagEditorDialog/List/index.tsx
@@ -3,12 +3,12 @@ import { useQuery } from '@apollo/react-hooks'
 import {
   Button,
   Dialog,
+  QueryError,
   Spinner,
   TextIcon,
   Translate,
   UserDigest,
 } from '~/components'
-import { QueryError } from '~/components/GQL'
 import TAG_MAINTAINERS from '~/components/GQL/queries/tagMaintainers'
 
 import styles from './styles.css'

--- a/src/components/Dialogs/TagEditorDialog/Remove/index.tsx
+++ b/src/components/Dialogs/TagEditorDialog/Remove/index.tsx
@@ -1,5 +1,4 @@
-import { Dialog, Translate } from '~/components'
-import { useMutation } from '~/components/GQL'
+import { Dialog, Translate, useMutation } from '~/components'
 import UPDATE_TAG_SETTING from '~/components/GQL/mutations/updateTagSetting'
 import updateTagMaintainers from '~/components/GQL/updates/tagMaintainers'
 
@@ -62,43 +61,39 @@ const TagRemoveEditor = ({ id, editor, close }: Props) => {
           textColor="white"
           loading={loading}
           onClick={async () => {
-            try {
-              const result = await update({
-                variables: {
-                  input: { id, type: 'remove_editor', editors: [editor.id] },
-                },
-                update: (cache) =>
-                  updateTagMaintainers({
-                    cache,
-                    id,
-                    type: 'remove',
-                    editors: [editor.id],
-                  }),
-              })
+            const result = await update({
+              variables: {
+                input: { id, type: 'remove_editor', editors: [editor.id] },
+              },
+              update: (cache) =>
+                updateTagMaintainers({
+                  cache,
+                  id,
+                  type: 'remove',
+                  editors: [editor.id],
+                }),
+            })
 
-              if (!result) {
-                throw new Error('tag leave failed')
-              }
-
-              window.dispatchEvent(
-                new CustomEvent(ADD_TOAST, {
-                  detail: {
-                    color: 'green',
-                    content: (
-                      <Translate
-                        zh_hant="移除協作者成功"
-                        zh_hans="移除协作者成功"
-                      />
-                    ),
-                    duration: 2000,
-                  },
-                })
-              )
-
-              close()
-            } catch (error) {
-              throw error
+            if (!result) {
+              throw new Error('tag leave failed')
             }
+
+            window.dispatchEvent(
+              new CustomEvent(ADD_TOAST, {
+                detail: {
+                  color: 'green',
+                  content: (
+                    <Translate
+                      zh_hant="移除協作者成功"
+                      zh_hans="移除协作者成功"
+                    />
+                  ),
+                  duration: 2000,
+                },
+              })
+            )
+
+            close()
           }}
         >
           <Translate zh_hant="確認移除" zh_hans="确认移除" />

--- a/src/components/Dialogs/TagLeaveDialog/index.tsx
+++ b/src/components/Dialogs/TagLeaveDialog/index.tsx
@@ -1,5 +1,10 @@
-import { Dialog, Translate, useDialogSwitch, useRoute } from '~/components'
-import { useMutation } from '~/components/GQL'
+import {
+  Dialog,
+  Translate,
+  useDialogSwitch,
+  useMutation,
+  useRoute,
+} from '~/components'
 import UPDATE_TAG_SETTING from '~/components/GQL/mutations/updateTagSetting'
 
 import { ADD_TOAST } from '~/common/enums'
@@ -47,36 +52,32 @@ const BaseDialog = ({ children, isOwner }: Props) => {
             bgColor="red"
             loading={loading}
             onClick={async () => {
-              try {
-                const result = await update({
-                  variables: {
-                    input: { id, type: isOwner ? 'leave' : 'leave_editor' },
+              const result = await update({
+                variables: {
+                  input: { id, type: isOwner ? 'leave' : 'leave_editor' },
+                },
+              })
+
+              if (!result) {
+                throw new Error('tag leave failed')
+              }
+
+              window.dispatchEvent(
+                new CustomEvent(ADD_TOAST, {
+                  detail: {
+                    color: 'green',
+                    content: (
+                      <Translate
+                        zh_hant="辭去權限成功"
+                        zh_hans="辞去权限成功"
+                      />
+                    ),
+                    duration: 2000,
                   },
                 })
+              )
 
-                if (!result) {
-                  throw new Error('tag leave failed')
-                }
-
-                window.dispatchEvent(
-                  new CustomEvent(ADD_TOAST, {
-                    detail: {
-                      color: 'green',
-                      content: (
-                        <Translate
-                          zh_hant="辭去權限成功"
-                          zh_hans="辞去权限成功"
-                        />
-                      ),
-                      duration: 2000,
-                    },
-                  })
-                )
-
-                close()
-              } catch (error) {
-                throw error
-              }
+              close()
             }}
           >
             <Translate zh_hant="確認辭去" zh_hans="确认辞去" />

--- a/src/components/Dialogs/UnsubscribeCircleDialog/index.tsx
+++ b/src/components/Dialogs/UnsubscribeCircleDialog/index.tsx
@@ -1,15 +1,4 @@
-import { useContext } from 'react'
-
-import {
-  Dialog,
-  LanguageContext,
-  Translate,
-  useDialogSwitch,
-} from '~/components'
-import { useMutation } from '~/components/GQL'
-
-import { ADD_TOAST } from '~/common/enums'
-import { parseFormSubmitErrors } from '~/common/utils'
+import { Dialog, Translate, useDialogSwitch, useMutation } from '~/components'
 
 import { UNSUBSCRIBE_CIRCLE } from './gql'
 
@@ -24,7 +13,6 @@ const BaseUnsubscribeCircleDialog = ({
   id,
   children,
 }: BaseUnsubscribeCircleDialogProps) => {
-  const { lang } = useContext(LanguageContext)
   const { show, open, close } = useDialogSwitch(true)
 
   const [unsubscribe, { loading, data }] = useMutation<UnsubscribeCircle>(
@@ -35,27 +23,6 @@ const BaseUnsubscribeCircleDialog = ({
   )
   const isMember = data?.unsubscribeCircle.isMember
   const isUnsubscribed = typeof isMember === 'boolean' && !isMember
-
-  const onUnsubscribe = async () => {
-    try {
-      await unsubscribe()
-    } catch (error) {
-      const [messages, codes] = parseFormSubmitErrors(error, lang)
-
-      if (!messages[codes[0]]) {
-        return
-      }
-
-      window.dispatchEvent(
-        new CustomEvent(ADD_TOAST, {
-          detail: {
-            color: 'red',
-            content: messages[codes[0]],
-          },
-        })
-      )
-    }
-  }
 
   return (
     <>
@@ -96,7 +63,7 @@ const BaseUnsubscribeCircleDialog = ({
             <Dialog.Footer.Button
               bgColor="red"
               loading={loading}
-              onClick={() => onUnsubscribe()}
+              onClick={() => unsubscribe()}
             >
               <Translate zh_hant="轉身離開" zh_hans="转身离开" />
             </Dialog.Footer.Button>

--- a/src/components/DraftDigest/Feed/DeleteButton.tsx
+++ b/src/components/DraftDigest/Feed/DeleteButton.tsx
@@ -7,8 +7,8 @@ import {
   TextIcon,
   Translate,
   useDialogSwitch,
+  useMutation,
 } from '~/components'
-import { useMutation } from '~/components/GQL'
 
 import { ADD_TOAST } from '~/common/enums'
 

--- a/src/components/Editor/SetCoverDialog/Uploader.tsx
+++ b/src/components/Editor/SetCoverDialog/Uploader.tsx
@@ -1,8 +1,13 @@
 import VisuallyHidden from '@reach/visually-hidden'
 import classNames from 'classnames'
 
-import { IconCamera16, IconSpinner16, TextIcon, Translate } from '~/components'
-import { useMutation } from '~/components/GQL'
+import {
+  IconCamera16,
+  IconSpinner16,
+  TextIcon,
+  Translate,
+  useMutation,
+} from '~/components'
 import UPLOAD_FILE from '~/components/GQL/mutations/uploadFile'
 
 import {
@@ -35,7 +40,11 @@ const Uploader: React.FC<UploaderProps> = ({
   setSelected,
   refetchAssets,
 }) => {
-  const [upload, { loading }] = useMutation<SingleFileUpload>(UPLOAD_FILE)
+  const [upload, { loading }] = useMutation<SingleFileUpload>(
+    UPLOAD_FILE,
+    undefined,
+    { showToast: false }
+  )
 
   const acceptTypes = ACCEPTED_UPLOAD_IMAGE_TYPES.join(',')
   const fieldId = 'editor-cover-upload-form'

--- a/src/components/FileUploader/AvatarUploader/index.tsx
+++ b/src/components/FileUploader/AvatarUploader/index.tsx
@@ -9,8 +9,8 @@ import {
   CircleAvatarProps,
   Spinner,
   Translate,
+  useMutation,
 } from '~/components'
-import { useMutation } from '~/components/GQL'
 import UPLOAD_FILE from '~/components/GQL/mutations/uploadFile'
 import { IconCamera24 } from '~/components/Icon'
 
@@ -43,7 +43,11 @@ export const AvatarUploader: React.FC<AvatarUploaderProps> = ({
 
   ...avatarProps
 }) => {
-  const [upload, { loading }] = useMutation<SingleFileUpload>(UPLOAD_FILE)
+  const [upload, { loading }] = useMutation<SingleFileUpload>(
+    UPLOAD_FILE,
+    undefined,
+    { showToast: false }
+  )
   const [avatar, setAvatar] = useState<string | undefined>(avatarProps.src)
 
   const acceptTypes = ACCEPTED_UPLOAD_IMAGE_TYPES.join(',')

--- a/src/components/FileUploader/CoverUploader/index.tsx
+++ b/src/components/FileUploader/CoverUploader/index.tsx
@@ -10,8 +10,8 @@ import {
   Spinner,
   TextIcon,
   Translate,
+  useMutation,
 } from '~/components'
-import { useMutation } from '~/components/GQL'
 import UPLOAD_FILE from '~/components/GQL/mutations/uploadFile'
 
 import {
@@ -67,7 +67,11 @@ export const CoverUploader = ({
   type,
 }: CoverUploaderProps) => {
   const [cover, setCover] = useState<string | undefined | null>(initCover)
-  const [upload, { loading }] = useMutation<SingleFileUpload>(UPLOAD_FILE)
+  const [upload, { loading }] = useMutation<SingleFileUpload>(
+    UPLOAD_FILE,
+    undefined,
+    { showToast: false }
+  )
 
   const acceptTypes = ACCEPTED_UPLOAD_IMAGE_TYPES.join(',')
   const fieldId = 'cover-upload-form'

--- a/src/components/Forms/ChangeEmailForm/Confirm.tsx
+++ b/src/components/Forms/ChangeEmailForm/Confirm.tsx
@@ -9,9 +9,9 @@ import {
   LanguageContext,
   Layout,
   Translate,
+  useMutation,
   VerificationSendCodeButton,
 } from '~/components'
-import { useMutation } from '~/components/GQL'
 import { CONFIRM_CODE } from '~/components/GQL/mutations/verificationCode'
 
 import {
@@ -53,8 +53,14 @@ const Confirm: React.FC<FormProps> = ({
   submitCallback,
   closeDialog,
 }) => {
-  const [confirmCode] = useMutation<ConfirmVerificationCode>(CONFIRM_CODE)
-  const [changeEmail] = useMutation<ChangeEmail>(CHANGE_EMAIL)
+  const [confirmCode] = useMutation<ConfirmVerificationCode>(
+    CONFIRM_CODE,
+    undefined,
+    { showToast: false }
+  )
+  const [changeEmail] = useMutation<ChangeEmail>(CHANGE_EMAIL, undefined, {
+    showToast: false,
+  })
   const { lang } = useContext(LanguageContext)
   const isInPage = purpose === 'page'
 

--- a/src/components/Forms/ChangeEmailForm/Request.tsx
+++ b/src/components/Forms/ChangeEmailForm/Request.tsx
@@ -8,9 +8,9 @@ import {
   LanguageContext,
   Layout,
   Translate,
+  useMutation,
   VerificationSendCodeButton,
 } from '~/components'
-import { useMutation } from '~/components/GQL'
 import { CONFIRM_CODE } from '~/components/GQL/mutations/verificationCode'
 
 import {

--- a/src/components/Forms/ChangePasswordForm/Confirm.tsx
+++ b/src/components/Forms/ChangePasswordForm/Confirm.tsx
@@ -3,8 +3,14 @@ import gql from 'graphql-tag'
 import _pickBy from 'lodash/pickBy'
 import { useContext } from 'react'
 
-import { Dialog, Form, LanguageContext, Layout, Translate } from '~/components'
-import { useMutation } from '~/components/GQL'
+import {
+  Dialog,
+  Form,
+  LanguageContext,
+  Layout,
+  Translate,
+  useMutation,
+} from '~/components'
 import { CONFIRM_CODE } from '~/components/GQL/mutations/verificationCode'
 
 import {
@@ -45,8 +51,14 @@ const Confirm: React.FC<FormProps> = ({
   submitCallback,
   closeDialog,
 }) => {
-  const [confirm] = useMutation<ConfirmVerificationCode>(CONFIRM_CODE)
-  const [reset] = useMutation<ResetPassword>(RESET_PASSWORD)
+  const [confirm] = useMutation<ConfirmVerificationCode>(
+    CONFIRM_CODE,
+    undefined,
+    { showToast: false }
+  )
+  const [reset] = useMutation<ResetPassword>(RESET_PASSWORD, undefined, {
+    showToast: false,
+  })
   const { lang } = useContext(LanguageContext)
 
   const isForget = type === 'forget'

--- a/src/components/Forms/ChangePasswordForm/Request.tsx
+++ b/src/components/Forms/ChangePasswordForm/Request.tsx
@@ -2,8 +2,14 @@ import { useFormik } from 'formik'
 import _pickBy from 'lodash/pickBy'
 import { useContext } from 'react'
 
-import { Dialog, Form, LanguageContext, Layout, Translate } from '~/components'
-import { useMutation } from '~/components/GQL'
+import {
+  Dialog,
+  Form,
+  LanguageContext,
+  Layout,
+  Translate,
+  useMutation,
+} from '~/components'
 import SEND_CODE from '~/components/GQL/mutations/sendCode'
 
 import { parseFormSubmitErrors, translate, validateEmail } from '~/common/utils'
@@ -37,7 +43,9 @@ const Request: React.FC<FormProps> = ({
   const titleId = isForget ? 'resetPassword' : 'changePassword'
   const redirectPath = isForget ? '/forget' : '/me/settings/change-password'
 
-  const [sendCode] = useMutation<SendVerificationCode>(SEND_CODE)
+  const [sendCode] = useMutation<SendVerificationCode>(SEND_CODE, undefined, {
+    showToast: false,
+  })
 
   const {
     values,

--- a/src/components/Forms/ChangeUserNameForm/Confirm.tsx
+++ b/src/components/Forms/ChangeUserNameForm/Confirm.tsx
@@ -3,8 +3,14 @@ import gql from 'graphql-tag'
 import _pickBy from 'lodash/pickBy'
 import React, { useContext } from 'react'
 
-import { Dialog, Form, LanguageContext, Layout, Translate } from '~/components'
-import { useMutation } from '~/components/GQL'
+import {
+  Dialog,
+  Form,
+  LanguageContext,
+  Layout,
+  Translate,
+  useMutation,
+} from '~/components'
 
 import {
   parseFormSubmitErrors,
@@ -40,7 +46,11 @@ const Confirm: React.FC<FormProps> = ({
   submitCallback,
   closeDialog,
 }) => {
-  const [update] = useMutation<UpdateUserInfoUserName>(UPDATE_USER_INFO)
+  const [update] = useMutation<UpdateUserInfoUserName>(
+    UPDATE_USER_INFO,
+    undefined,
+    { showToast: false }
+  )
   const { lang } = useContext(LanguageContext)
   const isInPage = purpose === 'page'
   const formId = 'username-confirm-form'

--- a/src/components/Forms/CreateCircleForm/Init.tsx
+++ b/src/components/Forms/CreateCircleForm/Init.tsx
@@ -2,8 +2,14 @@ import { useFormik } from 'formik'
 import _pickBy from 'lodash/pickBy'
 import { useContext, useRef } from 'react'
 
-import { Dialog, Form, LanguageContext, Layout, Translate } from '~/components'
-import { useMutation } from '~/components/GQL'
+import {
+  Dialog,
+  Form,
+  LanguageContext,
+  Layout,
+  Translate,
+  useMutation,
+} from '~/components'
 import PUT_CIRCLE from '~/components/GQL/mutations/putCircle'
 
 import {
@@ -44,7 +50,9 @@ const Init: React.FC<FormProps> = ({
   submitCallback,
   closeDialog,
 }) => {
-  const [create] = useMutation<PutCircle>(PUT_CIRCLE)
+  const [create] = useMutation<PutCircle>(PUT_CIRCLE, undefined, {
+    showToast: false,
+  })
   const { lang } = useContext(LanguageContext)
   const inputRef: React.RefObject<any> | null = useRef(null)
   // const isInDialog = purpose === 'dialog'

--- a/src/components/Forms/CreateCircleForm/Profile.tsx
+++ b/src/components/Forms/CreateCircleForm/Profile.tsx
@@ -10,8 +10,8 @@ import {
   LanguageContext,
   Layout,
   Translate,
+  useMutation,
 } from '~/components'
-import { useMutation } from '~/components/GQL'
 import PUT_CIRCLE from '~/components/GQL/mutations/putCircle'
 
 import {
@@ -54,7 +54,9 @@ interface FormValues {
 const UNCHANGED_FIELD = 'UNCHANGED_FIELD'
 
 const Init: React.FC<FormProps> = ({ circle, type, purpose, closeDialog }) => {
-  const [update] = useMutation<PutCircle>(PUT_CIRCLE)
+  const [update] = useMutation<PutCircle>(PUT_CIRCLE, undefined, {
+    showToast: false,
+  })
   const { lang } = useContext(LanguageContext)
   const isInPage = purpose === 'page'
 

--- a/src/components/Forms/LoginForm/index.tsx
+++ b/src/components/Forms/LoginForm/index.tsx
@@ -3,8 +3,14 @@ import gql from 'graphql-tag'
 import _pickBy from 'lodash/pickBy'
 import { useContext } from 'react'
 
-import { Dialog, Form, LanguageContext, Layout, Translate } from '~/components'
-import { useMutation } from '~/components/GQL'
+import {
+  Dialog,
+  Form,
+  LanguageContext,
+  Layout,
+  Translate,
+  useMutation,
+} from '~/components'
 
 import { ADD_TOAST, STORAGE_KEY_AUTH_TOKEN } from '~/common/enums'
 import {
@@ -54,7 +60,9 @@ export const LoginForm: React.FC<FormProps> = ({
   submitCallback,
   closeDialog,
 }) => {
-  const [login] = useMutation<UserLogin>(USER_LOGIN)
+  const [login] = useMutation<UserLogin>(USER_LOGIN, undefined, {
+    showToast: false,
+  })
   const { lang } = useContext(LanguageContext)
 
   const isInDialog = purpose === 'dialog'

--- a/src/components/Forms/PaymentForm/AddCredit/index.tsx
+++ b/src/components/Forms/PaymentForm/AddCredit/index.tsx
@@ -18,8 +18,8 @@ import {
   Form,
   LanguageContext,
   Translate,
+  useMutation,
 } from '~/components'
-import { useMutation } from '~/components/GQL'
 import WALLET_BALANCE from '~/components/GQL/queries/walletBalance'
 
 import {
@@ -78,7 +78,9 @@ const BaseAddCredit: React.FC<FormProps> = ({
   const stripe = useStripe()
   const elements = useElements()
   const { lang } = useContext(LanguageContext)
-  const [addCredit] = useMutation<AddCreditType>(ADD_CREDIT)
+  const [addCredit] = useMutation<AddCreditType>(ADD_CREDIT, undefined, {
+    showToast: false,
+  })
 
   const { data: balanceData } = useQuery<WalletBalance>(WALLET_BALANCE, {
     fetchPolicy: 'network-only',

--- a/src/components/Forms/PaymentForm/PayTo/Confirm/index.tsx
+++ b/src/components/Forms/PaymentForm/PayTo/Confirm/index.tsx
@@ -3,8 +3,14 @@ import { useFormik } from 'formik'
 import _pickBy from 'lodash/pickBy'
 import { useContext, useEffect } from 'react'
 
-import { Dialog, Form, LanguageContext, Spinner, Translate } from '~/components'
-import { useMutation } from '~/components/GQL'
+import {
+  Dialog,
+  Form,
+  LanguageContext,
+  Spinner,
+  Translate,
+  useMutation,
+} from '~/components'
 import PAY_TO from '~/components/GQL/mutations/payTo'
 import WALLET_BALANCE from '~/components/GQL/queries/walletBalance'
 
@@ -46,7 +52,9 @@ const Confirm: React.FC<FormProps> = ({
   const formId = 'pay-to-confirm-form'
 
   const { lang } = useContext(LanguageContext)
-  const [payTo] = useMutation<PayToMutate>(PAY_TO)
+  const [payTo] = useMutation<PayToMutate>(PAY_TO, undefined, {
+    showToast: false,
+  })
 
   const { data, loading } = useQuery<WalletBalance>(WALLET_BALANCE, {
     fetchPolicy: 'network-only',

--- a/src/components/Forms/PaymentForm/PayTo/SetAmount.tsx
+++ b/src/components/Forms/PaymentForm/PayTo/SetAmount.tsx
@@ -10,9 +10,9 @@ import {
   LanguageContext,
   Spinner,
   Translate,
+  useMutation,
   ViewerContext,
 } from '~/components'
-import { useMutation } from '~/components/GQL'
 import PAY_TO from '~/components/GQL/mutations/payTo'
 import WALLET_BALANCE from '~/components/GQL/queries/walletBalance'
 

--- a/src/components/Forms/PaymentForm/Payout/Confirm.tsx
+++ b/src/components/Forms/PaymentForm/Payout/Confirm.tsx
@@ -12,8 +12,8 @@ import {
   TextIcon,
   Tooltip,
   Translate,
+  useMutation,
 } from '~/components'
-import { useMutation } from '~/components/GQL'
 import PAYOUT from '~/components/GQL/mutations/payout'
 import WALLET_BALANCE from '~/components/GQL/queries/walletBalance'
 
@@ -58,7 +58,9 @@ const BaseConfirm: React.FC<FormProps> = ({
 
   const { lang } = useContext(LanguageContext)
   const inputRef: React.RefObject<any> | null = useRef(null)
-  const [payout] = useMutation<PayoutMutate>(PAYOUT)
+  const [payout] = useMutation<PayoutMutate>(PAYOUT, undefined, {
+    showToast: false,
+  })
 
   const {
     errors,

--- a/src/components/Forms/PaymentForm/ResetPassword/Confirm.tsx
+++ b/src/components/Forms/PaymentForm/ResetPassword/Confirm.tsx
@@ -9,9 +9,9 @@ import {
   LanguageContext,
   Spinner,
   Translate,
+  useMutation,
   useStep,
 } from '~/components'
-import { useMutation } from '~/components/GQL'
 
 import {
   parseFormSubmitErrors,
@@ -38,7 +38,11 @@ export const RESET_PAYMENT_PASSWORD = gql`
 `
 
 const Confirm: React.FC<FormProps> = ({ codeId, submitCallback }) => {
-  const [reset] = useMutation<ResetPaymentPassword>(RESET_PAYMENT_PASSWORD)
+  const [reset] = useMutation<ResetPaymentPassword>(
+    RESET_PAYMENT_PASSWORD,
+    undefined,
+    { showToast: false }
+  )
   const { lang } = useContext(LanguageContext)
   const { currStep, forward } = useStep<'password' | 'comparedPassword'>(
     'password'

--- a/src/components/Forms/PaymentForm/ResetPassword/Request.tsx
+++ b/src/components/Forms/PaymentForm/ResetPassword/Request.tsx
@@ -7,9 +7,9 @@ import {
   Form,
   LanguageContext,
   Translate,
+  useMutation,
   VerificationSendCodeButton,
 } from '~/components'
-import { useMutation } from '~/components/GQL'
 import { CONFIRM_CODE } from '~/components/GQL/mutations/verificationCode'
 
 import {
@@ -35,7 +35,11 @@ const Request: React.FC<FormProps> = ({
   defaultEmail = '',
   submitCallback,
 }) => {
-  const [confirmCode] = useMutation<ConfirmVerificationCode>(CONFIRM_CODE)
+  const [confirmCode] = useMutation<ConfirmVerificationCode>(
+    CONFIRM_CODE,
+    undefined,
+    { showToast: false }
+  )
   const { lang } = useContext(LanguageContext)
 
   const formId = `payment-password-reset-request-form`

--- a/src/components/Forms/PaymentForm/SetPassword/index.tsx
+++ b/src/components/Forms/PaymentForm/SetPassword/index.tsx
@@ -9,9 +9,9 @@ import {
   LanguageContext,
   Spinner,
   Translate,
+  useMutation,
   useStep,
 } from '~/components'
-import { useMutation } from '~/components/GQL'
 
 import {
   parseFormSubmitErrors,
@@ -44,7 +44,11 @@ const SET_PAYMENT_PASSWORD = gql`
 `
 
 const SetPassword: React.FC<FormProps> = ({ submitCallback }) => {
-  const [setPassword] = useMutation<SetPaymentPassword>(SET_PAYMENT_PASSWORD)
+  const [setPassword] = useMutation<SetPaymentPassword>(
+    SET_PAYMENT_PASSWORD,
+    undefined,
+    { showToast: false }
+  )
   const { lang } = useContext(LanguageContext)
   const { currStep, forward } = useStep<'password' | 'comparedPassword'>(
     'password'

--- a/src/components/Forms/PaymentForm/SubscribeCircle/CardPayment.tsx
+++ b/src/components/Forms/PaymentForm/SubscribeCircle/CardPayment.tsx
@@ -14,9 +14,9 @@ import {
   Dialog,
   LanguageContext,
   Translate,
+  useMutation,
   useStep,
 } from '~/components'
-import { useMutation } from '~/components/GQL'
 
 import { STRIPE_ERROR_MESSAGES } from '~/common/enums'
 import { analytics, parseFormSubmitErrors, translate } from '~/common/utils'
@@ -52,7 +52,11 @@ const BaseCardPayment: React.FC<CardPaymentProps> = ({
   const elements = useElements()
   const { lang } = useContext(LanguageContext)
 
-  const [subscribeCircle] = useMutation<SubscribeCircleType>(SUBSCRIBE_CIRCLE)
+  const [subscribeCircle] = useMutation<SubscribeCircleType>(
+    SUBSCRIBE_CIRCLE,
+    undefined,
+    { showToast: false }
+  )
 
   const [disabled, setDisabled] = useState(true)
   const [isSubmitting, setSubmitting] = useState(false)

--- a/src/components/Forms/PaymentForm/SubscribeCircle/PasswordPayment.tsx
+++ b/src/components/Forms/PaymentForm/SubscribeCircle/PasswordPayment.tsx
@@ -10,9 +10,9 @@ import {
   Spinner,
   TextIcon,
   Translate,
+  useMutation,
   withIcon,
 } from '~/components'
-import { useMutation } from '~/components/GQL'
 
 import { parseFormSubmitErrors, validatePaymentPassword } from '~/common/utils'
 
@@ -48,7 +48,11 @@ const Confirm: React.FC<FormProps> = ({
   const formId = 'subscirbe-circle-form'
 
   const { lang } = useContext(LanguageContext)
-  const [subscribeCircle] = useMutation<SubscribeCircleType>(SUBSCRIBE_CIRCLE)
+  const [subscribeCircle] = useMutation<SubscribeCircleType>(
+    SUBSCRIBE_CIRCLE,
+    undefined,
+    { showToast: false }
+  )
 
   const {
     errors,

--- a/src/components/Forms/SignUpForm/Init.tsx
+++ b/src/components/Forms/SignUpForm/Init.tsx
@@ -10,8 +10,8 @@ import {
   Layout,
   ReCaptchaContext,
   Translate,
+  useMutation,
 } from '~/components'
-import { useMutation } from '~/components/GQL'
 import SEND_CODE from '~/components/GQL/mutations/sendCode'
 
 import { CLOSE_ACTIVE_DIALOG, OPEN_LOGIN_DIALOG, PATHS } from '~/common/enums'
@@ -74,7 +74,9 @@ const Init: React.FC<FormProps> = ({
   const formId = 'sign-up-init-form'
 
   const { token, refreshToken } = useContext(ReCaptchaContext)
-  const [sendCode] = useMutation<SendVerificationCode>(SEND_CODE)
+  const [sendCode] = useMutation<SendVerificationCode>(SEND_CODE, undefined, {
+    showToast: false,
+  })
 
   const {
     values,

--- a/src/components/Forms/SignUpForm/Password.tsx
+++ b/src/components/Forms/SignUpForm/Password.tsx
@@ -3,8 +3,14 @@ import gql from 'graphql-tag'
 import _pickBy from 'lodash/pickBy'
 import { useContext } from 'react'
 
-import { Dialog, Form, LanguageContext, Layout, Translate } from '~/components'
-import { useMutation } from '~/components/GQL'
+import {
+  Dialog,
+  Form,
+  LanguageContext,
+  Layout,
+  Translate,
+  useMutation,
+} from '~/components'
 import { CONFIRM_CODE } from '~/components/GQL/mutations/verificationCode'
 
 import {
@@ -48,8 +54,14 @@ const Password: React.FC<FormProps> = ({
   submitCallback,
   closeDialog,
 }) => {
-  const [confirm] = useMutation<ConfirmVerificationCode>(CONFIRM_CODE)
-  const [register] = useMutation<UserRegister>(USER_REGISTER)
+  const [confirm] = useMutation<ConfirmVerificationCode>(
+    CONFIRM_CODE,
+    undefined,
+    { showToast: false }
+  )
+  const [register] = useMutation<UserRegister>(USER_REGISTER, undefined, {
+    showToast: false,
+  })
   const { lang } = useContext(LanguageContext)
   const isInPage = purpose === 'page'
   const formId = 'sign-up-password-form'

--- a/src/components/Forms/Verification/SendCodeButton/index.tsx
+++ b/src/components/Forms/Verification/SendCodeButton/index.tsx
@@ -2,7 +2,6 @@ import { useContext, useState } from 'react'
 
 import {
   Button,
-  LanguageContext,
   ReCaptchaContext,
   TextIcon,
   Translate,
@@ -11,12 +10,7 @@ import {
 } from '~/components'
 import SEND_CODE from '~/components/GQL/mutations/sendCode'
 
-import {
-  ADD_TOAST,
-  SEND_CODE_COUNTDOWN,
-  VERIFICATION_CODE_TYPES,
-} from '~/common/enums'
-import { parseFormSubmitErrors } from '~/common/utils'
+import { SEND_CODE_COUNTDOWN, VERIFICATION_CODE_TYPES } from '~/common/enums'
 
 import styles from './styles.css'
 
@@ -46,7 +40,6 @@ export const VerificationSendCodeButton: React.FC<VerificationSendCodeButtonProp
   type,
   disabled,
 }) => {
-  const { lang } = useContext(LanguageContext)
   const { token, refreshToken } = useContext(ReCaptchaContext)
 
   const [send] = useMutation<SendVerificationCode>(SEND_CODE)
@@ -57,32 +50,15 @@ export const VerificationSendCodeButton: React.FC<VerificationSendCodeButtonProp
   })
 
   const sendCode = async () => {
-    try {
-      await send({
-        variables: { input: { email, type, token } },
-      })
+    await send({
+      variables: { input: { email, type, token } },
+    })
 
-      setCountdown({ timeLeft: SEND_CODE_COUNTDOWN })
-      setSent(true)
+    setCountdown({ timeLeft: SEND_CODE_COUNTDOWN })
+    setSent(true)
 
-      if (refreshToken) {
-        refreshToken()
-      }
-    } catch (error) {
-      const [messages, codes] = parseFormSubmitErrors(error, lang)
-
-      if (!messages[codes[0]]) {
-        return
-      }
-
-      window.dispatchEvent(
-        new CustomEvent(ADD_TOAST, {
-          detail: {
-            color: 'red',
-            content: messages[codes[0]],
-          },
-        })
-      )
+    if (refreshToken) {
+      refreshToken()
     }
   }
 

--- a/src/components/GQL/error.tsx
+++ b/src/components/GQL/error.tsx
@@ -24,7 +24,15 @@ export const getErrorCodes = (error?: ApolloError): ErrorCodeKeys[] => {
 /**
  * Check mutation on error to throw a `<Toast>`
  */
-export const mutationOnError = (error: ApolloError) => {
+export type MutationOnErrorOptions = {
+  showToast?: boolean
+}
+export const mutationOnError = (
+  error: ApolloError,
+  options?: MutationOnErrorOptions
+) => {
+  const { showToast } = options || { showToast: true }
+
   // Add info to Sentry
   import('@sentry/browser').then((Sentry) => {
     Sentry.captureException(error)
@@ -74,61 +82,23 @@ export const mutationOnError = (error: ApolloError) => {
     )
   }
 
-  /**
-   * Catch common errors
-   */
-  let isCatched = false
-  const CATCH_CODES = [
-    ERROR_CODES.UNKNOWN_ERROR,
-    ERROR_CODES.NETWORK_ERROR,
-    ERROR_CODES.INTERNAL_SERVER_ERROR,
-    ERROR_CODES.BAD_USER_INPUT,
-    ERROR_CODES.ENTITY_NOT_FOUND,
-    ERROR_CODES.USER_NOT_FOUND,
-    ERROR_CODES.COMMENT_NOT_FOUND,
-    ERROR_CODES.ARTICLE_NOT_FOUND,
-    ERROR_CODES.ASSET_NOT_FOUND,
-    ERROR_CODES.DRAFT_NOT_FOUND,
-    ERROR_CODES.TAG_NOT_FOUND,
-    ERROR_CODES.NOTICE_NOT_FOUND,
-    ERROR_CODES.CIRCLE_NOT_FOUND,
-    ERROR_CODES.NOT_ENOUGH_MAT,
-    ERROR_CODES.ACTION_FAILED,
-    ERROR_CODES.UNABLE_TO_UPLOAD_FROM_URL,
-    ERROR_CODES.LIKER_NOT_FOUND,
-    ERROR_CODES.LIKER_USER_ID_EXISTS,
-    ERROR_CODES.LIKER_EMAIL_EXISTS,
-    ERROR_CODES.MIGRATION_REACH_LIMIT,
-    ERROR_CODES.FORBIDDEN_BY_STATE,
-    ERROR_CODES.FORBIDDEN_BY_TARGET_STATE,
-  ] as ErrorCodeKeys[]
-  CATCH_CODES.forEach((code) => {
-    if (errorMap[code]) {
-      isCatched = true
-      window.dispatchEvent(
-        new CustomEvent(ADD_TOAST, {
-          detail: {
-            color: 'red',
-            content: <Translate id={code} />,
-          },
-        })
-      )
-    }
-  })
-  if (isCatched) {
-    return
+  if (showToast) {
+    window.dispatchEvent(
+      new CustomEvent(ADD_TOAST, {
+        detail: {
+          color: 'red',
+          content: <Translate id={errorCodes[0]} />,
+        },
+      })
+    )
   }
 
-  /**
-   * Throw error
-   */
   throw error
 }
 
 /**
  * Pass an `useQuery` or `useLazyQuery` error and return `<Error>`
  */
-
 export const QueryError = ({ error }: { error: ApolloError }) => {
   // Add info to Sentry
   import('@sentry/browser').then((Sentry) => {

--- a/src/components/GQL/hooks.ts
+++ b/src/components/GQL/hooks.ts
@@ -13,24 +13,36 @@ import { DocumentNode } from 'graphql'
 
 import { GQL_CONTEXT_PUBLIC_QUERY_KEY } from '~/common/enums'
 
-import { mutationOnError } from './error'
+import { mutationOnError, MutationOnErrorOptions } from './error'
+
+/**
+ * `useMutation` wrapper with error catching
+ *
+ */
+type CustomMutationProps = MutationOnErrorOptions
 
 export const useMutation = <TData = any, TVariables = OperationVariables>(
   mutation: DocumentNode,
-  options?: MutationHookOptions<TData, TVariables>
+  options?: MutationHookOptions<TData, TVariables>,
+  customMutationProps?: CustomMutationProps
 ): MutationTuple<TData, TVariables> => {
   const [mutate, result] = baseUseMutation(mutation, {
-    onError: (error) => mutationOnError(error),
+    onError: (error) => mutationOnError(error, customMutationProps),
     ...options,
   })
 
   return [mutate, result]
 }
 
+/**
+ * `useQuery` wrappers work with `authLink` of `withApollo.ts` for separating
+ * public and private queries;
+ *
+ * @see {@url https://github.com/thematters/matters-web/issues/1051}
+ */
 interface CustomQueryProps {
   publicQuery?: boolean
 }
-
 export const usePublicQuery = <TData = any, TVariables = OperationVariables>(
   query: DocumentNode,
   options?: QueryHookOptions<TData, TVariables>,

--- a/src/components/GlobalDialogs/TermAlertDialog/index.tsx
+++ b/src/components/GlobalDialogs/TermAlertDialog/index.tsx
@@ -5,16 +5,15 @@ import { useContext, useState } from 'react'
 
 import {
   Dialog,
-  LanguageContext,
   Term,
   Translate,
+  useMutation,
   ViewerContext,
 } from '~/components'
-import { useMutation } from '~/components/GQL'
 import USER_LOGOUT from '~/components/GQL/mutations/userLogout'
 
 import { ADD_TOAST, STORAGE_KEY_AUTH_TOKEN } from '~/common/enums'
-import { parseFormSubmitErrors, storage, unsubscribePush } from '~/common/utils'
+import { storage, unsubscribePush } from '~/common/utils'
 
 import styles from './styles.css'
 
@@ -37,35 +36,20 @@ const UPDATE_AGREE_ON = gql`
 `
 
 const TermContent: React.FC<TermContentProps> = ({ closeDialog }) => {
-  const [logout] = useMutation<UserLogout>(USER_LOGOUT)
+  const [logout] = useMutation<UserLogout>(USER_LOGOUT, undefined, {
+    showToast: false,
+  })
   const [update] = useMutation<UpdateUserInfoAgreeOn>(UPDATE_AGREE_ON)
-  const { lang } = useContext(LanguageContext)
 
   const { handleSubmit, isSubmitting } = useFormik({
     initialValues: {},
     onSubmit: async (values, { setSubmitting, setFieldError }) => {
       try {
         await update({ variables: { input: { agreeOn: true } } })
-
         setSubmitting(false)
         closeDialog()
       } catch (error) {
         setSubmitting(false)
-
-        const [messages, codes] = parseFormSubmitErrors(error, lang)
-
-        if (!messages[codes[0]]) {
-          return
-        }
-
-        window.dispatchEvent(
-          new CustomEvent(ADD_TOAST, {
-            detail: {
-              color: 'red',
-              content: messages[codes[0]],
-            },
-          })
-        )
       }
     },
   })

--- a/src/components/Layout/NavMenu/Bottom.tsx
+++ b/src/components/Layout/NavMenu/Bottom.tsx
@@ -6,8 +6,8 @@ import {
   Menu,
   TextIcon,
   Translate,
+  useMutation,
 } from '~/components'
-import { useMutation } from '~/components/GQL'
 import USER_LOGOUT from '~/components/GQL/mutations/userLogout'
 
 import { ADD_TOAST, PATHS, STORAGE_KEY_AUTH_TOKEN } from '~/common/enums'
@@ -20,7 +20,9 @@ interface NavMenuBottomProps {
 }
 
 const NavMenuBottom: React.FC<NavMenuBottomProps> = ({ isInSideDrawerNav }) => {
-  const [logout] = useMutation<UserLogout>(USER_LOGOUT)
+  const [logout] = useMutation<UserLogout>(USER_LOGOUT, undefined, {
+    showToast: false,
+  })
   const onClickLogout = async () => {
     try {
       await unsubscribePush()

--- a/src/components/OnboardingTasks/Tasks/index.tsx
+++ b/src/components/OnboardingTasks/Tasks/index.tsx
@@ -5,14 +5,13 @@ import {
   EmbedShare,
   LanguageContext,
   Translate,
+  useMutation,
   useResponsive,
   ViewerContext,
 } from '~/components'
-import { useMutation } from '~/components/GQL'
 import CREATE_DRAFT from '~/components/GQL/mutations/createDraft'
 
 import {
-  ADD_TOAST,
   CLOSE_ONBOARDING_TASKS_DIALOG,
   ONBOARDING_TASKS_HIDE,
   OPEN_LIKE_COIN_DIALOG,
@@ -20,13 +19,7 @@ import {
   OPEN_RECOMMEND_TAG_DIALOG,
   URL_QS,
 } from '~/common/enums'
-import {
-  analytics,
-  parseFormSubmitErrors,
-  routerPush,
-  toPath,
-  translate,
-} from '~/common/utils'
+import { analytics, routerPush, toPath, translate } from '~/common/utils'
 
 import styles from './styles.css'
 import TaskItem from './TaskItem'
@@ -45,32 +38,15 @@ const Tasks = () => {
     },
   })
   const createDraft = async () => {
-    try {
-      analytics.trackEvent('click_button', {
-        type: 'write',
-      })
-      const result = await putDraft()
-      const { slug, id } = result?.data?.putDraft || {}
+    analytics.trackEvent('click_button', {
+      type: 'write',
+    })
+    const result = await putDraft()
+    const { slug, id } = result?.data?.putDraft || {}
 
-      if (slug && id) {
-        const path = toPath({ page: 'draftDetail', slug, id })
-        routerPush(path.href)
-      }
-    } catch (error) {
-      const [messages, codes] = parseFormSubmitErrors(error, lang)
-
-      if (!messages[codes[0]]) {
-        return null
-      }
-
-      window.dispatchEvent(
-        new CustomEvent(ADD_TOAST, {
-          detail: {
-            color: 'red',
-            content: messages[codes[0]],
-          },
-        })
-      )
+    if (slug && id) {
+      const path = toPath({ page: 'draftDetail', slug, id })
+      routerPush(path.href)
     }
   }
 

--- a/src/components/Root/index.tsx
+++ b/src/components/Root/index.tsx
@@ -9,6 +9,7 @@ import {
   FeaturesProvider,
   LanguageProvider,
   Layout,
+  QueryError,
   Toast,
   usePublicQuery,
   useRoute,
@@ -16,7 +17,6 @@ import {
   ViewerUser,
 } from '~/components'
 import PageViewTracker from '~/components/Analytics/PageViewTracker'
-import { QueryError } from '~/components/GQL'
 import SplashScreen from '~/components/SplashScreen'
 
 import { ROOT_QUERY_PRIVATE, ROOT_QUERY_PUBLIC } from './gql'

--- a/src/components/Search/SearchOverview/ClearHistoryButton.tsx
+++ b/src/components/Search/SearchOverview/ClearHistoryButton.tsx
@@ -1,7 +1,6 @@
 import gql from 'graphql-tag'
 
-import { Button, TextIcon, Translate } from '~/components'
-import { useMutation } from '~/components/GQL'
+import { Button, TextIcon, Translate, useMutation } from '~/components'
 
 import { ADD_TOAST } from '~/common/enums'
 

--- a/src/components/TagDigest/Buttons/FollowButton/Follow.tsx
+++ b/src/components/TagDigest/Buttons/FollowButton/Follow.tsx
@@ -1,7 +1,6 @@
 import _isNil from 'lodash/isNil'
 
-import { Button, TextIcon, Translate } from '~/components'
-import { useMutation } from '~/components/GQL'
+import { Button, TextIcon, Translate, useMutation } from '~/components'
 import TOGGLE_FOLLOW_TAG from '~/components/GQL/mutations/toggleFollowTag'
 import updateViewerFollowingTagCount from '~/components/GQL/updates/viewerFollowingTagCount'
 

--- a/src/components/TagDigest/Buttons/FollowButton/Unfollow.tsx
+++ b/src/components/TagDigest/Buttons/FollowButton/Unfollow.tsx
@@ -1,8 +1,7 @@
 import _isNil from 'lodash/isNil'
 import { useState } from 'react'
 
-import { Button, TextIcon, Translate } from '~/components'
-import { useMutation } from '~/components/GQL'
+import { Button, TextIcon, Translate, useMutation } from '~/components'
 import TOGGLE_FOLLOW_TAG from '~/components/GQL/mutations/toggleFollowTag'
 import updateViewerFollowingTagCount from '~/components/GQL/updates/viewerFollowingTagCount'
 

--- a/src/components/UserProfile/EditProfileButton/ProfileEditor/index.tsx
+++ b/src/components/UserProfile/EditProfileButton/ProfileEditor/index.tsx
@@ -10,8 +10,8 @@ import {
   Form,
   LanguageContext,
   Translate,
+  useMutation,
 } from '~/components'
-import { useMutation } from '~/components/GQL'
 
 import { ADD_TOAST, ASSET_TYPE, ENTITY_TYPE } from '~/common/enums'
 import {
@@ -62,7 +62,11 @@ const UPDATE_USER_INFO = gql`
 const UNCHANGED_FIELD = 'UNCHANGED_FIELD'
 
 const ProfileEditor: React.FC<FormProps> = ({ user, closeDialog }) => {
-  const [update] = useMutation<UpdateUserInfoProfile>(UPDATE_USER_INFO)
+  const [update] = useMutation<UpdateUserInfoProfile>(
+    UPDATE_USER_INFO,
+    undefined,
+    { showToast: false }
+  )
   const { lang } = useContext(LanguageContext)
 
   const formId = 'edit-profile-form'

--- a/src/pages/recommendation.tsx
+++ b/src/pages/recommendation.tsx
@@ -7,9 +7,9 @@ import {
   EmptyArticle,
   InfiniteScroll,
   Layout,
+  QueryError,
   Spinner,
 } from '~/components'
-import { QueryError } from '~/components/GQL'
 
 import { mergeConnections } from '~/common/utils'
 

--- a/src/views/ArticleDetail/AppreciationButton/index.tsx
+++ b/src/views/ArticleDetail/AppreciationButton/index.tsx
@@ -6,10 +6,10 @@ import {
   ReCaptchaContext,
   Tooltip,
   Translate,
+  useMutation,
   useRoute,
   ViewerContext,
 } from '~/components'
-import { useMutation } from '~/components/GQL'
 import CLIENT_PREFERENCE from '~/components/GQL/queries/clientPreference'
 import updateAppreciation from '~/components/GQL/updates/appreciation'
 

--- a/src/views/ArticleDetail/Collection/index.tsx
+++ b/src/views/ArticleDetail/Collection/index.tsx
@@ -5,13 +5,13 @@ import _uniq from 'lodash/uniq'
 import {
   ArticleDigestSidebar,
   List,
+  QueryError,
   Spinner,
   Title,
   Translate,
   useResponsive,
   ViewMoreButton,
 } from '~/components'
-import { QueryError } from '~/components/GQL'
 import articleFragments from '~/components/GQL/fragments/article'
 
 import { analytics, mergeConnections } from '~/common/utils'

--- a/src/views/ArticleDetail/Content/index.tsx
+++ b/src/views/ArticleDetail/Content/index.tsx
@@ -3,8 +3,7 @@ import gql from 'graphql-tag'
 import throttle from 'lodash/throttle'
 import { useContext, useEffect, useRef, useState } from 'react'
 
-import { ViewerContext } from '~/components'
-import { useMutation } from '~/components/GQL'
+import { useMutation, ViewerContext } from '~/components'
 
 import styles from '~/common/styles/utils/content.article.css'
 import {
@@ -35,7 +34,9 @@ const Content = ({
   translating?: boolean
 }) => {
   const viewer = useContext(ViewerContext)
-  const [read] = useMutation<ReadArticle>(READ_ARTICLE)
+  const [read] = useMutation<ReadArticle>(READ_ARTICLE, undefined, {
+    showToast: false,
+  })
 
   const contentContainer = useRef(null)
 

--- a/src/views/ArticleDetail/EditMode/Header/index.tsx
+++ b/src/views/ArticleDetail/EditMode/Header/index.tsx
@@ -7,9 +7,9 @@ import {
   Tag,
   TextIcon,
   Translate,
+  useMutation,
 } from '~/components'
 import { fragments as EditorFragments } from '~/components/Editor/fragments'
-import { useMutation } from '~/components/GQL'
 import articleFragments from '~/components/GQL/fragments/article'
 
 import { ADD_TOAST } from '~/common/enums'

--- a/src/views/ArticleDetail/Responses/LatestResponses/index.tsx
+++ b/src/views/ArticleDetail/Responses/LatestResponses/index.tsx
@@ -6,6 +6,7 @@ import { useContext, useEffect, useState } from 'react'
 import {
   EmptyResponse,
   List,
+  QueryError,
   Spinner,
   Switch,
   Title,
@@ -18,7 +19,6 @@ import {
   ViewerContext,
   ViewMoreButton,
 } from '~/components'
-import { QueryError } from '~/components/GQL'
 
 import { REFETCH_RESPONSES, URL_FRAGMENT } from '~/common/enums'
 import {

--- a/src/views/ArticleDetail/index.tsx
+++ b/src/views/ArticleDetail/index.tsx
@@ -15,6 +15,7 @@ import {
   Head,
   Layout,
   PullToRefresh,
+  QueryError,
   Spinner,
   Throw404,
   Title,
@@ -24,7 +25,6 @@ import {
   useRoute,
   ViewerContext,
 } from '~/components'
-import { QueryError } from '~/components/GQL'
 import CLIENT_PREFERENCE from '~/components/GQL/queries/clientPreference'
 import { UserDigest } from '~/components/UserDigest'
 

--- a/src/views/Authors/index.tsx
+++ b/src/views/Authors/index.tsx
@@ -6,13 +6,13 @@ import {
   InfiniteScroll,
   Layout,
   List,
+  QueryError,
   Spinner,
   Translate,
   usePublicQuery,
   UserDigest,
   ViewerContext,
 } from '~/components'
-import { QueryError } from '~/components/GQL'
 
 import { analytics, mergeConnections } from '~/common/utils'
 

--- a/src/views/Circle/Detail/DropdownActions/index.tsx
+++ b/src/views/Circle/Detail/DropdownActions/index.tsx
@@ -13,13 +13,13 @@ import {
   TextIcon,
   Translate,
   UnsubscribeCircleDialog,
+  useMutation,
   ViewerContext,
 } from '~/components'
 import {
   SearchSelectDialog,
   SearchSelectNode,
 } from '~/components/Dialogs/SearchSelectDialog'
-import { useMutation } from '~/components/GQL'
 import PUT_CIRCLE_ARTICLES from '~/components/GQL/mutations/putCircleArticles'
 
 import { ADD_TOAST, REFETCH_CIRCLE_DETAIL_ARTICLES, TEXT } from '~/common/enums'

--- a/src/views/Circle/Detail/Profile/FollowButton/Follow.tsx
+++ b/src/views/Circle/Detail/Profile/FollowButton/Follow.tsx
@@ -1,7 +1,6 @@
 import _isNil from 'lodash/isNil'
 
-import { Button, TextIcon, Translate } from '~/components'
-import { useMutation } from '~/components/GQL'
+import { Button, TextIcon, Translate, useMutation } from '~/components'
 import TOGGLE_FOLLOW_CIRCLE from '~/components/GQL/mutations/toggleFollowCircle'
 import updateCircleFollowerCount from '~/components/GQL/updates/circleFollowerCount'
 

--- a/src/views/Circle/Detail/Profile/FollowButton/Unfollow.tsx
+++ b/src/views/Circle/Detail/Profile/FollowButton/Unfollow.tsx
@@ -1,8 +1,7 @@
 import _isNil from 'lodash/isNil'
 import { useState } from 'react'
 
-import { Button, TextIcon, Translate } from '~/components'
-import { useMutation } from '~/components/GQL'
+import { Button, TextIcon, Translate, useMutation } from '~/components'
 import TOGGLE_FOLLOW_CIRCLE from '~/components/GQL/mutations/toggleFollowCircle'
 import updateCircleFollowerCount from '~/components/GQL/updates/circleFollowerCount'
 

--- a/src/views/Circle/Detail/Works/index.tsx
+++ b/src/views/Circle/Detail/Works/index.tsx
@@ -6,13 +6,13 @@ import {
   EmptyTagArticles,
   InfiniteScroll,
   List,
+  QueryError,
   Spinner,
   useEventListener,
   usePublicQuery,
   usePullToRefresh,
   ViewerContext,
 } from '~/components'
-import { QueryError } from '~/components/GQL'
 
 import { REFETCH_CIRCLE_DETAIL_ARTICLES } from '~/common/enums'
 import { analytics, mergeConnections } from '~/common/utils'

--- a/src/views/Circle/Detail/index.tsx
+++ b/src/views/Circle/Detail/index.tsx
@@ -5,6 +5,7 @@ import {
   Head,
   Layout,
   PullToRefresh,
+  QueryError,
   Spacer,
   Spinner,
   SubscribeCircleDialog,
@@ -16,7 +17,6 @@ import {
   useRoute,
   ViewerContext,
 } from '~/components'
-import { QueryError } from '~/components/GQL'
 
 import DropdownActions from './DropdownActions'
 import { CIRCLE_DETAIL_PRIVATE, CIRCLE_DETAIL_PUBLIC } from './gql'

--- a/src/views/Circle/Followers/CircleFollowers.tsx
+++ b/src/views/Circle/Followers/CircleFollowers.tsx
@@ -4,6 +4,7 @@ import {
   EmptyWarning,
   InfiniteScroll,
   List,
+  QueryError,
   Spinner,
   Translate,
   usePublicQuery,
@@ -11,7 +12,6 @@ import {
   useRoute,
   ViewerContext,
 } from '~/components'
-import { QueryError } from '~/components/GQL'
 import { UserDigest } from '~/components/UserDigest'
 
 import { mergeConnections } from '~/common/utils'

--- a/src/views/Circle/Followers/index.tsx
+++ b/src/views/Circle/Followers/index.tsx
@@ -5,6 +5,7 @@ import {
   Head,
   Layout,
   PullToRefresh,
+  QueryError,
   Spinner,
   Throw404,
   usePublicQuery,
@@ -12,7 +13,6 @@ import {
   useRoute,
   ViewerContext,
 } from '~/components'
-import { QueryError } from '~/components/GQL'
 
 import IMAGE_LOGO_192 from '@/public/static/icon-192x192.png?url'
 

--- a/src/views/Circle/Members/CircleMembers.tsx
+++ b/src/views/Circle/Members/CircleMembers.tsx
@@ -4,6 +4,7 @@ import {
   EmptyWarning,
   InfiniteScroll,
   List,
+  QueryError,
   Spinner,
   Translate,
   usePublicQuery,
@@ -11,7 +12,6 @@ import {
   useRoute,
   ViewerContext,
 } from '~/components'
-import { QueryError } from '~/components/GQL'
 import { UserDigest } from '~/components/UserDigest'
 
 import { mergeConnections } from '~/common/utils'

--- a/src/views/Circle/Members/index.tsx
+++ b/src/views/Circle/Members/index.tsx
@@ -5,6 +5,7 @@ import {
   Head,
   Layout,
   PullToRefresh,
+  QueryError,
   Spinner,
   Throw404,
   usePublicQuery,
@@ -12,7 +13,6 @@ import {
   useRoute,
   ViewerContext,
 } from '~/components'
-import { QueryError } from '~/components/GQL'
 
 import IMAGE_LOGO_192 from '@/public/static/icon-192x192.png?url'
 

--- a/src/views/Follow/FollowFeed/ArticlesFeed/index.tsx
+++ b/src/views/Follow/FollowFeed/ArticlesFeed/index.tsx
@@ -6,12 +6,12 @@ import {
   EmptyArticle,
   InfiniteScroll,
   List,
+  QueryError,
   Spinner,
   TextIcon,
   Translate,
   UserDigest,
 } from '~/components'
-import { QueryError } from '~/components/GQL'
 import { UserDigestMiniProps } from '~/components/UserDigest/Mini'
 
 import { analytics, mergeConnections } from '~/common/utils'

--- a/src/views/Follow/FollowFeed/CommentsFeed/index.tsx
+++ b/src/views/Follow/FollowFeed/CommentsFeed/index.tsx
@@ -1,8 +1,13 @@
 import { useQuery } from '@apollo/react-hooks'
 import gql from 'graphql-tag'
 
-import { EmptyArticle, InfiniteScroll, List, Spinner } from '~/components'
-import { QueryError } from '~/components/GQL'
+import {
+  EmptyArticle,
+  InfiniteScroll,
+  List,
+  QueryError,
+  Spinner,
+} from '~/components'
 
 import { analytics, mergeConnections } from '~/common/utils'
 

--- a/src/views/Follow/FollowFeed/DonationsFeed/index.tsx
+++ b/src/views/Follow/FollowFeed/DonationsFeed/index.tsx
@@ -6,12 +6,12 @@ import {
   EmptyFolloweeDonatedArticles,
   InfiniteScroll,
   List,
+  QueryError,
   Spinner,
   TextIcon,
   Translate,
   UserDigest,
 } from '~/components'
-import { QueryError } from '~/components/GQL'
 import CLIENT_PREFERENCE from '~/components/GQL/queries/clientPreference'
 import { UserDigestMiniProps } from '~/components/UserDigest/Mini'
 

--- a/src/views/Follow/FollowFeed/TagsFeed/index.tsx
+++ b/src/views/Follow/FollowFeed/TagsFeed/index.tsx
@@ -10,12 +10,12 @@ import {
   EmptyFollowingTag,
   InfiniteScroll,
   List,
+  QueryError,
   Spinner,
   Tag,
   TextIcon,
   Translate,
 } from '~/components'
-import { QueryError } from '~/components/GQL'
 
 import { analytics, mergeConnections } from '~/common/utils'
 

--- a/src/views/Follow/PickAuthors/AuthorPicker/index.tsx
+++ b/src/views/Follow/PickAuthors/AuthorPicker/index.tsx
@@ -7,12 +7,12 @@ import {
   IconReload12,
   List,
   PageHeader,
+  QueryError,
   Spinner,
   TextIcon,
   Translate,
   UserDigest,
 } from '~/components'
-import { QueryError } from '~/components/GQL'
 
 import styles from './styles.css'
 

--- a/src/views/Follow/index.tsx
+++ b/src/views/Follow/index.tsx
@@ -2,8 +2,13 @@ import { useQuery } from '@apollo/react-hooks'
 import gql from 'graphql-tag'
 import { useContext, useEffect } from 'react'
 
-import { Layout, Spinner, useResponsive, ViewerContext } from '~/components'
-import { useMutation } from '~/components/GQL'
+import {
+  Layout,
+  Spinner,
+  useMutation,
+  useResponsive,
+  ViewerContext,
+} from '~/components'
 import viewerUnreadFolloweeArticles from '~/components/GQL/updates/viewerUnreadFolloweeArticles'
 
 import FollowFeed from './FollowFeed'

--- a/src/views/Home/Feed/Authors/index.tsx
+++ b/src/views/Home/Feed/Authors/index.tsx
@@ -3,6 +3,7 @@ import _random from 'lodash/random'
 import { useContext, useEffect } from 'react'
 
 import {
+  QueryError,
   ShuffleButton,
   Slides,
   Spinner,
@@ -10,7 +11,6 @@ import {
   UserDigest,
   ViewerContext,
 } from '~/components'
-import { QueryError } from '~/components/GQL'
 
 import { analytics } from '~/common/utils'
 

--- a/src/views/Home/Feed/Tags/index.tsx
+++ b/src/views/Home/Feed/Tags/index.tsx
@@ -3,13 +3,13 @@ import _random from 'lodash/random'
 import { useContext, useEffect } from 'react'
 
 import {
+  QueryError,
   ShuffleButton,
   Slides,
   Spinner,
   usePublicQuery,
   ViewerContext,
 } from '~/components'
-import { QueryError } from '~/components/GQL'
 
 import { analytics } from '~/common/utils'
 

--- a/src/views/Home/Feed/index.tsx
+++ b/src/views/Home/Feed/index.tsx
@@ -7,12 +7,12 @@ import {
   EmptyArticle,
   InfiniteScroll,
   List,
+  QueryError,
   Spinner,
   usePublicQuery,
   useResponsive,
   ViewerContext,
 } from '~/components'
-import { QueryError } from '~/components/GQL'
 import CLIENT_PREFERENCE from '~/components/GQL/queries/clientPreference'
 
 import { analytics, mergeConnections } from '~/common/utils'

--- a/src/views/Home/Sidebar/Authors/index.tsx
+++ b/src/views/Home/Sidebar/Authors/index.tsx
@@ -3,13 +3,13 @@ import { useContext, useEffect } from 'react'
 
 import {
   List,
+  QueryError,
   ShuffleButton,
   Spinner,
   usePublicQuery,
   UserDigest,
   ViewerContext,
 } from '~/components'
-import { QueryError } from '~/components/GQL'
 
 import { analytics } from '~/common/utils'
 

--- a/src/views/Home/Sidebar/Tags/index.tsx
+++ b/src/views/Home/Sidebar/Tags/index.tsx
@@ -6,13 +6,13 @@ import {
   Card,
   Img,
   List,
+  QueryError,
   ShuffleButton,
   Spinner,
   Tag,
   usePublicQuery,
   ViewerContext,
 } from '~/components'
-import { QueryError } from '~/components/GQL'
 
 import { analytics, toPath } from '~/common/utils'
 

--- a/src/views/Me/Bookmarks/index.tsx
+++ b/src/views/Me/Bookmarks/index.tsx
@@ -8,9 +8,9 @@ import {
   InfiniteScroll,
   Layout,
   List,
+  QueryError,
   Spinner,
 } from '~/components'
-import { QueryError } from '~/components/GQL'
 
 import { mergeConnections } from '~/common/utils'
 

--- a/src/views/Me/DraftDetail/PublishButton/PublishDialog/PublishContent.tsx
+++ b/src/views/Me/DraftDetail/PublishButton/PublishDialog/PublishContent.tsx
@@ -1,7 +1,6 @@
 import gql from 'graphql-tag'
 
-import { Dialog, Translate, useRoute } from '~/components'
-import { useMutation } from '~/components/GQL'
+import { Dialog, Translate, useMutation, useRoute } from '~/components'
 
 import PUBLISH_IMAGE from '@/public/static/images/publish-1.svg'
 

--- a/src/views/Me/DraftDetail/PublishState/RetryButton.tsx
+++ b/src/views/Me/DraftDetail/PublishState/RetryButton.tsx
@@ -1,7 +1,12 @@
 import gql from 'graphql-tag'
 
-import { Button, IconArrowRight16, TextIcon, Translate } from '~/components'
-import { useMutation } from '~/components/GQL'
+import {
+  Button,
+  IconArrowRight16,
+  TextIcon,
+  Translate,
+  useMutation,
+} from '~/components'
 
 import { RetryPublish } from './__generated__/RetryPublish'
 

--- a/src/views/Me/Drafts/index.tsx
+++ b/src/views/Me/Drafts/index.tsx
@@ -8,9 +8,9 @@ import {
   InfiniteScroll,
   Layout,
   List,
+  QueryError,
   Spinner,
 } from '~/components'
-import { QueryError } from '~/components/GQL'
 
 import { mergeConnections } from '~/common/utils'
 

--- a/src/views/Me/History/index.tsx
+++ b/src/views/Me/History/index.tsx
@@ -8,9 +8,9 @@ import {
   InfiniteScroll,
   Layout,
   List,
+  QueryError,
   Spinner,
 } from '~/components'
-import { QueryError } from '~/components/GQL'
 
 import { analytics, mergeConnections } from '~/common/utils'
 

--- a/src/views/Me/Notifications/index.tsx
+++ b/src/views/Me/Notifications/index.tsx
@@ -12,10 +12,10 @@ import {
   PullToRefresh,
   Spacer,
   Spinner,
+  useMutation,
   usePullToRefresh,
   useResponsive,
 } from '~/components'
-import { useMutation } from '~/components/GQL'
 import updateViewerUnreadNoticeCount from '~/components/GQL/updates/viewerUnreadNoticeCount'
 
 import { mergeConnections } from '~/common/utils'

--- a/src/views/Me/Settings/Blocked/SettingsBlocked.tsx
+++ b/src/views/Me/Settings/Blocked/SettingsBlocked.tsx
@@ -5,10 +5,10 @@ import {
   EmptyWarning,
   InfiniteScroll,
   List,
+  QueryError,
   Spinner,
   Translate,
 } from '~/components'
-import { QueryError } from '~/components/GQL'
 import { UserDigest } from '~/components/UserDigest'
 
 import { mergeConnections } from '~/common/utils'

--- a/src/views/Me/Settings/Notification/index.tsx
+++ b/src/views/Me/Settings/Notification/index.tsx
@@ -1,8 +1,14 @@
 import { useQuery } from '@apollo/react-hooks'
 import gql from 'graphql-tag'
 
-import { Head, Layout, PullToRefresh, Spacer, Spinner } from '~/components'
-import { useMutation } from '~/components/GQL'
+import {
+  Head,
+  Layout,
+  PullToRefresh,
+  Spacer,
+  Spinner,
+  useMutation,
+} from '~/components'
 
 import ArticleSettings from './Article'
 import CommentSettings from './Comment'

--- a/src/views/Me/Wallet/Buttons/PayoutButton.tsx
+++ b/src/views/Me/Wallet/Buttons/PayoutButton.tsx
@@ -6,10 +6,9 @@ import {
   IconSpinner16,
   PayoutDialog,
   Translate,
+  useMutation,
 } from '~/components'
-import { useMutation } from '~/components/GQL'
 
-import { ADD_TOAST } from '~/common/enums'
 import { sleep } from '~/common/utils'
 
 import { ConnectStripeAccount } from './__generated__/ConnectStripeAccount'
@@ -46,22 +45,11 @@ const PayoutButton: React.FC<PayoutButtonProps> = ({
             if (hasStripeAccount) {
               open()
             } else {
-              try {
-                const { data } = await connectStripeAccount()
-                const redirectUrl = data?.connectStripeAccount.redirectUrl
-                open()
-                await sleep(2000)
-                window.open(redirectUrl, '_blank')
-              } catch (e) {
-                window.dispatchEvent(
-                  new CustomEvent(ADD_TOAST, {
-                    detail: {
-                      color: 'red',
-                      content: <Translate id="ACTION_FAILED" />,
-                    },
-                  })
-                )
-              }
+              const { data } = await connectStripeAccount()
+              const redirectUrl = data?.connectStripeAccount.redirectUrl
+              open()
+              await sleep(2000)
+              window.open(redirectUrl, '_blank')
             }
           }}
         >

--- a/src/views/TagDetail/Articles/index.tsx
+++ b/src/views/TagDetail/Articles/index.tsx
@@ -6,13 +6,13 @@ import {
   EmptyTagArticles,
   InfiniteScroll,
   List,
+  QueryError,
   Spinner,
   useEventListener,
   usePublicQuery,
   usePullToRefresh,
   ViewerContext,
 } from '~/components'
-import { QueryError } from '~/components/GQL'
 import {
   TAG_ARTICLES_PRIVATE,
   TAG_ARTICLES_PUBLIC,

--- a/src/views/TagDetail/Buttons/AddButton/CreateDraftMenuItem/index.tsx
+++ b/src/views/TagDetail/Buttons/AddButton/CreateDraftMenuItem/index.tsx
@@ -6,19 +6,13 @@ import {
   Menu,
   TextIcon,
   Translate,
+  useMutation,
   ViewerContext,
 } from '~/components'
-import { useMutation } from '~/components/GQL'
 import CREATE_DRAFT from '~/components/GQL/mutations/createDraft'
 
 import { ADD_TOAST, OPEN_LIKE_COIN_DIALOG } from '~/common/enums'
-import {
-  analytics,
-  parseFormSubmitErrors,
-  routerPush,
-  toPath,
-  translate,
-} from '~/common/utils'
+import { analytics, routerPush, toPath, translate } from '~/common/utils'
 
 import { CreateDraft } from '~/components/GQL/mutations/__generated__/CreateDraft'
 import { TagDetailPublic_node_Tag } from '../../../__generated__/TagDetailPublic'
@@ -47,45 +41,28 @@ const CreateDraftButton: React.FC<CreateDraftButtonProps> = ({ tag }) => {
   })
 
   const createDraft = async () => {
-    try {
-      if (viewer.isInactive) {
-        window.dispatchEvent(
-          new CustomEvent(ADD_TOAST, {
-            detail: {
-              color: 'red',
-              content: <Translate id="FORBIDDEN" />,
-            },
-          })
-        )
-        return
-      }
-
-      analytics.trackEvent('click_button', {
-        type: 'write',
-      })
-
-      const result = await putDraft()
-      const { slug, id } = result?.data?.putDraft || {}
-
-      if (slug && id) {
-        const path = toPath({ page: 'draftDetail', slug, id })
-        routerPush(path.href)
-      }
-    } catch (error) {
-      const [messages, codes] = parseFormSubmitErrors(error, lang)
-
-      if (!messages[codes[0]]) {
-        return null
-      }
-
+    if (viewer.isInactive) {
       window.dispatchEvent(
         new CustomEvent(ADD_TOAST, {
           detail: {
             color: 'red',
-            content: messages[codes[0]],
+            content: <Translate id="FORBIDDEN" />,
           },
         })
       )
+      return
+    }
+
+    analytics.trackEvent('click_button', {
+      type: 'write',
+    })
+
+    const result = await putDraft()
+    const { slug, id } = result?.data?.putDraft || {}
+
+    if (slug && id) {
+      const path = toPath({ page: 'draftDetail', slug, id })
+      routerPush(path.href)
     }
   }
 

--- a/src/views/TagDetail/Buttons/AddButton/index.tsx
+++ b/src/views/TagDetail/Buttons/AddButton/index.tsx
@@ -8,13 +8,13 @@ import {
   Menu,
   TextIcon,
   Translate,
+  useMutation,
   ViewerContext,
 } from '~/components'
 import {
   SearchSelectDialog,
   SearchSelectNode,
 } from '~/components/Dialogs/SearchSelectDialog'
-import { useMutation } from '~/components/GQL'
 import ADD_ARTICLES_TAGS from '~/components/GQL/mutations/addArticlesTags'
 import updateTagArticlesCount from '~/components/GQL/updates/tagArticlesCount'
 

--- a/src/views/TagDetail/Buttons/FollowButton/Follow.tsx
+++ b/src/views/TagDetail/Buttons/FollowButton/Follow.tsx
@@ -6,9 +6,9 @@ import {
   IconAdd16,
   TextIcon,
   Translate,
+  useMutation,
   ViewerContext,
 } from '~/components'
-import { useMutation } from '~/components/GQL'
 import TOGGLE_FOLLOW_TAG from '~/components/GQL/mutations/toggleFollowTag'
 import updateTagFollowers from '~/components/GQL/updates/tagFollowers'
 

--- a/src/views/TagDetail/Buttons/FollowButton/Unfollow.tsx
+++ b/src/views/TagDetail/Buttons/FollowButton/Unfollow.tsx
@@ -1,8 +1,13 @@
 import _isNil from 'lodash/isNil'
 import { useContext, useState } from 'react'
 
-import { Button, TextIcon, Translate, ViewerContext } from '~/components'
-import { useMutation } from '~/components/GQL'
+import {
+  Button,
+  TextIcon,
+  Translate,
+  useMutation,
+  ViewerContext,
+} from '~/components'
 import TOGGLE_FOLLOW_TAG from '~/components/GQL/mutations/toggleFollowTag'
 import updateTagFollowers from '~/components/GQL/updates/tagFollowers'
 

--- a/src/views/TagDetail/Community/Maintainers/index.tsx
+++ b/src/views/TagDetail/Community/Maintainers/index.tsx
@@ -3,13 +3,13 @@ import { useQuery } from '@apollo/react-hooks'
 import {
   Button,
   IconSettings24,
+  QueryError,
   Spinner,
   TagEditorDialog,
   TextIcon,
   Translate,
   UserDigest,
 } from '~/components'
-import { QueryError } from '~/components/GQL'
 import TAG_MAINTAINERS from '~/components/GQL/queries/tagMaintainers'
 
 import styles from '../styles.css'

--- a/src/views/TagDetail/Community/Participants/index.tsx
+++ b/src/views/TagDetail/Community/Participants/index.tsx
@@ -3,13 +3,13 @@ import { NetworkStatus } from 'apollo-client'
 import {
   InfiniteScroll,
   List,
+  QueryError,
   Spinner,
   Translate,
   usePublicQuery,
   usePullToRefresh,
   UserDigest,
 } from '~/components'
-import { QueryError } from '~/components/GQL'
 
 import { analytics, mergeConnections } from '~/common/utils'
 

--- a/src/views/TagDetail/DropdownActions/index.tsx
+++ b/src/views/TagDetail/DropdownActions/index.tsx
@@ -17,13 +17,13 @@ import {
   TagLeaveDialog,
   TextIcon,
   Translate,
+  useMutation,
   ViewerContext,
 } from '~/components'
 import {
   SearchSelectDialog,
   SearchSelectNode,
 } from '~/components/Dialogs/SearchSelectDialog'
-import { useMutation } from '~/components/GQL'
 import ADD_ARTICLES_TAGS from '~/components/GQL/mutations/addArticlesTags'
 import updateTagArticlesCount from '~/components/GQL/updates/tagArticlesCount'
 

--- a/src/views/Tags/index.tsx
+++ b/src/views/Tags/index.tsx
@@ -6,10 +6,10 @@ import {
   Head,
   InfiniteScroll,
   Layout,
+  QueryError,
   Spinner,
   usePublicQuery,
 } from '~/components'
-import { QueryError } from '~/components/GQL'
 
 import { analytics, mergeConnections, toPath } from '~/common/utils'
 

--- a/src/views/User/Articles/UserArticles.tsx
+++ b/src/views/User/Articles/UserArticles.tsx
@@ -7,6 +7,7 @@ import {
   IconDotDivider,
   InfiniteScroll,
   List,
+  QueryError,
   Spinner,
   Translate,
   usePublicQuery,
@@ -14,7 +15,6 @@ import {
   useRoute,
   ViewerContext,
 } from '~/components'
-import { QueryError } from '~/components/GQL'
 import {
   USER_ARTICLES_PRIVATE,
   USER_ARTICLES_PUBLIC,

--- a/src/views/User/Comments/UserComments.tsx
+++ b/src/views/User/Comments/UserComments.tsx
@@ -10,13 +10,13 @@ import {
   Head,
   InfiniteScroll,
   List,
+  QueryError,
   Spinner,
   usePublicQuery,
   usePullToRefresh,
   useRoute,
   ViewerContext,
 } from '~/components'
-import { QueryError } from '~/components/GQL'
 
 import {
   analytics,

--- a/src/views/User/Followees/UserFollowees.tsx
+++ b/src/views/User/Followees/UserFollowees.tsx
@@ -5,6 +5,7 @@ import {
   Head,
   InfiniteScroll,
   List,
+  QueryError,
   Spinner,
   Translate,
   usePublicQuery,
@@ -12,7 +13,6 @@ import {
   useRoute,
   ViewerContext,
 } from '~/components'
-import { QueryError } from '~/components/GQL'
 import { UserDigest } from '~/components/UserDigest'
 
 import { analytics, mergeConnections } from '~/common/utils'

--- a/src/views/User/Followers/UserFollowers.tsx
+++ b/src/views/User/Followers/UserFollowers.tsx
@@ -5,6 +5,7 @@ import {
   Head,
   InfiniteScroll,
   List,
+  QueryError,
   Spinner,
   Translate,
   usePublicQuery,
@@ -12,7 +13,6 @@ import {
   useRoute,
   ViewerContext,
 } from '~/components'
-import { QueryError } from '~/components/GQL'
 import { UserDigest } from '~/components/UserDigest'
 
 import { analytics, mergeConnections } from '~/common/utils'

--- a/src/views/User/Subscriptions/UserSubscriptions.tsx
+++ b/src/views/User/Subscriptions/UserSubscriptions.tsx
@@ -4,6 +4,7 @@ import {
   Head,
   InfiniteScroll,
   List,
+  QueryError,
   Spinner,
   Title,
   Translate,
@@ -11,7 +12,6 @@ import {
   usePullToRefresh,
   useRoute,
 } from '~/components'
-import { QueryError } from '~/components/GQL'
 
 import { analytics, mergeConnections } from '~/common/utils'
 

--- a/src/views/User/Tags/UserTags.tsx
+++ b/src/views/User/Tags/UserTags.tsx
@@ -4,6 +4,7 @@ import {
   Head,
   InfiniteScroll,
   List,
+  QueryError,
   Spinner,
   Tag,
   Translate,
@@ -11,7 +12,6 @@ import {
   usePullToRefresh,
   useRoute,
 } from '~/components'
-import { QueryError } from '~/components/GQL'
 
 import { analytics, mergeConnections, toPath } from '~/common/utils'
 


### PR DESCRIPTION
During the implementation of #1777, I found some errors like `CIRCLE_NOT_FOUND` was caught and then shown and skip the error throwing, which makes mutation inside [`try...catch...`](https://github.com/thematters/matters-web/pull/1777/files#diff-a9913444763a337cf658f9b2fbe0c7e4b2e1e67614efa87e97ed1027cfe0c5adR71-R82) doesn't work as we expected [1].  

In these changes, forms ignore the default error catching behavior and show the error message in the form field instead [2].

[1] Showing toast and subscription becomes complete
![image](https://user-images.githubusercontent.com/4065233/106425243-973e8780-649e-11eb-89a9-32c910d0d6b6.png)


[2] 
![image](https://user-images.githubusercontent.com/4065233/106425140-5f374480-649e-11eb-8229-c113938fb8cc.png)
