### PR TITLE
fix(comment-url): hold fragment if there's any

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",
     "prepare": "husky install",
-    "vercel-build": "set -xe; npm run gen:type && if [[ \"$NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF\" =~ release/* ]] ; then cp -va .env.prod .env ; echo 'NEXT_PUBLIC_SITE_DOMAIN=web-next.matters.news' | tee -a .env.local; else cp -va .env.dev .env ; echo 'NEXT_PUBLIC_SITE_DOMAIN=web-dev.matters.news' | tee -a .env.local ; fi && npm run build"
+    "vercel-build": "set -xe; if [[ \"$NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF\" =~ release/* ]] ; then cp -va .env.prod .env ; echo 'NEXT_PUBLIC_SITE_DOMAIN=web-next.matters.news' | tee -a .env.local; else cp -va .env.dev .env ; echo 'NEXT_PUBLIC_SITE_DOMAIN=web-dev.matters.news' | tee -a .env.local ; fi && npm run gen:type && npm run build"
   },
   "dependencies": {
     "@apollo/react-common": "^3.1.3",

--- a/src/common/utils/analytics.ts
+++ b/src/common/utils/analytics.ts
@@ -247,3 +247,14 @@ type PageType =
   | 'user_profile'
   | 'circle_detail'
   | 'edit_draft'
+
+export interface UtmParams {
+  utm_source?: string // required in most cases
+  utm_medium?: string // required in most cases
+  utm_campaign?: string // all others are really optional
+  utm_content?: string
+  utm_term?: string
+  utm_id?: string
+}
+
+export type UtmParam = keyof UtmParams

--- a/src/common/utils/route.ts
+++ b/src/common/utils/route.ts
@@ -4,6 +4,7 @@ import { Key, pathToRegexp } from 'path-to-regexp'
 
 import { PATHS, ROUTES } from '~/common/enums'
 
+import { UtmParams } from './analytics'
 import { fromGlobalId } from './globalId'
 import { parseURL } from './url'
 
@@ -28,11 +29,12 @@ interface CommentArgs {
 }
 
 type ToPathArgs =
-  | {
+  | ({
       page: 'articleDetail'
       article: ArticleArgs
       fragment?: string
-    }
+      // [UtmParam]?: string
+    } & UtmParams)
   | {
       page:
         | 'circleDetail'
@@ -70,7 +72,15 @@ type ToPathArgs =
  *
  * (works on SSR & CSR)
  */
-export const toPath = (args: ToPathArgs): { href: string } => {
+export const toPath = (
+  args: ToPathArgs
+): {
+  href: string
+  pathname?: string
+  // search?: string
+  // searchParams?: URLSearchParams | null
+  // hash?: string
+} => {
   switch (args.page) {
     case 'articleDetail': {
       const {
@@ -80,18 +90,37 @@ export const toPath = (args: ToPathArgs): { href: string } => {
         author: { userName },
       } = args.article
 
-      let asUrl = `/@${userName}/${slug}-${mediaHash}`
+      let pathname = `/@${userName}/${slug}-${mediaHash}`
       try {
         if (id) {
           const { id: articleId } = fromGlobalId(id as string)
-          asUrl = `/@${userName}/${articleId}-${slug}-${mediaHash}`
+          pathname = `/@${userName}/${articleId}-${slug}-${mediaHash}`
         }
       } catch (err) {
         console.error(`unable to parse global id:`, { id }, err)
       }
 
+      let search = ''
+      let searchParams: URLSearchParams | null = null
+      const { utm_source, utm_medium } = args
+      if ([utm_source, utm_medium].some(Boolean)) {
+        searchParams = new URLSearchParams(
+          [
+            ['utm_source', utm_source as string],
+            ['utm_medium', utm_medium as string],
+          ].filter(([k, v]) => !!v)
+        )
+        search = '?' + searchParams.toString()
+      }
+
+      const hash = args.fragment ? `#${args.fragment}` : ''
+
       return {
-        href: args.fragment ? `${asUrl}#${args.fragment}` : asUrl,
+        href: `${pathname}${search}${hash}`,
+        pathname,
+        // search,
+        // searchParams,
+        // hash,
       }
     }
     case 'circleDetail': {

--- a/src/components/ArticleDigest/Feed/index.tsx
+++ b/src/components/ArticleDigest/Feed/index.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { Card, CircleDigest, ResponsiveImage } from '~/components'
 import { UserDigest } from '~/components/UserDigest'
 
-import { stripHtml, toPath } from '~/common/utils'
+import { stripHtml, toPath, UtmParams } from '~/common/utils'
 
 import { ArticleDigestTitle } from '../Title'
 import FollowButton from './FollowButton'
@@ -26,7 +26,8 @@ export type ArticleDigestFeedProps = {
     Partial<ArticleDigestFeedArticlePrivate>
   header?: React.ReactNode
 } & ArticleDigestFeedControls &
-  FooterActionsProps
+  FooterActionsProps &
+  UtmParams
 
 const BaseArticleDigestFeed = ({
   article,
@@ -37,6 +38,9 @@ const BaseArticleDigestFeed = ({
   hasCircle = true,
   onClick,
   onClickAuthor,
+
+  utm_source,
+  utm_medium,
 
   ...controls
 }: ArticleDigestFeedProps) => {
@@ -51,6 +55,8 @@ const BaseArticleDigestFeed = ({
   const path = toPath({
     page: 'articleDetail',
     article,
+    utm_source,
+    utm_medium,
   })
 
   return (

--- a/src/components/ArticleDigest/Title/index.tsx
+++ b/src/components/ArticleDigest/Title/index.tsx
@@ -3,7 +3,7 @@ import gql from 'graphql-tag'
 
 import { LinkWrapper, LinkWrapperProps, Translate } from '~/components'
 
-import { toPath } from '~/common/utils'
+import { toPath, UtmParams } from '~/common/utils'
 
 import styles from './styles.css'
 
@@ -29,7 +29,8 @@ type ArticleDigestTitleProps = {
 
   disabled?: boolean
   onClick?: () => void
-} & Pick<LinkWrapperProps, 'onClick'>
+} & Pick<LinkWrapperProps, 'onClick'> &
+  UtmParams
 
 const fragments = {
   article: gql`
@@ -58,12 +59,17 @@ export const ArticleDigestTitle = ({
   disabled,
   onClick,
 
+  utm_source,
+  utm_medium,
+
   ...restProps
 }: ArticleDigestTitleProps) => {
   const { articleState: state } = article
   const path = toPath({
     page: 'articleDetail',
     article,
+    utm_source,
+    utm_medium,
   })
   const isBanned = state === 'banned'
   const title = isBanned ? <Translate id="articleBanned" /> : article.title

--- a/src/components/ClientUpdater/index.tsx
+++ b/src/components/ClientUpdater/index.tsx
@@ -47,13 +47,19 @@ export const ClientUpdater = () => {
    * Update routeHistory
    */
   const routeHistoryRef = useRef<string[]>([])
-  const routeChangeComplete = (url: string) => {
-    if (!client?.writeData) {
+  const routeChangeComplete = (
+    url: string,
+    { shallow }: { shallow: boolean }
+  ) => {
+    if (!client?.writeData || shallow) {
+      // skip shallow route change
       return
     }
 
     const newRouteHistory = [...routeHistoryRef.current, url]
     routeHistoryRef.current = newRouteHistory
+
+    console.log('update routeHistory to:', { url, newRouteHistory })
 
     client.writeData({
       id: 'ClientPreference:local',

--- a/src/components/Layout/Header/BackButton/index.tsx
+++ b/src/components/Layout/Header/BackButton/index.tsx
@@ -43,6 +43,8 @@ export const BackButton: React.FC<BackButtonProps> = ({
 
     const routeHistory = data?.clientPreference.routeHistory || []
 
+    console.log('onBack:', { routeHistory })
+
     if (routeHistory.length > 0) {
       router.back()
     } else {

--- a/src/views/ArticleDetail/index.tsx
+++ b/src/views/ArticleDetail/index.tsx
@@ -200,8 +200,32 @@ const ArticleDetail = () => {
       },
     })
 
-    if (newPath.href !== router.asPath) {
-      router.push(newPath.href, undefined, { shallow: true })
+    // parse current URL: router.asPath
+    const u = new URL(
+      `https://${process.env.NEXT_PUBLIC_SITE_DOMAIN}${router.asPath}`
+    )
+    const n = new URL(
+      `https://${process.env.NEXT_PUBLIC_SITE_DOMAIN}${
+        newPath.href || newPath.pathname
+      }`
+    )
+    // hide all utm_ tracking code parameters
+    // copy all others
+    const rems = [
+      ...u.searchParams, // uses .entries()
+      ...n.searchParams,
+    ].filter(([k, v]) => !k?.startsWith('utm_'))
+    const nsearch = rems.length > 0 ? `?${new URLSearchParams(rems)}` : ''
+    const nhref = `${n.pathname}${nsearch}${n.hash || u.hash}`
+
+    if (nhref !== router.asPath) {
+      console.log('replacing url:', {
+        from: router.asPath,
+        to: newPath.href,
+        nhref,
+        isSame: nhref === router.asPath,
+      })
+      router.replace(nhref, undefined, { shallow: true })
     }
   }, [latestHash])
 

--- a/src/views/Home/Feed/MainFeed/index.tsx
+++ b/src/views/Home/Feed/MainFeed/index.tsx
@@ -209,6 +209,7 @@ const MainFeed = ({ feedSortType: sortBy }: MainFeedProps) => {
             <List.Item key={`${sortBy}:${edge.node.id}`}>
               <ArticleDigestFeed
                 article={edge.node}
+                utm_source="homepage"
                 onClick={() =>
                   analytics.trackEvent('click_feed', {
                     type: sortBy,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "allowJs": false,
     "allowSyntheticDefaultImports": true,
     "jsx": "preserve",
-    "lib": ["dom", "es2017"],
+    "lib": ["dom", "dom.iterable", "es2019"],
     "module": "esnext",
     "moduleResolution": "node",
     "noEmit": true,


### PR DESCRIPTION
1. for comment url https://web-next.matters.news/p/30000#comments
2. for particular comment url https://web-next.matters.news/@smog_again/30000#Q29tbWVudDoyNzg5Njc-Q29tbWVudDoyNzkwMDY
3. for article owner's `?mode=edit` to enter edit mode

also add utm tracking code, for better computing links source&destination before or after visiting a link

should also resolve https://github.com/thematters/matters-web/issues/2587