### PR TITLE
fix(unicode-regex): move the unicode non-alpha-num to separate pre-co…

### DIFF
--- a/src/common/utils/text.ts
+++ b/src/common/utils/text.ts
@@ -12,12 +12,14 @@ export const stripHtml = (html: string | null, replacement = ' ') =>
     .replace(/&lt;/g, '<')
     .replace(/&gt;/g, '>')
 
+const nonAlphaNumUni = String.raw`[^\p{Letter}\p{Number}]+`
+const prefixOrSuffixNonAlphaNum = new RegExp(
+  `(^${nonAlphaNumUni}|${nonAlphaNumUni}$)`,
+  'gu'
+)
+
 export const stripPunctPrefixSuffix = (content: string) =>
-  `${content}`
-    .trim() // strip white space in both ends
-    .replace(/^[^\p{Letter}\p{Number}]+/gu, '') // strip prefix punctuation
-    .replace(/[^\p{Letter}\p{Number}]+$/gu, '') // strip suffix punctuation
-    .trim() // strip white space again
+  `${content}`.replace(prefixOrSuffixNonAlphaNum, '') // strip prefix or suffix punct
 
 export const makeSummary = (html: string, length = 140) => {
   // buffer for search


### PR DESCRIPTION
…mpiled regex

merged into #2451

there's an issue in deep dependencies of babel calls `regexpu`
to transpile unicode regex to ES5, but it has a bug causing

    TypeError: symbol.charCodeAt is not a function

https://github.com/mathiasbynens/regexpu-core/issues/13 unicodePropertyEscape: error when enclosed in square brackets #13

Luckily, it has known limitation,
https://github.com/mathiasbynens/regexpu#known-limitations
1. regexpu only transpiles regular expression literals, so things like RegExp('…', 'u') are not affected.

So here we can switch to pre-compiled regex with new constructor to avoid this issue; (and some performance gain)