### PR TITLE
add logbook again, via the new `hasNFTs` boolean flag

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,12 @@
 name: Test
 
 on:
-  pull_request:
-    branches:
-      - '*'
+  push:
+    branches-ignore:
+      - develop
+      - main
+      - master
+      - stage
 
 jobs:
   build_and_test:
@@ -29,14 +32,8 @@ jobs:
       - name: Install Dependencies
         run: npm ci
 
-      - name: Generate Types
-        if: github.base_ref == 'develop'
-        run: |
-          npm run gen:clean \
-          && npm run gen:type
-
-      - name: Generate Types (stage)
-        if: github.base_ref == 'stage'
+      - name: Generate Types (Develop)
+        if: github.base_ref != 'master'
         run: |
           npm run gen:clean \
           && npm run gen:type

--- a/src/components/Avatar/index.tsx
+++ b/src/components/Avatar/index.tsx
@@ -45,6 +45,7 @@ const fragments = {
         cryptoWallet {
           id
           address
+          hasNFTs
           # nfts { id }
         }
       }
@@ -60,9 +61,7 @@ export const Avatar = (props: AvatarProps) => {
   const isCivicLiker = user?.liker.civicLiker
   const badges = user?.info?.badges || []
   const hasArchitectBadge = badges.some((b) => b.type === 'architect')
-  const hasLogbook = false /*
-    Array.isArray(user?.info?.cryptoWallet?.nfts) &&
-    (user?.info?.cryptoWallet?.nfts || []).length > 0 */
+  const hasLogbook = !!user?.info?.cryptoWallet?.hasNFTs
   const avatarClasses = classNames({
     avatar: true,
     [size]: true,

--- a/src/components/Context/Viewer/index.tsx
+++ b/src/components/Context/Viewer/index.tsx
@@ -40,6 +40,7 @@ const ViewerFragments = {
           cryptoWallet {
             id
             address
+            hasNFTs
             # nfts { id }
           }
         }

--- a/src/components/UserProfile/DropdownActions/index.tsx
+++ b/src/components/UserProfile/DropdownActions/index.tsx
@@ -51,9 +51,7 @@ const fragments = {
           cryptoWallet {
             id
             address
-            nfts {
-              id
-            }
+            hasNFTs
           }
         }
         ...BlockUserPublic
@@ -147,9 +145,9 @@ const DropdownActions = ({ user, isMe }: DropdownActionsProps) => {
   const controls = {
     hasEditProfile: isMe,
     hasBlockUser: !isMe,
-    hasLogbook:
+    hasLogbook: !!user.info.cryptoWallet?.hasNFTs /*
       Array.isArray(user.info.cryptoWallet?.nfts) &&
-      (user.info.cryptoWallet?.nfts || []).length > 0,
+      (user.info.cryptoWallet?.nfts || []).length > 0, */,
   }
 
   if (_isEmpty(_pickBy(controls))) {

--- a/src/components/UserProfile/index.tsx
+++ b/src/components/UserProfile/index.tsx
@@ -36,7 +36,7 @@ import { FollowingDialog } from './FollowingDialog'
 import { USER_PROFILE_PRIVATE, USER_PROFILE_PUBLIC } from './gql'
 import styles from './styles.css'
 
-import { UserProfileUserPrivate_user_info_cryptoWallet_nfts } from './__generated__/UserProfileUserPrivate'
+// import { UserProfileUserPrivate_user_info_cryptoWallet_nfts } from './__generated__/UserProfileUserPrivate'
 import { UserProfileUserPublic } from './__generated__/UserProfileUserPublic'
 
 export const UserProfile = () => {
@@ -131,12 +131,12 @@ export const UserProfile = () => {
   const hasSeedBadge = badges.some((b) => b.type === 'seed')
   const hasArchitectBadge = badges.some((b) => b.type === 'architect')
   const hasGoldenMotorBadge = badges.some((b) => b.type === 'golden_motor')
-  const hasTraveloggersBadge =
+  const hasTraveloggersBadge = !!user.info.cryptoWallet?.hasNFTs /*
     Array.isArray(user.info.cryptoWallet?.nfts) &&
     (
       user?.info.cryptoWallet
         ?.nfts as UserProfileUserPrivate_user_info_cryptoWallet_nfts[]
-    ).length > 0
+    ).length > 0 */
 
   const profileCover = user.info.profileCover || ''
   const userState = user.status?.state as string

--- a/src/stories/mocks/index.ts
+++ b/src/stories/mocks/index.ts
@@ -17,6 +17,7 @@ export const MOCK_USER = {
       __typename: 'CryptoWallet' as any,
       id: 'crypto-wallet-0000',
       address: '0x0x0x0x0x0x0x0x0x0x0x',
+      hasNFTs: true,
       nfts: [
         {
           __typename: 'NFTAsset' as any,
@@ -179,6 +180,7 @@ export const MOCK_CRYPTO_WALLET = {
   __typename: 'CryptoWallet' as any,
   id: 'crypto-wallet-0000',
   address: '0x0x0x0x0x0x0x0x0x0x0x',
+  hasNFTs: false,
   nfts: [
     {
       __typename: 'NFTAsset' as any,


### PR DESCRIPTION
the new `hasNFTs` boolean is cached, can serve high calling rate
should replace all occurrence of `nfts.length > 0` check

revert #2352