### PR TITLE
fix(i18n): fix <html lang>

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -60,12 +60,6 @@ const nextConfig = {
   reactStrictMode: true,
   compress: false,
   poweredByHeader: false,
-  i18n: {
-    locales: ['zh-Hant', 'zh-Hans', 'en', '__defaultLocale'],
-    // FIXME: Disable Next.js auto detection and prefixing since we have a fallback strategy based on user request and browser perference in `<LanguageContext>`
-    defaultLocale: '__defaultLocale',
-    localeDetection: false,
-  },
 }
 
 const withBundleAnalyzer = require('@next/bundle-analyzer')({

--- a/src/common/enums/lang.ts
+++ b/src/common/enums/lang.ts
@@ -35,5 +35,3 @@ export const CONTENT_LANG_TEXT_MAP = {
     la: 'Latin',
   },
 }
-
-export const DEFAULT_LOCALE = '__defaultLocale'

--- a/src/common/utils/language.ts
+++ b/src/common/utils/language.ts
@@ -25,13 +25,38 @@ export const toLocale = (lang: string) => {
   lang = lang.toLowerCase()
 
   // zh_hans
-  if (['zh-cn', 'zh-hans', 'zh_hans'].indexOf(lang) >= 0) {
+  if (['zh-cn', 'zh_cn', 'zh-hans', 'zh_hans'].indexOf(lang) >= 0) {
     return 'zh-Hans'
   }
 
   // zh_hant
-  if (['zh', 'zh-tw', 'zh-hk', 'zh-hant', 'zh_hant'].indexOf(lang) >= 0) {
+  if (
+    ['zh', 'zh_tw', 'zh-tw', 'zh_hk', 'zh-hk', 'zh-hant', 'zh_hant'].indexOf(
+      lang
+    ) >= 0
+  ) {
     return 'zh-Hant'
+  }
+
+  // en
+  if (['en', 'en-us', 'en-au', 'en-za', 'en-gb'].indexOf(lang) >= 0) {
+    return 'en'
+  }
+
+  return ''
+}
+
+export const toOGLanguage = (lang: string) => {
+  lang = lang.toLowerCase()
+
+  // zh_hans
+  if (['zh-cn', 'zh-hans', 'zh_hans'].indexOf(lang) >= 0) {
+    return 'zh_CN'
+  }
+
+  // zh_hant
+  if (['zh', 'zh-tw', 'zh-hk', 'zh-hant', 'zh_hant'].indexOf(lang) >= 0) {
+    return 'zh_TW'
   }
 
   // en

--- a/src/components/Dialogs/ShareDialog/Content.tsx
+++ b/src/components/Dialogs/ShareDialog/Content.tsx
@@ -1,7 +1,6 @@
 import classNames from 'classnames'
 
 import { TextId } from '~/common/enums'
-import { toLocale } from '~/common/utils'
 import { Dialog, ShareButtons, Translate } from '~/components'
 
 import Copy from './Copy'
@@ -31,9 +30,7 @@ const ShareDialogContent: React.FC<ShareDialogContentProps> = ({
   footerButtons,
 }) => {
   const url = new URL(shareLink)
-  const pathnames = url.pathname.split('/')
-  const showTranslation = toLocale(pathnames[1]) !== ''
-  if (showTranslation) {
+  if (url.searchParams.get('locale')) {
     description = (
       <Translate
         zh_hant="分享這篇文章的翻譯版本"

--- a/src/components/Forms/PaymentForm/AddCredit/index.tsx
+++ b/src/components/Forms/PaymentForm/AddCredit/index.tsx
@@ -34,7 +34,11 @@ import {
   useMutation,
 } from '~/components'
 import WALLET_BALANCE from '~/components/GQL/queries/walletBalance'
-import { AddCreditMutation, WalletBalanceQuery } from '~/gql/graphql'
+import {
+  AddCreditMutation,
+  UserLanguage,
+  WalletBalanceQuery,
+} from '~/gql/graphql'
 
 import ConfirmTable from '../ConfirmTable'
 import StripeCheckout from '../StripeCheckout'
@@ -296,7 +300,7 @@ const AddCreditForm: React.FC<FormProps> = (props) => {
   return (
     <Elements
       stripe={stripePromise}
-      options={{ locale: lang === 'zh_hans' ? 'zh' : 'en' }}
+      options={{ locale: lang === UserLanguage.ZhHans ? 'zh' : 'en' }}
     >
       <BaseAddCredit {...props} />
     </Elements>

--- a/src/components/Forms/PaymentForm/SubscribeCircle/CardPayment.tsx
+++ b/src/components/Forms/PaymentForm/SubscribeCircle/CardPayment.tsx
@@ -22,6 +22,7 @@ import {
   DigestRichCirclePrivateFragment,
   DigestRichCirclePublicFragment,
   SubscribeCircleMutation,
+  UserLanguage,
 } from '~/gql/graphql'
 
 import StripeCheckout from '../StripeCheckout'
@@ -180,7 +181,7 @@ const CardPayment: React.FC<CardPaymentProps> = (props) => {
   return (
     <Elements
       stripe={stripePromise}
-      options={{ locale: lang === 'zh_hans' ? 'zh' : 'en' }}
+      options={{ locale: lang === UserLanguage.ZhHans ? 'zh' : 'en' }}
     >
       <BaseCardPayment {...props} />
     </Elements>

--- a/src/components/Head/index.tsx
+++ b/src/components/Head/index.tsx
@@ -6,7 +6,12 @@ import IMAGE_FAVICON_16 from '@/public/static/favicon-16x16.png'
 import IMAGE_FAVICON_32 from '@/public/static/favicon-32x32.png'
 import IMAGE_FAVICON_64 from '@/public/static/favicon-64x64.png'
 import IMAGE_INTRO from '@/public/static/images/intro.jpg'
-import { toLocale, translate, TranslateArgs } from '~/common/utils'
+import {
+  toLocale,
+  toOGLanguage,
+  translate,
+  TranslateArgs,
+} from '~/common/utils'
 import { LanguageContext, useRoute } from '~/components'
 import { UserLanguage } from '~/gql/graphql'
 
@@ -58,8 +63,8 @@ export const Head: React.FC<HeadProps> = (props) => {
 
   const i18nUrl = (language: string) => {
     return props.path
-      ? `https://${siteDomain}/${language}${props.path}`
-      : `https://${siteDomain}/${language}${router.asPath || '/'}`
+      ? `https://${siteDomain}/${props.path}?locale=${language}`
+      : `https://${siteDomain}/${router.asPath || '/'}?locale=${language}`
   }
 
   if (props.jsonLdData && !props.jsonLdData.description) {
@@ -134,6 +139,7 @@ export const Head: React.FC<HeadProps> = (props) => {
         key="og:description"
         content={head.description}
       />
+      <meta property="og:locale" key="og:locale" content={toOGLanguage(lang)} />
       <meta name="twitter:url" key="twitter:url" content={head.url} />
       <meta
         name="twitter:card"

--- a/src/components/Hook/useRoute.ts
+++ b/src/components/Hook/useRoute.ts
@@ -1,6 +1,8 @@
 import { useRouter } from 'next/router'
 
 import { PATHS } from '~/common/enums'
+import { toUserLanguage } from '~/common/utils'
+import { UserLanguage } from '~/gql/graphql'
 
 /**
  * Utilities for route
@@ -19,6 +21,7 @@ type QueryKey =
   | 'q'
   | 'type'
   | 'provider'
+  | 'locale'
   | string
 
 export const useRoute = () => {
@@ -59,5 +62,17 @@ export const useRoute = () => {
     router.replace({ query })
   }
 
-  return { isInPath, isPathStartWith, getQuery, setQuery, replaceQuery, router }
+  // i18n
+  const locale = getQuery('locale')
+  const routerLang = toUserLanguage(locale) as UserLanguage
+
+  return {
+    isInPath,
+    isPathStartWith,
+    getQuery,
+    setQuery,
+    replaceQuery,
+    router,
+    routerLang,
+  }
 }

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,17 +1,48 @@
-import Document, { Head, Html, Main, NextScript } from 'next/document'
+import _get from 'lodash/get'
+import Document, {
+  DocumentContext,
+  Head,
+  Html,
+  Main,
+  NextScript,
+} from 'next/document'
 import Script from 'next/script'
 import React from 'react'
 
 import { CSP_POLICY } from '~/common/enums'
+import { toLocale } from '~/common/utils'
 
 interface MattersDocumentProps {
   lang: HTMLLanguage
 }
 
 class MattersDocument extends Document<MattersDocumentProps> {
+  public static async getInitialProps(ctx: DocumentContext) {
+    const initialProps = await Document.getInitialProps(ctx)
+    const heads = initialProps.head
+
+    let lang: HTMLLanguage = 'zh-Hant'
+    if (heads) {
+      heads.every((head) => {
+        const property = _get(head, 'props.property')
+        const content = _get(head, 'props.content')
+        if (property === 'og:locale' && content) {
+          lang = toLocale(content) as HTMLLanguage
+          return false
+        }
+        return true
+      })
+    }
+
+    return {
+      lang,
+      ...initialProps,
+    }
+  }
+
   public render() {
     return (
-      <Html>
+      <Html lang={this.props.lang}>
         <Head>
           <meta httpEquiv="Content-Security-Policy" content={CSP_POLICY} />
         </Head>

--- a/src/views/ArticleDetail/Toolbar/index.tsx
+++ b/src/views/ArticleDetail/Toolbar/index.tsx
@@ -76,7 +76,7 @@ const Toolbar = ({
   const path = toPath({ page: 'articleDetail', article })
   const sharePath =
     translated && translatedLanguage
-      ? `/${toLocale(translatedLanguage)}${path.href}`
+      ? `${path.href}?locale=${toLocale(translatedLanguage)}`
       : path.href
 
   const dropdonwActionsProps: DropdownActionsControls = {

--- a/src/views/ArticleDetail/index.tsx
+++ b/src/views/ArticleDetail/index.tsx
@@ -4,13 +4,8 @@ import dynamic from 'next/dynamic'
 import { useContext, useEffect, useState } from 'react'
 import { Waypoint } from 'react-waypoint'
 
-import { ADD_TOAST, DEFAULT_LOCALE, URL_QS } from '~/common/enums'
-import {
-  normalizeTag,
-  toGlobalId,
-  toPath,
-  toUserLanguage,
-} from '~/common/utils'
+import { ADD_TOAST, URL_QS } from '~/common/enums'
+import { normalizeTag, toGlobalId, toPath } from '~/common/utils'
 import {
   BackToHomeButton,
   EmptyLayout,
@@ -120,10 +115,9 @@ const BaseArticleDetail = ({
   article: NonNullable<ArticleDetailPublicQuery['article']>
   privateFetched: boolean
 }) => {
-  const { getQuery, router } = useRoute()
+  const { getQuery, routerLang } = useRoute()
   const mediaHash = getQuery('mediaHash')
   const viewer = useContext(ViewerContext)
-  const locale = router.locale !== DEFAULT_LOCALE ? router.locale : ''
 
   const features = useFeatures()
   const [fixedWall, setFixedWall] = useState(false)
@@ -153,7 +147,7 @@ const BaseArticleDetail = ({
 
   // translation
   const [autoTranslation] = useState(article.translation) // cache initial article data since it will be overwrote by newly's if URL is shadow replaced
-  const [translated, setTranslate] = useState(!!locale)
+  const [translated, setTranslate] = useState(!!routerLang)
   const originalLang = article.language
   const {
     lang: preferredLang,
@@ -215,11 +209,11 @@ const BaseArticleDetail = ({
 
   // set language cookie for anonymous if it doesn't exist
   useEffect(() => {
-    if (cookieLang || viewer.isAuthed || !locale) {
+    if (cookieLang || viewer.isAuthed || !routerLang) {
       return
     }
 
-    setLang(toUserLanguage(locale) as UserLanguage)
+    setLang(routerLang)
   }, [])
 
   const {
@@ -374,12 +368,11 @@ const ArticleDetail = ({
 }: {
   includeTranslation: boolean
 }) => {
-  const { getQuery, router } = useRoute()
+  const { getQuery, router, routerLang } = useRoute()
   const mediaHash = getQuery('mediaHash')
   const articleId =
     (router.query.mediaHash as string)?.match(/^(\d+)/)?.[1] || ''
   const viewer = useContext(ViewerContext)
-  const locale = router.locale !== DEFAULT_LOCALE ? router.locale : ''
 
   /**
    * fetch public data
@@ -395,7 +388,7 @@ const ArticleDetail = ({
     {
       variables: {
         mediaHash,
-        language: locale ? toUserLanguage(locale) : UserLanguage.ZhHant,
+        language: routerLang || UserLanguage.ZhHant,
         includeTranslation,
       },
       skip: !isQueryByHash,
@@ -406,7 +399,7 @@ const ArticleDetail = ({
     {
       variables: {
         id: toGlobalId({ type: 'Article', id: articleId }),
-        language: locale ? toUserLanguage(locale) : UserLanguage.ZhHant,
+        language: routerLang || UserLanguage.ZhHant,
         includeTranslation,
       },
       skip: isQueryByHash,
@@ -489,10 +482,7 @@ const ArticleDetail = ({
     const nsearch = rems.length > 0 ? `?${new URLSearchParams(rems)}` : ''
     const nhref = `${n.pathname}${nsearch}${n.hash || u.hash}`
 
-    if (
-      nhref !== router.asPath ||
-      (router.locale && router.locale !== DEFAULT_LOCALE)
-    ) {
+    if (nhref !== router.asPath || routerLang) {
       router.replace(nhref, undefined, { shallow: true, locale: false })
     }
   }, [latestHash])
@@ -609,11 +599,10 @@ const ArticleDetail = ({
 }
 
 const ArticleDetailOuter = () => {
-  const { getQuery, router } = useRoute()
+  const { getQuery, router, routerLang } = useRoute()
   const mediaHash = getQuery('mediaHash')
   const articleId =
     (router.query.mediaHash as string)?.match(/^(\d+)/)?.[1] || ''
-  const locale = router.locale !== DEFAULT_LOCALE ? router.locale : ''
 
   const isQueryByHash = !!(mediaHash && isMediaHashPossiblyValid(mediaHash))
   const resultByHash = usePublicQuery<ArticleAvailableTranslationsQuery>(
@@ -630,10 +619,8 @@ const ArticleDetailOuter = () => {
   const { data } = resultByHash.data ? resultByHash : resultByNodeId
   const loading = resultByHash.loading || resultByNodeId.loading
   const includeTranslation =
-    !!locale &&
-    (data?.article?.availableTranslations || []).includes(
-      toUserLanguage(locale) as UserLanguage
-    )
+    !!routerLang &&
+    (data?.article?.availableTranslations || []).includes(routerLang)
 
   /**
    * Rendering


### PR DESCRIPTION
* remove next.js i18n config (since it's not support [hiding locale prefix](https://github.com/vercel/next.js/discussions/35497)) and use `?locale` for article translation instead;
  * also changed href of `<link rel="alternate">` from `/{locale}` to [`?locale`](https://github.com/thematters/matters-web/pull/3561/files#diff-9dfc2532305642f988357bc2494e14b80575e0a2992ddbe19d0fa31fda1d2c71R64-R67); 
* fix <html lang> by [reverting changes of `_document.tsx`](https://github.com/thematters/matters-web/pull/2734);
