### PR TITLE
feat(track-exp): add delay_msecs to track delays of exposure events

### DIFF
--- a/src/common/utils/analytics.ts
+++ b/src/common/utils/analytics.ts
@@ -144,11 +144,13 @@ interface CardExposureProp {
   feedType: FeedType
   contentType: ContentType | ActivityType
   location: number | string
+  delay_msecs?: number
 }
 
 interface TagExposureProp {
   id: string
   location: number | string
+  delay_msecs?: number
 }
 
 // content type

--- a/src/components/Analytics/CardExposureTracker/index.tsx
+++ b/src/components/Analytics/CardExposureTracker/index.tsx
@@ -35,6 +35,7 @@ export const CardExposureTracker = ({
               contentType,
               location,
               id,
+              delay_msecs: window?.performance.now() ?? -1,
             })
             setRecorded(true)
           }, 500)

--- a/src/components/Analytics/TagExposureTracker/index.tsx
+++ b/src/components/Analytics/TagExposureTracker/index.tsx
@@ -29,6 +29,9 @@ export const TagExposureTracker = ({
             analytics.trackEvent('tag_exposure', {
               location,
               id,
+
+              // performance.now() = Date.now() - performance.timing.navigationStart
+              delay_msecs: window?.performance.now() ?? -1,
             })
             setRecorded(true)
           }, 500)


### PR DESCRIPTION
for both CardExposure and TagExposure