### PR TITLE
chore(deps): update node version to 12.22

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,7 @@ on:
       - master
       - develop
       - stage
-    types: [ closed ]
+    types: [closed]
 
 env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2.5.0
         with:
-          node-version: '12.16'
+          node-version: '12.22'
 
       - name: Cache Dependencies
         id: cache

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2.5.0
         with:
-          node-version: '12.16'
+          node-version: '12.22'
 
       - name: Cache Dependencies
         id: cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2.5.0
         with:
-          node-version: '12.16'
+          node-version: '12.22'
 
       - name: Cache Dependencies
         id: cache


### PR DESCRIPTION
> The minimum Node.js version has been bumped from 12.0.0 to 12.22.0, which is the first version of Node.js with native ES modules support.
>
> https://nextjs.org/blog/next-12