### PR TITLE
remove/querystring: npm uninstall querystring

### DIFF
--- a/src/common/utils/route.ts
+++ b/src/common/utils/route.ts
@@ -1,6 +1,6 @@
 import Router from 'next/router'
 import { Key, pathToRegexp } from 'path-to-regexp'
-import queryString from 'query-string'
+// import queryString from 'query-string'
 
 import { PATHS, ROUTES } from '~/common/enums'
 
@@ -180,9 +180,8 @@ export const toPath = (args: ToPathArgs): { href: string } => {
 }
 
 export const getTarget = (url?: string) => {
-  url = url || window.location.href
-  const qs = queryString.parseUrl(url).query
-  const target = encodeURIComponent((qs.target as string) || '')
+  const qs = new URL(url || window.location.href).searchParams
+  const target = encodeURIComponent((qs.get('target') as string) || '')
 
   return target
 }
@@ -308,7 +307,7 @@ export const captureClicks = (e: React.MouseEvent<HTMLElement, MouseEvent>) => {
     const result = regexp.exec(url.pathname)
 
     if (result) {
-      const searchQuery = queryString.parse(url.search) || {}
+      const searchQuery = new URLSearchParams(url.search) || {}
       const matchedQuery: { [key: string]: string } = {}
       keys.forEach((k, i) => (matchedQuery[k.name] = result[i + 1]))
 

--- a/src/components/Share/Buttons/Douban.tsx
+++ b/src/components/Share/Buttons/Douban.tsx
@@ -1,4 +1,4 @@
-import queryString from 'query-string'
+// import queryString from 'query-string'
 
 import { TextIcon, Translate, withIcon } from '~/components'
 
@@ -21,14 +21,14 @@ const Douban = ({
     onClick={() => {
       const description = dom
         .$('meta[name="description"]')
-        ?.getAttribute('content')
-      const shareUrl =
-        'http://www.douban.com/share/service?' +
-        queryString.stringify({
+        ?.getAttribute('content') as string
+      const shareUrl = `http://www.douban.com/share/service?${new URLSearchParams(
+        {
           href: link,
           name: title,
           text: description,
-        })
+        }
+      ).toString()}`
       analytics.trackEvent('share', {
         type: 'douban',
       })

--- a/src/components/Share/Buttons/Email.tsx
+++ b/src/components/Share/Buttons/Email.tsx
@@ -1,4 +1,4 @@
-import queryString from 'query-string'
+// import queryString from 'query-string'
 
 import { TextIcon, Translate, withIcon } from '~/components'
 
@@ -22,12 +22,10 @@ const Email = ({
       const description = dom
         .$('meta[name="description"]')
         ?.getAttribute('content')
-      const shareUrl =
-        'mailto:?' +
-        queryString.stringify({
-          subject: title,
-          body: `${description}\n\n${link}`,
-        })
+      const shareUrl = `mailto:?${new URLSearchParams({
+        subject: title,
+        body: `${description}\n\n${link}`,
+      }).toString()}`
       analytics.trackEvent('share', {
         type: 'email',
       })

--- a/src/components/Share/Buttons/Facebook.tsx
+++ b/src/components/Share/Buttons/Facebook.tsx
@@ -1,4 +1,4 @@
-import queryString from 'query-string'
+// import queryString from 'query-string'
 
 import { TextIcon, withIcon } from '~/components'
 
@@ -19,11 +19,11 @@ const Facebook = ({
   <button
     type="button"
     onClick={() => {
-      const shareUrl =
-        'https://www.facebook.com/sharer/sharer.php?' +
-        queryString.stringify({
+      const shareUrl = `https://www.facebook.com/sharer/sharer.php?${new URLSearchParams(
+        {
           u: link,
-        })
+        }
+      ).toString()}`
       analytics.trackEvent('share', {
         type: 'facebook',
       })

--- a/src/components/Share/Buttons/LINE.tsx
+++ b/src/components/Share/Buttons/LINE.tsx
@@ -1,4 +1,4 @@
-import queryString from 'query-string'
+// import queryString from 'query-string'
 
 import { TextIcon, withIcon } from '~/components'
 
@@ -19,12 +19,12 @@ const LINE = ({
   <button
     type="button"
     onClick={() => {
-      const shareUrl =
-        'https://social-plugins.line.me/lineit/share?' +
-        queryString.stringify({
+      const shareUrl = `https://social-plugins.line.me/lineit/share?${new URLSearchParams(
+        {
           url: link,
           text: title,
-        })
+        }
+      ).toString()}`
 
       analytics.trackEvent('share', {
         type: 'line',

--- a/src/components/Share/Buttons/Telegram.tsx
+++ b/src/components/Share/Buttons/Telegram.tsx
@@ -1,4 +1,4 @@
-import queryString from 'query-string'
+// import queryString from 'query-string'
 
 import { TextIcon, withIcon } from '~/components'
 
@@ -19,12 +19,10 @@ const Telegram = ({
   <button
     type="button"
     onClick={() => {
-      const shareUrl =
-        'https://telegram.me/share?' +
-        queryString.stringify({
-          url: link,
-          text: title,
-        })
+      const shareUrl = `https://telegram.me/share?${new URLSearchParams({
+        url: link,
+        text: title,
+      }).toString()}`
       analytics.trackEvent('share', {
         type: 'telegram',
       })

--- a/src/components/Share/Buttons/Twitter.tsx
+++ b/src/components/Share/Buttons/Twitter.tsx
@@ -21,35 +21,35 @@ const Twitter = ({
   <button
     type="button"
     onClick={() => {
-      const u = new URL('https://twitter.com/intent/tweet')
-      let text = `${title}`
-      if (Array.isArray(tags)) {
-        // u.searchParams.set('hashtags', tags.map((w) => w.trim()).join(','))
-        text += ` ${tags
-          .join(' ')
-          .trim()
-          .split(/\s+/)
-          .filter(Boolean)
-          .slice(0, 8) // at most 8 keywords be used as hashtags
-          .map((w) => `#${w.trim()}`)
-          .join(' ')}`
-      }
-      text += ' via @matterslab'
-      u.searchParams.set('text', text)
-
-      // u.searchParams.set('via', 'matterslab')
-      u.searchParams.set(
-        'related',
-        'matterslab:MattersNews 中文,Mattersw3b:Matters Lab'
-      )
+      const text = `${title}${
+        Array.isArray(tags)
+          ? ` ${tags
+              .join(' ')
+              .trim()
+              .split(/\s+/)
+              .filter(Boolean)
+              .slice(0, 8) // at most 8 keywords be used as hashtags
+              .map((w) => `#${w.trim()}`)
+              .join(' ')}`
+          : ''
+      } via @matterslab`
 
       // only this way (to omit `via`,`hashtags`) can leave url link at the end, then hidden by default
-      u.searchParams.set('url', stripNonEnglishUrl(link))
+      // u.searchParams.set('url', stripNonEnglishUrl(link))
+
+      const shareUrl = `https://twitter.com/intent/tweet?${new URLSearchParams({
+        text,
+        // u.searchParams.set('hashtags', tags.map((w) => w.trim()).join(','))
+        // u.searchParams.set('via', 'matterslab')
+        related: 'matterslab:MattersNews 中文,Mattersw3b:Matters Lab',
+        url: stripNonEnglishUrl(link),
+      }).toString()}`
 
       analytics.trackEvent('share', {
         type: 'twitter',
       })
-      return window.open(u.href, 'Share to Twitter')
+
+      return window.open(shareUrl, 'Share to Twitter')
     }}
   >
     {circle && withIcon(IconShareTwitterCircle)({ size: 'xl-m' })}

--- a/src/components/Share/Buttons/Weibo.tsx
+++ b/src/components/Share/Buttons/Weibo.tsx
@@ -1,4 +1,4 @@
-import queryString from 'query-string'
+// import queryString from 'query-string'
 
 import { TextIcon, Translate, withIcon } from '~/components'
 
@@ -19,14 +19,16 @@ const Weibo = ({
   <button
     type="button"
     onClick={() => {
-      const cover = dom.$('meta[property="og:image"]')?.getAttribute('content')
-      const shareUrl =
-        'http://service.weibo.com/share/share.php?' +
-        queryString.stringify({
+      const cover = dom
+        .$('meta[property="og:image"]')
+        ?.getAttribute('content') as string
+      const shareUrl = `http://service.weibo.com/share/share.php?${new URLSearchParams(
+        {
           url: link,
           title,
           pic: cover,
-        })
+        }
+      ).toString()}`
       return window.open(shareUrl, '分享到微博')
     }}
   >

--- a/src/components/Share/Buttons/WhatsApp.tsx
+++ b/src/components/Share/Buttons/WhatsApp.tsx
@@ -1,4 +1,4 @@
-import queryString from 'query-string'
+// import queryString from 'query-string'
 
 import { TextIcon, withIcon } from '~/components'
 
@@ -19,11 +19,9 @@ const Whatsapp = ({
   <button
     type="button"
     onClick={() => {
-      const shareUrl =
-        'https://api.whatsapp.com/send?' +
-        queryString.stringify({
-          text: title ? title + ' ' + link : link,
-        })
+      const shareUrl = `https://api.whatsapp.com/send?${new URLSearchParams({
+        text: title ? title + ' ' + link : link,
+      }).toString()}`
 
       analytics.trackEvent('share', {
         type: 'whatsapp',

--- a/src/views/OAuth/Authorize/index.tsx
+++ b/src/views/OAuth/Authorize/index.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from '@apollo/react-hooks'
 import gql from 'graphql-tag'
 import Link from 'next/link'
-import queryString from 'query-string'
+// import queryString from 'query-string'
 import { useContext } from 'react'
 
 import {
@@ -39,12 +39,10 @@ const OAUTH_CLIENT_INFO = gql`
 `
 
 const BaseOAuthAuthorize = () => {
-  const { getQuery, router } = useRoute()
+  const { getQuery } = useRoute()
   const viewer = useContext(ViewerContext)
   const { lang } = useContext(LanguageContext)
-  const actionUrl = `${OAUTH_AUTHORIZE_ENDPOINT}?${queryString.stringify(
-    router.query
-  )}`
+  const actionUrl = `${OAUTH_AUTHORIZE_ENDPOINT}${window.location.search}`
   const clientId = getQuery('client_id')
   const state = getQuery('state')
   const requestScopes = getQuery('scope')


### PR DESCRIPTION
all use web builtin APIs (URL / URLSearchParams) instead

