### PR TITLE
Make the size of manage button adaptive

### DIFF
--- a/src/views/TagDetail/Community/Maintainers/index.tsx
+++ b/src/views/TagDetail/Community/Maintainers/index.tsx
@@ -27,7 +27,7 @@ const ManageButton = () => {
     <TagEditorDialog>
       {({ openDialog }) => (
         <Button
-          size={['4rem', '1.5rem']}
+          spacing={['xtight', 'xtight']}
           textColor="green"
           textActiveColor="white"
           bgActiveColor="green"


### PR DESCRIPTION
Fix this bug https://github.com/thematters/matters-web/issues/2498.

With this change, now the button look consistent.
<img width="706" alt="image" src="https://user-images.githubusercontent.com/705652/169698403-9b13fb30-aed6-4028-bddb-1f40485d721c.png">
