### PR TITLE
feat(settings): open like.co/in legacy login when clicking likerId

### DIFF
--- a/src/views/Me/Settings/Settings/Wallet/index.tsx
+++ b/src/views/Me/Settings/Settings/Wallet/index.tsx
@@ -57,7 +57,7 @@ const WalletSettings = () => {
           !likerId
             ? () =>
                 window.dispatchEvent(new CustomEvent(OPEN_LIKE_COIN_DIALOG, {}))
-            : undefined
+            : () => window.open('https://like.co/in?legacy=1')
         }
         role="button"
         rightText={likerId || <Translate id="setup" />}


### PR DESCRIPTION
Clicking Liker ID in Settings brings users to like.co Liker ID settings UI
We have also added the qs `legacy=1` which automatically shows legacy login UI with matters login
i.e. https://like.co/in?legacy=1