### PR TITLE
use global npm cache instead of node_modules cache

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,15 +27,7 @@ jobs:
           node-version: '16.14'
           cache: 'npm'
 
-      - name: Cache NPM dependencies
-        uses: actions/cache@v3
-        id: node_modules_cache
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-npm-v3-${{ hashFiles('package-lock.json') }}
-
       - name: Install Dependencies
-        if: steps.node_modules_cache.outputs.cache-hit != 'true'
         run: npm ci --legacy-peer-deps
 
       - name: Generate Types (develop)

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -22,15 +22,7 @@ jobs:
           node-version: '16.14'
           cache: 'npm'
 
-      - name: Cache NPM dependencies
-        uses: actions/cache@v3
-        id: node_modules_cache
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-npm-v3-${{ hashFiles('package-lock.json') }}
-
       - name: Install Dependencies
-        if: steps.node_modules_cache.outputs.cache-hit != 'true'
         run: npm ci --legacy-peer-deps
 
       - name: Generate Types

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -15,15 +15,7 @@ jobs:
           node-version: '16.14'
           cache: 'npm'
 
-      - name: Cache NPM dependencies
-        uses: actions/cache@v3
-        id: node_modules_cache
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-npm-v3-${{ hashFiles('package-lock.json') }}
-
       - name: Install Dependencies
-        if: steps.node_modules_cache.outputs.cache-hit != 'true'
         run: npm ci --legacy-peer-deps
 
       - name: Generate Types (Develop)

--- a/.github/workflows/test_e2e.yml
+++ b/.github/workflows/test_e2e.yml
@@ -24,15 +24,7 @@ jobs:
           node-version: '16.14'
           cache: 'npm'
 
-      - name: Cache NPM dependencies
-        uses: actions/cache@v3
-        id: node_modules_cache
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-npm-v3-${{ hashFiles('package-lock.json') }}
-
       - name: Install Dependencies
-        if: steps.node_modules_cache.outputs.cache-hit != 'true'
         run: npm ci --legacy-peer-deps
 
       - name: Get installed Playwright version


### PR DESCRIPTION
> The action follows [actions/cache](https://github.com/actions/cache/blob/main/examples.md#node---npm) guidelines, and caches global cache on the machine instead of node_modules, so cache can be reused between different Node.js versions.
>
> https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-data
