### PR TITLE
update Content-Security-Policy: add matters s3 url

### DIFF
--- a/src/common/enums/csp.ts
+++ b/src/common/enums/csp.ts
@@ -39,6 +39,9 @@ const IMG_SRC = [
   'data:',
   process.env.NEXT_PUBLIC_ASSET_DOMAIN,
 
+  // for some old articles were using this s3 urls directly
+  'matters-server-production.s3-ap-southeast-1.amazonaws.com',
+
   // GA
   'www.google-analytics.com',
 ].join(' ')


### PR DESCRIPTION
should fix large part of #2254  as @robertu7 mentioned there were still others server urls when users were copying pictures

these old articles were referencing from `srcSet=https://matters-server-production.s3-ap-southeast-1.amazonaws.com/embed/...` directly