### PR TITLE
fix(relate-tags): send with trackRelatedTags instead

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "matters-web",
-  "version": "4.3.7",
+  "version": "4.3.8",
   "description": "codebase of Matters' website",
   "sideEffects": false,
   "author": "Matters <hi@matters.news>",
   "engines": {
-    "node": "16.14"
+    "node": ">=16.14"
   },
   "license": "Apache-2.0",
   "scripts": {
@@ -32,7 +32,7 @@
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",
     "prepare": "husky install",
-    "vercel-build": "set -xe; npm run gen:type && if [[ \"$NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF\" =~ release/* ]] ; then cp -va .env.prod .env.local ; echo 'NEXT_PUBLIC_SITE_DOMAIN=web-next.matters.news' | tee -a .env.local; else cp -va .env.dev .env.local ; echo 'NEXT_PUBLIC_SITE_DOMAIN=web-dev.matters.news' | tee -a .env.local ; fi && echo 'NEXT_PUBLIC_NEXT_ASSET_DOMAIN=' | tee -a .env.local && npm run build"
+    "vercel-build": "set -xe; if [[ \"$NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF\" =~ release/* ]] ; then npm run gen:type:prod; cp -va .env.prod .env ; echo 'NEXT_PUBLIC_SITE_DOMAIN=web-next.matters.news' | tee -a .env.local; else npm run gen:type; cp -va .env.dev .env ; echo 'NEXT_PUBLIC_SITE_DOMAIN=web-dev.matters.news' | tee -a .env.local ; fi && npm run build"
   },
   "dependencies": {
     "@apollo/react-common": "^3.1.3",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",
     "prepare": "husky install",
-    "vercel-build": "set -xe; if [[ \"$NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF\" =~ release/* ]] ; then npm run gen:type:prod; cp -va .env.prod .env ; echo 'NEXT_PUBLIC_SITE_DOMAIN=web-next.matters.news' | tee -a .env.local; else npm run gen:type; cp -va .env.dev .env ; echo 'NEXT_PUBLIC_SITE_DOMAIN=web-dev.matters.news' | tee -a .env.local ; fi && npm run build"
+    "vercel-build": "set -xe; if [[ \"$NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF\" =~ release/* ]] ; then npm run gen:type:prod; cp -va .env.prod .env ; echo -e 'NEXT_PUBLIC_SITE_DOMAIN=web-next.matters.news\nNEXT_PUBLIC_NEXT_ASSET_DOMAIN=web-next.matters.news' | tee -a .env.local; else npm run gen:type; cp -va .env.dev .env ; echo 'NEXT_PUBLIC_SITE_DOMAIN=web-dev.matters.news' | tee -a .env.local ; fi && npm run build"
   },
   "dependencies": {
     "@apollo/react-common": "^3.1.3",

--- a/src/common/utils/resolvers/gatewayUrls.ts
+++ b/src/common/utils/resolvers/gatewayUrls.ts
@@ -78,7 +78,7 @@ const gatewayUrlsResolver = async () => {
   const gatwayUrls = checkers.filter(({ alive }) => alive).map(({ url }) => url)
 
   // meson network use 302 redirect, so we have to push it in mannually
-  gatwayUrls.unshift('https://matters-meson.net/api/cdn/10vbg9/ipfs/:hash')
+  gatwayUrls.unshift('https://pz-matters.meson.network/ipfs/:hash')
 
   return gatwayUrls
 }

--- a/src/components/Head/index.tsx
+++ b/src/components/Head/index.tsx
@@ -11,7 +11,13 @@ import IMAGE_FAVICON_32 from '@/public/static/favicon-32x32.png'
 import IMAGE_FAVICON_64 from '@/public/static/favicon-64x64.png'
 import IMAGE_INTRO from '@/public/static/images/intro.jpg'
 
-const isProd = process.env.NEXT_PUBLIC_RUNTIME_ENV === 'production'
+const siteDomain =
+  process.env.NEXT_PUBLIC_SITE_DOMAIN_CANONICAL || // for web-next, set this different as serving domain; suggested canonical domain ('matters.news') to robots
+  process.env.NEXT_PUBLIC_SITE_DOMAIN ||
+  'matters.news'
+const isProdServingCanonical =
+  process.env.NEXT_PUBLIC_RUNTIME_ENV === 'production' &&
+  process.env.NEXT_PUBLIC_SITE_DOMAIN === 'matters.news' // is serving domain same as canonical domain?
 
 interface HeadProps {
   title?: string | TranslateArgs
@@ -41,10 +47,8 @@ export const Head: React.FC<HeadProps> = (props) => {
       ? `${props.keywords.join(',')},matters,matters.news,創作有價`
       : 'matters,matters.news,創作有價',
     url: props.path
-      ? `https://${process.env.NEXT_PUBLIC_SITE_DOMAIN}${props.path}`
-      : router.asPath
-      ? `https://${process.env.NEXT_PUBLIC_SITE_DOMAIN}${router.asPath}`
-      : 'https://' + process.env.NEXT_PUBLIC_SITE_DOMAIN,
+      ? `https://${siteDomain}${props.path}`
+      : `https://${siteDomain}${router.asPath || '/'}`,
     image: props.image || IMAGE_INTRO.src,
   }
   const canonicalUrl = head.url?.split('#')[0].split('?')[0]
@@ -94,10 +98,10 @@ export const Head: React.FC<HeadProps> = (props) => {
       )}
 
       {/* noindex for non-production enviroment */}
-      {!isProd && (
+      {!isProdServingCanonical && (
         <meta name="robots" content="noindex, nofollow" key="robots" />
       )}
-      {!isProd && (
+      {!isProdServingCanonical && (
         <meta name="googlebot" content="noindex, nofollow" key="googlebot" />
       )}
 

--- a/src/views/TagDetail/RelatedTags/index.tsx
+++ b/src/views/TagDetail/RelatedTags/index.tsx
@@ -11,7 +11,6 @@ import {
   // LanguageContext,
   List,
   PageHeader,
-  // TextIcon,
   Slides,
   TagDigest,
   Translate,
@@ -61,9 +60,7 @@ const RelatedTags: React.FC<RelatedTagsProps> = ({ tagId, inSidebar }) => {
   const { edges } =
     (data?.node?.__typename === 'Tag' && data.node.recommended) || {}
 
-  // const { lang } = useContext(LanguageContext)
-
-  const onClick = (i: number, id: string) => () =>
+  const trackRelatedTags = (i: number, id: string) =>
     analytics.trackEvent('click_feed', {
       type: 'related_tags',
       contentType: 'tag',
@@ -92,7 +89,10 @@ const RelatedTags: React.FC<RelatedTagsProps> = ({ tagId, inSidebar }) => {
                     key={cursor}
                     tag={node}
                     onClick={() =>
-                      onClick((edgeIndex + 1) * (nodeIndex + 1) - 1, node.id)
+                      trackRelatedTags(
+                        (edgeIndex + 1) * (nodeIndex + 1) - 1,
+                        node.id
+                      )
                     }
                   />
                 ))}
@@ -122,7 +122,10 @@ const RelatedTags: React.FC<RelatedTagsProps> = ({ tagId, inSidebar }) => {
       <List hasBorder={false}>
         {edges?.map(({ node, cursor }, i) => (
           <List.Item key={cursor}>
-            <TagDigest.Sidebar tag={node} onClick={() => onClick(i, node.id)} />
+            <TagDigest.Sidebar
+              tag={node}
+              onClick={() => trackRelatedTags(i, node.id)}
+            />
           </List.Item>
         ))}
       </List>


### PR DESCRIPTION
* dbc561967 (HEAD) feat(web-next): turn noindex to bots for web-next
* 4393e5eda (origin/release/4.3.8, local) Update Meson gateway with new API
* 9690210cc (origin/release/relate-tags-) fix(relate-tags): send with trackRelatedTags instead

- fix with the function call, from previous problem was a meta function not calling
- and, avoid the confusing onClick meta function naming