### PR TITLE
fix/duplicate-tos: show the translations only when lang is not 'en'

### DIFF
--- a/src/components/Term/index.tsx
+++ b/src/components/Term/index.tsx
@@ -15,14 +15,14 @@ export const Term = () => {
 
   return (
     <section className="term">
-      <section
+      {lang ?.startsWith('zh') && <section
         dangerouslySetInnerHTML={{
           __html: translate({
             ...ToS,
             lang,
           }),
         }}
-      />
+      />}
 
       <section
         dangerouslySetInnerHTML={{
@@ -33,14 +33,14 @@ export const Term = () => {
         }}
       />
 
-      <section
+      {lang ?.startsWith('zh') && <section
         dangerouslySetInnerHTML={{
           __html: translate({
             ...Privacy,
             lang,
           }),
         }}
-      />
+      />}
 
       <section
         dangerouslySetInnerHTML={{


### PR DESCRIPTION
the 'en' terms & privacy are always shown.

resolves #2376
TOS shows duplicate of terms and privacy policy, under English environment