### PR TITLE
feat(ci): upload only .next/static to R2

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -8,7 +8,7 @@
 NEXT_PUBLIC_RUNTIME_ENV=development
 NEXT_PUBLIC_SITE_DOMAIN=web-develop.matters.news
 NEXT_PUBLIC_ASSET_DOMAIN=assets-develop.matters.news
-NEXT_PUBLIC_NEXT_ASSET_DOMAIN=pub-2ce0bec75adf43618236ee3385e688fe.r2.dev
+NEXT_PUBLIC_NEXT_ASSET_DOMAIN=assets-next-dev.mattersprotocol.io
 NEXT_PUBLIC_API_URL=https://server-develop.matters.news/graphql
 NEXT_PUBLIC_OAUTH_URL=https://auth-server-develop.matters.news/oauth
 NEXT_PUBLIC_OAUTH_API_URL=https://auth-server-develop.matters.news/graphql

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,12 +77,6 @@ jobs:
           && npm install --production --legacy-peer-deps \
           && zip -r --symlinks deploy.zip . -x .git/\*
 
-      # === `develop` branch ===
-      # - name: Upload Assets (develop)
-      #   if: github.base_ref == 'develop'
-      #   run: |
-      #     aws s3 sync .next s3://web-develop.matters.news/_next
-
       - name: Upload Assets (develop - R2)
         if: github.base_ref == 'develop'
         uses: wei/rclone@v1
@@ -93,7 +87,7 @@ jobs:
           RCLONE_CONFIG_R2_SECRET_ACCESS_KEY: ${{ secrets.RCLONE_CONFIG_R2_SECRET_ACCESS_KEY }}
           RCLONE_CONFIG_R2_ENDPOINT: ${{ secrets.RCLONE_CONFIG_R2_ENDPOINT }}
         with:
-          args: sync .next r2:matters-assets-next-develop/_next -P
+          args: sync .next/static r2:matters-assets-next-develop/_next/static -P
 
       - name: Deploy to EB (develop)
         if: github.base_ref == 'develop'
@@ -110,12 +104,6 @@ jobs:
           use_existing_version_if_available: true
           wait_for_deployment: true
 
-      # === `master` branch ===
-      # - name: Upload Assets (production)
-      #   if: github.base_ref == 'master'
-      #   run: |
-      #     aws s3 sync .next s3://matters.news/_next
-
       - name: Upload Assets (production - R2)
         if: github.base_ref == 'master'
         uses: wei/rclone@v1
@@ -126,7 +114,7 @@ jobs:
           RCLONE_CONFIG_R2_SECRET_ACCESS_KEY: ${{ secrets.RCLONE_CONFIG_R2_SECRET_ACCESS_KEY }}
           RCLONE_CONFIG_R2_ENDPOINT: ${{ secrets.RCLONE_CONFIG_R2_ENDPOINT }}
         with:
-          args: sync .next r2:matters-assets-next/_next -P
+          args: sync .next/static r2:matters-assets-next/_next/static -P
 
       - name: Deploy to EB (production)
         if: github.base_ref == 'master'


### PR DESCRIPTION
> The only folder you need to host on your CDN is the contents of .next/static/, which should be uploaded as _next/static/ as the above URL request indicates. Do not upload the rest of your .next/ folder, as you should not expose your server code and other configuration to the public.
> https://nextjs.org/docs/api-reference/next.config.js/cdn-support-with-asset-prefix