### PR TITLE
fix(asset): local update draft assets if uploaded completely instead of refetch

### DIFF
--- a/src/components/Editor/SetCoverDialog/Uploader.tsx
+++ b/src/components/Editor/SetCoverDialog/Uploader.tsx
@@ -9,6 +9,7 @@ import {
   useMutation,
 } from '~/components'
 import UPLOAD_FILE from '~/components/GQL/mutations/uploadFile'
+import updateDraftAssets from '~/components/GQL/updates/draftAssets'
 
 import {
   ACCEPTED_UPLOAD_IMAGE_TYPES,
@@ -42,7 +43,17 @@ const Uploader: React.FC<UploaderProps> = ({
 }) => {
   const [upload, { loading }] = useMutation<SingleFileUpload>(
     UPLOAD_FILE,
-    undefined,
+    {
+      update: (cache, { data }) => {
+        if (data?.singleFileUpload) {
+          updateDraftAssets({
+            cache,
+            id: entityId,
+            asset: data.singleFileUpload,
+          })
+        }
+      },
+    },
     { showToast: false }
   )
 
@@ -88,8 +99,6 @@ const Uploader: React.FC<UploaderProps> = ({
           },
         },
       })
-
-      await refetchAssets()
 
       if (data?.singleFileUpload) {
         setSelected(data?.singleFileUpload)

--- a/src/components/GQL/updates/draftAssets.ts
+++ b/src/components/GQL/updates/draftAssets.ts
@@ -1,0 +1,54 @@
+import { DataProxy } from 'apollo-cache'
+import { DRAFT_ASSETS } from '~/views/Me/DraftDetail/gql'
+
+import { ERROR_CODES } from '~/common/enums'
+
+import {
+  DraftAssets,
+  DraftAssets_node_Draft_assets as Asset,
+} from '~/views/Me/DraftDetail/__generated__/DraftAssets'
+
+const update = ({
+  cache,
+  id,
+  asset,
+}: {
+  cache: DataProxy
+  id: string
+  asset: Asset
+}) => {
+  try {
+    if (!id) {
+      return
+    }
+
+    const variables = { id }
+    const cacheData = cache.readQuery<DraftAssets>({
+      query: DRAFT_ASSETS,
+      variables,
+    })
+
+    if (
+      !cacheData ||
+      !cacheData.node ||
+      cacheData.node.__typename !== 'Draft'
+    ) {
+      return
+    }
+
+    cacheData.node.assets.unshift(asset)
+    cache.writeQuery({
+      query: DRAFT_ASSETS,
+      variables,
+      data: cacheData,
+    })
+  } catch (e) {
+    if (e.message.startsWith("Can't find field")) {
+      console.warn(ERROR_CODES.QUERY_FIELD_NOT_FOUND)
+    } else {
+      console.error(e)
+    }
+  }
+}
+
+export default update


### PR DESCRIPTION
Since file upload won't purge cache of draft, updating local cache of draft's assets.