### PR TITLE
feat(i18n): enable "formatjs/enforce-id" rule

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -11,15 +11,5 @@
         },
       }
     ]
-  ],
-  "plugins": [
-    "@babel/plugin-proposal-optional-chaining",
-    [
-      "formatjs",
-      {
-        "idInterpolationPattern": "[sha512:contenthash:base64:6]",
-        "ast": true
-      }
-    ]
   ]
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,6 +15,12 @@
     "@next/next/no-img-element": "off",
     "formatjs/no-offset": "error",
     "formatjs/enforce-default-message": "error",
-    "formatjs/no-multiple-whitespaces": "error"
+    "formatjs/no-multiple-whitespaces": "error",
+    "formatjs/enforce-id": [
+      "error",
+      {
+        "idInterpolationPattern": "[sha512:contenthash:base64:6]"
+      }
+    ]
   }
 }

--- a/lang/default.json
+++ b/lang/default.json
@@ -190,10 +190,6 @@
   "3yk8fB": {
     "defaultMessage": "Wallet"
   },
-  "3ynsJ3": {
-    "defaultMessage": "Want to know more? Check the",
-    "description": "src/views/Me/Analytics/EmptyAnalytics/index.tsx"
-  },
   "47FYwb": {
     "defaultMessage": "Cancel"
   },
@@ -203,10 +199,6 @@
   "4KuZ0o": {
     "defaultMessage": "Asset not found",
     "description": "ASSET_NOT_FOUND"
-  },
-  "4giHJT": {
-    "defaultMessage": "Have wallet questions on mobile device ? Click the",
-    "description": "src/components/Forms/WalletAuthForm/Select.tsx"
   },
   "4l6vz1": {
     "defaultMessage": "Copy"
@@ -294,6 +286,10 @@
     "defaultMessage": "Cancelled",
     "description": "src/components/Transaction/State/index.tsx"
   },
+  "70UCEy": {
+    "defaultMessage": "Have wallet questions on mobile device ? Click the",
+    "description": "src/components/Forms/WalletAuthForm/Select.tsx"
+  },
   "73iajM": {
     "defaultMessage": "Oops. Something went wrong. Please try again later.",
     "description": "BAD_USER_INPUT"
@@ -337,6 +333,10 @@
   "8qGjpr": {
     "defaultMessage": "Settings",
     "description": "src/views/Me/Settings/Misc/index.tsx"
+  },
+  "8rMZWb": {
+    "defaultMessage": "replied to your discussion on",
+    "description": "src/components/Notice/CommentCommentNotice/CommentNewReplyNotice.tsx"
   },
   "8t6Cs8": {
     "defaultMessage": "Matters Daily Report",
@@ -575,6 +575,10 @@
     "defaultMessage": "This ID cannot be modified. Are you sure you want to use {id} as your Matters ID?",
     "description": "src/components/Dialogs/SetUserNameDialog/ConfirmStep.tsx"
   },
+  "GG9uXH": {
+    "defaultMessage": "Please go to the relevant page to resend the link. You can also",
+    "description": "src/views/Callback/GoogleCallback.tsx"
+  },
   "GHxtae": {
     "defaultMessage": "Wallet",
     "description": "src/components/Forms/SelectAuthMethodForm/AuthTabs.tsx"
@@ -635,6 +639,10 @@
   },
   "HnxG15": {
     "defaultMessage": "Set"
+  },
+  "HqnUd1": {
+    "defaultMessage": "Add hash from IPFS into compatible reader such as",
+    "description": "src/components/Dialogs/RssFeedDialog/Content.tsx"
   },
   "HxcjQl": {
     "defaultMessage": "Matters continues to provide services that combine creativity with blockchain technology. You will be the first to experience them after completing connecting wallet.",
@@ -857,10 +865,6 @@
   },
   "Q8Qw5B": {
     "defaultMessage": "Description"
-  },
-  "QBEE1c": {
-    "defaultMessage": "Please go to the relevant page to resend the link. You can also",
-    "description": "src/views/Callback/GoogleCallback.tsx"
   },
   "QUqfbW": {
     "defaultMessage": "Describe more about your Circle",
@@ -1153,10 +1157,6 @@
     "defaultMessage": "Processing",
     "description": "src/components/Transaction/State/index.tsx"
   },
-  "b+LSgI": {
-    "defaultMessage": "replied to your discussion on",
-    "description": "src/components/Notice/CommentCommentNotice/CommentNewReplyNotice.tsx"
-  },
   "b6zdPs": {
     "defaultMessage": "{count} articles",
     "description": "src/components/Book/index.tsx"
@@ -1193,10 +1193,6 @@
   },
   "cd/II9": {
     "defaultMessage": "{totalCount, plural, =1 {article} other {articles}}"
-  },
-  "cf37Zy": {
-    "defaultMessage": "Add hash from IPFS into compatible reader such as",
-    "description": "src/components/Dialogs/RssFeedDialog/Content.tsx"
   },
   "cg1VJ2": {
     "defaultMessage": "Connect Wallet"
@@ -1315,10 +1311,6 @@
     "defaultMessage": "followed your circle",
     "description": "src/components/Notice/CircleNotice/CircleNewUserNotice.tsx"
   },
-  "hrfF+i": {
-    "defaultMessage": "Don't have a wallet yet? Check the",
-    "description": "src/components/Forms/WalletAuthForm/Select.tsx"
-  },
   "hrgo+E": {
     "defaultMessage": "Archive"
   },
@@ -1383,6 +1375,10 @@
   "kkZioy": {
     "defaultMessage": "Remove",
     "description": "src/components/Dialogs/RemoveArticleCollectionDialog/index.tsx"
+  },
+  "l/f7bu": {
+    "defaultMessage": "Want to know more? Check the",
+    "description": "src/views/Me/Analytics/EmptyAnalytics/index.tsx"
   },
   "l0/EvT": {
     "defaultMessage": "Last step: Set Matters ID",
@@ -1664,6 +1660,10 @@
   },
   "vAc1Bw": {
     "defaultMessage": "Block User"
+  },
+  "vCt85u": {
+    "defaultMessage": "Don't have a wallet yet? Check the",
+    "description": "src/components/Forms/WalletAuthForm/Select.tsx"
   },
   "vH8sCb": {
     "defaultMessage": "Circle"

--- a/lang/en.json
+++ b/lang/en.json
@@ -190,10 +190,6 @@
   "3yk8fB": {
     "defaultMessage": "Wallet"
   },
-  "3ynsJ3": {
-    "defaultMessage": "Want to know more? Check the ",
-    "description": "src/views/Me/Analytics/EmptyAnalytics/index.tsx"
-  },
   "47FYwb": {
     "defaultMessage": "Cancel"
   },
@@ -203,10 +199,6 @@
   "4KuZ0o": {
     "defaultMessage": "Asset not found",
     "description": "ASSET_NOT_FOUND"
-  },
-  "4giHJT": {
-    "defaultMessage": "Have wallet questions on mobile device ? Click the ",
-    "description": "src/components/Forms/WalletAuthForm/Select.tsx"
   },
   "4l6vz1": {
     "defaultMessage": "Copy"
@@ -294,6 +286,10 @@
     "defaultMessage": "Cancelled",
     "description": "src/components/Transaction/State/index.tsx"
   },
+  "70UCEy": {
+    "defaultMessage": "Have wallet questions on mobile device ? Click the",
+    "description": "src/components/Forms/WalletAuthForm/Select.tsx"
+  },
   "73iajM": {
     "defaultMessage": "Oops. Something went wrong. Please try again later.",
     "description": "BAD_USER_INPUT"
@@ -337,6 +333,10 @@
   "8qGjpr": {
     "defaultMessage": "Settings",
     "description": "src/views/Me/Settings/Misc/index.tsx"
+  },
+  "8rMZWb": {
+    "defaultMessage": "replied to your discussion on",
+    "description": "src/components/Notice/CommentCommentNotice/CommentNewReplyNotice.tsx"
   },
   "8t6Cs8": {
     "defaultMessage": "Matters Daily Report",
@@ -575,6 +575,10 @@
     "defaultMessage": "This ID cannot be modified. Are you sure you want to use {id} as your Matters ID?",
     "description": "src/components/Dialogs/SetUserNameDialog/ConfirmStep.tsx"
   },
+  "GG9uXH": {
+    "defaultMessage": "Please go to the relevant page to resend the link. You can also",
+    "description": "src/views/Callback/GoogleCallback.tsx"
+  },
   "GHxtae": {
     "defaultMessage": "Wallet",
     "description": "src/components/Forms/SelectAuthMethodForm/AuthTabs.tsx"
@@ -635,6 +639,10 @@
   },
   "HnxG15": {
     "defaultMessage": "Set"
+  },
+  "HqnUd1": {
+    "defaultMessage": "Add hash from IPFS into compatible reader such as",
+    "description": "src/components/Dialogs/RssFeedDialog/Content.tsx"
   },
   "HxcjQl": {
     "defaultMessage": "Matters continues to provide services that combine creativity with blockchain technology. You will be the first to experience them after completing connecting wallet.",
@@ -857,10 +865,6 @@
   },
   "Q8Qw5B": {
     "defaultMessage": "Description"
-  },
-  "QBEE1c": {
-    "defaultMessage": "Please go to the relevant page to resend the link. You can also ",
-    "description": "src/views/Callback/GoogleCallback.tsx"
   },
   "QUqfbW": {
     "defaultMessage": "Describe more about your Circle",
@@ -1153,10 +1157,6 @@
     "defaultMessage": "Processing",
     "description": "src/components/Transaction/State/index.tsx"
   },
-  "b+LSgI": {
-    "defaultMessage": "replied to your discussion on",
-    "description": "src/components/Notice/CommentCommentNotice/CommentNewReplyNotice.tsx"
-  },
   "b6zdPs": {
     "defaultMessage": "{count} Articles",
     "description": "src/components/Book/index.tsx"
@@ -1193,10 +1193,6 @@
   },
   "cd/II9": {
     "defaultMessage": "{totalCount, plural, =1 {article} other {articles}}"
-  },
-  "cf37Zy": {
-    "defaultMessage": "Add hash from IPFS into compatible reader such as ",
-    "description": "src/components/Dialogs/RssFeedDialog/Content.tsx"
   },
   "cg1VJ2": {
     "defaultMessage": "Connect Wallet"
@@ -1315,10 +1311,6 @@
     "defaultMessage": "followed your circle",
     "description": "src/components/Notice/CircleNotice/CircleNewUserNotice.tsx"
   },
-  "hrfF+i": {
-    "defaultMessage": "Don't have a wallet yet? Check the ",
-    "description": "src/components/Forms/WalletAuthForm/Select.tsx"
-  },
   "hrgo+E": {
     "defaultMessage": "Archive"
   },
@@ -1383,6 +1375,10 @@
   "kkZioy": {
     "defaultMessage": "Remove",
     "description": "src/components/Dialogs/RemoveArticleCollectionDialog/index.tsx"
+  },
+  "l/f7bu": {
+    "defaultMessage": "Want to know more? Check the",
+    "description": "src/views/Me/Analytics/EmptyAnalytics/index.tsx"
   },
   "l0/EvT": {
     "defaultMessage": "Last step: Set Matters ID",
@@ -1664,6 +1660,10 @@
   },
   "vAc1Bw": {
     "defaultMessage": "Block User"
+  },
+  "vCt85u": {
+    "defaultMessage": "Don't have a wallet yet? Check the",
+    "description": "src/components/Forms/WalletAuthForm/Select.tsx"
   },
   "vH8sCb": {
     "defaultMessage": "Circle"

--- a/lang/zh-Hans.json
+++ b/lang/zh-Hans.json
@@ -190,10 +190,6 @@
   "3yk8fB": {
     "defaultMessage": "我的钱包"
   },
-  "3ynsJ3": {
-    "defaultMessage": "想了解更多？详见 ",
-    "description": "src/views/Me/Analytics/EmptyAnalytics/index.tsx"
-  },
   "47FYwb": {
     "defaultMessage": "取消"
   },
@@ -203,10 +199,6 @@
   "4KuZ0o": {
     "defaultMessage": "资源不存在",
     "description": "ASSET_NOT_FOUND"
-  },
-  "4giHJT": {
-    "defaultMessage": "在行动装置上使用问题，参考 ",
-    "description": "src/components/Forms/WalletAuthForm/Select.tsx"
   },
   "4l6vz1": {
     "defaultMessage": "复制"
@@ -294,6 +286,10 @@
     "defaultMessage": "已取消",
     "description": "src/components/Transaction/State/index.tsx"
   },
+  "70UCEy": {
+    "defaultMessage": "Have wallet questions on mobile device ? Click the",
+    "description": "src/components/Forms/WalletAuthForm/Select.tsx"
+  },
   "73iajM": {
     "defaultMessage": "出错了，请检查你输入的内容",
     "description": "BAD_USER_INPUT"
@@ -337,6 +333,10 @@
   "8qGjpr": {
     "defaultMessage": "设置",
     "description": "src/views/Me/Settings/Misc/index.tsx"
+  },
+  "8rMZWb": {
+    "defaultMessage": "replied to your discussion on",
+    "description": "src/components/Notice/CommentCommentNotice/CommentNewReplyNotice.tsx"
   },
   "8t6Cs8": {
     "defaultMessage": "Matters 日报",
@@ -575,6 +575,10 @@
     "defaultMessage": "ID 设置后无法修改，确认使用 {id} 作为 Matters ID 吗？",
     "description": "src/components/Dialogs/SetUserNameDialog/ConfirmStep.tsx"
   },
+  "GG9uXH": {
+    "defaultMessage": "Please go to the relevant page to resend the link. You can also",
+    "description": "src/views/Callback/GoogleCallback.tsx"
+  },
   "GHxtae": {
     "defaultMessage": "数字钱包",
     "description": "src/components/Forms/SelectAuthMethodForm/AuthTabs.tsx"
@@ -635,6 +639,10 @@
   },
   "HnxG15": {
     "defaultMessage": "设定"
+  },
+  "HqnUd1": {
+    "defaultMessage": "Add hash from IPFS into compatible reader such as",
+    "description": "src/components/Dialogs/RssFeedDialog/Content.tsx"
   },
   "HxcjQl": {
     "defaultMessage": "Matters 将提供更多创作与区块链结合的服务，接入钱包后即可在未来第一时间体验新功能。",
@@ -857,10 +865,6 @@
   },
   "Q8Qw5B": {
     "defaultMessage": "描述"
-  },
-  "QBEE1c": {
-    "defaultMessage": "请移步相关页面重新获取链接，您也可以 ",
-    "description": "src/views/Callback/GoogleCallback.tsx"
   },
   "QUqfbW": {
     "defaultMessage": "说说围炉的有趣之处，吸引支持者加入",
@@ -1153,10 +1157,6 @@
     "defaultMessage": "进行中…",
     "description": "src/components/Transaction/State/index.tsx"
   },
-  "b+LSgI": {
-    "defaultMessage": "回复了你在围炉 ",
-    "description": "src/components/Notice/CommentCommentNotice/CommentNewReplyNotice.tsx"
-  },
   "b6zdPs": {
     "defaultMessage": "{count} 篇文章",
     "description": "src/components/Book/index.tsx"
@@ -1193,10 +1193,6 @@
   },
   "cd/II9": {
     "defaultMessage": "{totalCount, plural, =1 {篇文章} other {篇文章}}"
-  },
-  "cf37Zy": {
-    "defaultMessage": "添加 IPFS 生成的 IPNS 指纹到阅读器，如：",
-    "description": "src/components/Dialogs/RssFeedDialog/Content.tsx"
   },
   "cg1VJ2": {
     "defaultMessage": "连接加密钱包"
@@ -1315,10 +1311,6 @@
     "defaultMessage": "追踪了你的围炉",
     "description": "src/components/Notice/CircleNotice/CircleNewUserNotice.tsx"
   },
-  "hrfF+i": {
-    "defaultMessage": "刚接触加密钱包？参考 ",
-    "description": "src/components/Forms/WalletAuthForm/Select.tsx"
-  },
   "hrgo+E": {
     "defaultMessage": "归档"
   },
@@ -1383,6 +1375,10 @@
   "kkZioy": {
     "defaultMessage": "确认移出",
     "description": "src/components/Dialogs/RemoveArticleCollectionDialog/index.tsx"
+  },
+  "l/f7bu": {
+    "defaultMessage": "Want to know more? Check the",
+    "description": "src/views/Me/Analytics/EmptyAnalytics/index.tsx"
   },
   "l0/EvT": {
     "defaultMessage": "最后一步：设置 Matters ID",
@@ -1664,6 +1660,10 @@
   },
   "vAc1Bw": {
     "defaultMessage": "屏蔽用户"
+  },
+  "vCt85u": {
+    "defaultMessage": "Don't have a wallet yet? Check the",
+    "description": "src/components/Forms/WalletAuthForm/Select.tsx"
   },
   "vH8sCb": {
     "defaultMessage": "我的围炉"

--- a/lang/zh-Hans.json
+++ b/lang/zh-Hans.json
@@ -287,7 +287,7 @@
     "description": "src/components/Transaction/State/index.tsx"
   },
   "70UCEy": {
-    "defaultMessage": "Have wallet questions on mobile device ? Click the",
+    "defaultMessage": "在行动装置上使用问题，参考 ",
     "description": "src/components/Forms/WalletAuthForm/Select.tsx"
   },
   "73iajM": {
@@ -335,7 +335,7 @@
     "description": "src/views/Me/Settings/Misc/index.tsx"
   },
   "8rMZWb": {
-    "defaultMessage": "replied to your discussion on",
+    "defaultMessage": "回复了你在围炉 ",
     "description": "src/components/Notice/CommentCommentNotice/CommentNewReplyNotice.tsx"
   },
   "8t6Cs8": {
@@ -576,7 +576,7 @@
     "description": "src/components/Dialogs/SetUserNameDialog/ConfirmStep.tsx"
   },
   "GG9uXH": {
-    "defaultMessage": "Please go to the relevant page to resend the link. You can also",
+    "defaultMessage": "请移步相关页面重新获取链接，您也可以 ",
     "description": "src/views/Callback/GoogleCallback.tsx"
   },
   "GHxtae": {
@@ -641,7 +641,7 @@
     "defaultMessage": "设定"
   },
   "HqnUd1": {
-    "defaultMessage": "Add hash from IPFS into compatible reader such as",
+    "defaultMessage": "添加 IPFS 生成的 IPNS 指纹到阅读器，如：",
     "description": "src/components/Dialogs/RssFeedDialog/Content.tsx"
   },
   "HxcjQl": {
@@ -1377,7 +1377,7 @@
     "description": "src/components/Dialogs/RemoveArticleCollectionDialog/index.tsx"
   },
   "l/f7bu": {
-    "defaultMessage": "Want to know more? Check the",
+    "defaultMessage": "想了解更多？詳見 ",
     "description": "src/views/Me/Analytics/EmptyAnalytics/index.tsx"
   },
   "l0/EvT": {
@@ -1662,7 +1662,7 @@
     "defaultMessage": "屏蔽用户"
   },
   "vCt85u": {
-    "defaultMessage": "Don't have a wallet yet? Check the",
+    "defaultMessage": "刚接触加密钱包？参考 ",
     "description": "src/components/Forms/WalletAuthForm/Select.tsx"
   },
   "vH8sCb": {

--- a/lang/zh-Hant.json
+++ b/lang/zh-Hant.json
@@ -190,10 +190,6 @@
   "3yk8fB": {
     "defaultMessage": "我的錢包"
   },
-  "3ynsJ3": {
-    "defaultMessage": "想了解更多？詳見 ",
-    "description": "src/views/Me/Analytics/EmptyAnalytics/index.tsx"
-  },
   "47FYwb": {
     "defaultMessage": "取消"
   },
@@ -203,10 +199,6 @@
   "4KuZ0o": {
     "defaultMessage": "資源不存在",
     "description": "ASSET_NOT_FOUND"
-  },
-  "4giHJT": {
-    "defaultMessage": "在行動裝置上使用問題，參考 ",
-    "description": "src/components/Forms/WalletAuthForm/Select.tsx"
   },
   "4l6vz1": {
     "defaultMessage": "複製"
@@ -294,6 +286,10 @@
     "defaultMessage": "已取消",
     "description": "src/components/Transaction/State/index.tsx"
   },
+  "70UCEy": {
+    "defaultMessage": "Have wallet questions on mobile device ? Click the",
+    "description": "src/components/Forms/WalletAuthForm/Select.tsx"
+  },
   "73iajM": {
     "defaultMessage": "出錯了，請檢查你輸入的內容",
     "description": "BAD_USER_INPUT"
@@ -337,6 +333,10 @@
   "8qGjpr": {
     "defaultMessage": "設定",
     "description": "src/views/Me/Settings/Misc/index.tsx"
+  },
+  "8rMZWb": {
+    "defaultMessage": "replied to your discussion on",
+    "description": "src/components/Notice/CommentCommentNotice/CommentNewReplyNotice.tsx"
   },
   "8t6Cs8": {
     "defaultMessage": "Matters 日報",
@@ -575,6 +575,10 @@
     "defaultMessage": "ID 設置後無法修改，確認使用 {id} 作為 Matters ID 嗎？",
     "description": "src/components/Dialogs/SetUserNameDialog/ConfirmStep.tsx"
   },
+  "GG9uXH": {
+    "defaultMessage": "Please go to the relevant page to resend the link. You can also",
+    "description": "src/views/Callback/GoogleCallback.tsx"
+  },
   "GHxtae": {
     "defaultMessage": "數字錢包",
     "description": "src/components/Forms/SelectAuthMethodForm/AuthTabs.tsx"
@@ -635,6 +639,10 @@
   },
   "HnxG15": {
     "defaultMessage": "設定"
+  },
+  "HqnUd1": {
+    "defaultMessage": "Add hash from IPFS into compatible reader such as",
+    "description": "src/components/Dialogs/RssFeedDialog/Content.tsx"
   },
   "HxcjQl": {
     "defaultMessage": "Matters 將提供更多創作與區塊鏈結合的服務，接入錢包後即可在未來第一時間體驗新功能。",
@@ -857,10 +865,6 @@
   },
   "Q8Qw5B": {
     "defaultMessage": "描述"
-  },
-  "QBEE1c": {
-    "defaultMessage": "請移步相關頁面重新獲取連結，您也可以 ",
-    "description": "src/views/Callback/GoogleCallback.tsx"
   },
   "QUqfbW": {
     "defaultMessage": "說說圍爐的有趣之處，吸引支持者加入",
@@ -1153,10 +1157,6 @@
     "defaultMessage": "進行中…",
     "description": "src/components/Transaction/State/index.tsx"
   },
-  "b+LSgI": {
-    "defaultMessage": "回覆了你在圍爐 ",
-    "description": "src/components/Notice/CommentCommentNotice/CommentNewReplyNotice.tsx"
-  },
   "b6zdPs": {
     "defaultMessage": "{count} 篇文章",
     "description": "src/components/Book/index.tsx"
@@ -1193,10 +1193,6 @@
   },
   "cd/II9": {
     "defaultMessage": "{totalCount, plural, =1 {篇文章} other {篇文章}}"
-  },
-  "cf37Zy": {
-    "defaultMessage": "添加 IPFS 生成的 IPNS 指紋到閱讀器，如：",
-    "description": "src/components/Dialogs/RssFeedDialog/Content.tsx"
   },
   "cg1VJ2": {
     "defaultMessage": "連接加密錢包"
@@ -1315,10 +1311,6 @@
     "defaultMessage": "追蹤了你的圍爐",
     "description": "src/components/Notice/CircleNotice/CircleNewUserNotice.tsx"
   },
-  "hrfF+i": {
-    "defaultMessage": "剛接觸加密錢包？參考 ",
-    "description": "src/components/Forms/WalletAuthForm/Select.tsx"
-  },
   "hrgo+E": {
     "defaultMessage": "封存"
   },
@@ -1383,6 +1375,10 @@
   "kkZioy": {
     "defaultMessage": "確認移出",
     "description": "src/components/Dialogs/RemoveArticleCollectionDialog/index.tsx"
+  },
+  "l/f7bu": {
+    "defaultMessage": "Want to know more? Check the",
+    "description": "src/views/Me/Analytics/EmptyAnalytics/index.tsx"
   },
   "l0/EvT": {
     "defaultMessage": "最後一步：设置 Matters ID",
@@ -1664,6 +1660,10 @@
   },
   "vAc1Bw": {
     "defaultMessage": "封鎖用戶"
+  },
+  "vCt85u": {
+    "defaultMessage": "Don't have a wallet yet? Check the",
+    "description": "src/components/Forms/WalletAuthForm/Select.tsx"
   },
   "vH8sCb": {
     "defaultMessage": "我的圍爐"

--- a/lang/zh-Hant.json
+++ b/lang/zh-Hant.json
@@ -287,7 +287,7 @@
     "description": "src/components/Transaction/State/index.tsx"
   },
   "70UCEy": {
-    "defaultMessage": "Have wallet questions on mobile device ? Click the",
+    "defaultMessage": "在行動裝置上使用問題，參考 ",
     "description": "src/components/Forms/WalletAuthForm/Select.tsx"
   },
   "73iajM": {
@@ -335,7 +335,7 @@
     "description": "src/views/Me/Settings/Misc/index.tsx"
   },
   "8rMZWb": {
-    "defaultMessage": "replied to your discussion on",
+    "defaultMessage": "回覆了你在圍爐 ",
     "description": "src/components/Notice/CommentCommentNotice/CommentNewReplyNotice.tsx"
   },
   "8t6Cs8": {
@@ -576,7 +576,7 @@
     "description": "src/components/Dialogs/SetUserNameDialog/ConfirmStep.tsx"
   },
   "GG9uXH": {
-    "defaultMessage": "Please go to the relevant page to resend the link. You can also",
+    "defaultMessage": "請移步相關頁面重新獲取連結，您也可以 ",
     "description": "src/views/Callback/GoogleCallback.tsx"
   },
   "GHxtae": {
@@ -641,7 +641,7 @@
     "defaultMessage": "設定"
   },
   "HqnUd1": {
-    "defaultMessage": "Add hash from IPFS into compatible reader such as",
+    "defaultMessage": "添加 IPFS 生成的 IPNS 指紋到閱讀器，如：",
     "description": "src/components/Dialogs/RssFeedDialog/Content.tsx"
   },
   "HxcjQl": {
@@ -1377,7 +1377,7 @@
     "description": "src/components/Dialogs/RemoveArticleCollectionDialog/index.tsx"
   },
   "l/f7bu": {
-    "defaultMessage": "Want to know more? Check the",
+    "defaultMessage": "想了解更多？詳見 ",
     "description": "src/views/Me/Analytics/EmptyAnalytics/index.tsx"
   },
   "l0/EvT": {
@@ -1662,7 +1662,7 @@
     "defaultMessage": "封鎖用戶"
   },
   "vCt85u": {
-    "defaultMessage": "Don't have a wallet yet? Check the",
+    "defaultMessage": "剛接觸加密錢包？參考 ",
     "description": "src/components/Forms/WalletAuthForm/Select.tsx"
   },
   "vH8sCb": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,6 @@
         "apollo-link-ws": "^1.0.20",
         "apollo-utilities": "^1.3.4",
         "autosize": "^6.0.1",
-        "babel-plugin-formatjs": "^10.5.3",
         "classnames": "^2.3.2",
         "colorthief": "^2.4.0",
         "d3-array": "^2.12.1",
@@ -1279,6 +1278,7 @@
       "version": "7.12.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.12.1.tgz",
       "integrity": "sha512-1yRi7yAtB0ETgxdY9ti/p2TivUxJkTdhu/ZbF9MshVGqOx1TdB3b7xCXs49Fupgg50N45KcAsRP/ZqWjs9SRjg==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
       },
@@ -4972,6 +4972,7 @@
       "version": "3.13.3",
       "resolved": "https://registry.npmjs.org/@formatjs/ts-transformer/-/ts-transformer-3.13.3.tgz",
       "integrity": "sha512-W6+huH4dLYx8eZfZue6fcreNzLZHoPboreqJSkickYCKIOicI35zC0Txb4xCT6kau/DXAKTpNEln3V2NgX6Igg==",
+      "dev": true,
       "dependencies": {
         "@formatjs/icu-messageformat-parser": "2.6.0",
         "@types/json-stable-stringify": "^1.0.32",
@@ -4994,6 +4995,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -5008,6 +5010,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -5023,6 +5026,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -5033,12 +5037,14 @@
     "node_modules/@formatjs/ts-transformer/node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "node_modules/@formatjs/ts-transformer/node_modules/tslib": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
+      "dev": true
     },
     "node_modules/@foundry-rs/easy-foundryup": {
       "version": "0.1.3",
@@ -12328,6 +12334,7 @@
       "version": "7.20.0",
       "resolved": "https://registry.npmmirror.com/@types/babel__core/-/babel__core-7.20.0.tgz",
       "integrity": "sha512-+n8dL/9GWblDO0iU6eZAwEIJVr5DWigtle+Q6HLOrh/pdbXOhOtqzq8VPPE2zvNJzSKY4vH/z3iT3tn0A3ypiQ==",
+      "dev": true,
       "dependencies": {
         "@babel/parser": "^7.20.7",
         "@babel/types": "^7.20.7",
@@ -12340,22 +12347,16 @@
       "version": "7.6.4",
       "resolved": "https://registry.npmmirror.com/@types/babel__generator/-/babel__generator-7.6.4.tgz",
       "integrity": "sha512-tFkciB9j2K755yrTALxD44McOrk+gfpIpvC3sxHjRawj6PfnQxrse4Clq5y/Rq+G3mrBurMax/lG8Qn2t9mSsg==",
+      "dev": true,
       "dependencies": {
         "@babel/types": "^7.0.0"
-      }
-    },
-    "node_modules/@types/babel__helper-plugin-utils": {
-      "version": "7.10.0",
-      "resolved": "https://registry.npmmirror.com/@types/babel__helper-plugin-utils/-/babel__helper-plugin-utils-7.10.0.tgz",
-      "integrity": "sha512-60YtHzhQ9HAkToHVV+TB4VLzBn9lrfgrsOjiJMtbv/c1jPdekBxaByd6DMsGBzROXWoIL6U3lEFvvbu69RkUoA==",
-      "dependencies": {
-        "@types/babel__core": "*"
       }
     },
     "node_modules/@types/babel__template": {
       "version": "7.4.1",
       "resolved": "https://registry.npmmirror.com/@types/babel__template/-/babel__template-7.4.1.tgz",
       "integrity": "sha512-azBFKemX6kMg5Io+/rdGT0dkGreboUVR0Cdm3fz9QJWpaQGJRQXl7C+6hOTCZcMll7KFyEQpgbYI2lHdsS4U7g==",
+      "dev": true,
       "dependencies": {
         "@babel/parser": "^7.1.0",
         "@babel/types": "^7.0.0"
@@ -12365,6 +12366,7 @@
       "version": "7.18.3",
       "resolved": "https://registry.npmmirror.com/@types/babel__traverse/-/babel__traverse-7.18.3.tgz",
       "integrity": "sha512-1kbcJ40lLB7MHsj39U4Sh1uTd2E7rLEa79kmDpI6cy+XiXsteB3POdQomoq4FxszMrO3ZYchkhYJw7A2862b3w==",
+      "dev": true,
       "dependencies": {
         "@babel/types": "^7.3.0"
       }
@@ -12873,7 +12875,8 @@
     "node_modules/@types/json-stable-stringify": {
       "version": "1.0.34",
       "resolved": "https://registry.npmjs.org/@types/json-stable-stringify/-/json-stable-stringify-1.0.34.tgz",
-      "integrity": "sha512-s2cfwagOQAS8o06TcwKfr9Wx11dNGbH2E9vJz1cqV+a/LOyhWNLUNd6JSRYNzvB4d29UuJX2M0Dj9vE1T8fRXw=="
+      "integrity": "sha512-s2cfwagOQAS8o06TcwKfr9Wx11dNGbH2E9vJz1cqV+a/LOyhWNLUNd6JSRYNzvB4d29UuJX2M0Dj9vE1T8fRXw==",
+      "dev": true
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
@@ -15895,29 +15898,6 @@
       "dependencies": {
         "object.assign": "^4.1.0"
       }
-    },
-    "node_modules/babel-plugin-formatjs": {
-      "version": "10.5.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-formatjs/-/babel-plugin-formatjs-10.5.3.tgz",
-      "integrity": "sha512-PBeryWyN2HY2VUGNFPQS6+DPNQ/I9zDZ97y38i1+LzIpIyTHBePECq/ehEABE73PvvF2irFiN7TCYBrQQw5+lA==",
-      "dependencies": {
-        "@babel/core": "^7.10.4",
-        "@babel/helper-plugin-utils": "^7.10.4",
-        "@babel/plugin-syntax-jsx": "7",
-        "@babel/traverse": "7",
-        "@babel/types": "^7.12.11",
-        "@formatjs/icu-messageformat-parser": "2.6.0",
-        "@formatjs/ts-transformer": "3.13.3",
-        "@types/babel__core": "^7.1.7",
-        "@types/babel__helper-plugin-utils": "^7.10.0",
-        "@types/babel__traverse": "^7.1.7",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/babel-plugin-formatjs/node_modules/tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmmirror.com/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/babel-plugin-istanbul": {
       "version": "6.1.1",
@@ -26747,6 +26727,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.2.tgz",
       "integrity": "sha512-eunSSaEnxV12z+Z73y/j5N37/In40GK4GmsSy+tEHJMxknvqnA7/djeYtAgW0GsWHUfg+847WJjKaEylk2y09g==",
+      "dev": true,
       "dependencies": {
         "jsonify": "^0.0.1"
       },
@@ -26804,6 +26785,7 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
       "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -37133,6 +37115,7 @@
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
       "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -39914,6 +39897,7 @@
       "version": "7.12.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.12.1.tgz",
       "integrity": "sha512-1yRi7yAtB0ETgxdY9ti/p2TivUxJkTdhu/ZbF9MshVGqOx1TdB3b7xCXs49Fupgg50N45KcAsRP/ZqWjs9SRjg==",
+      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.10.4"
       }
@@ -42442,6 +42426,7 @@
       "version": "3.13.3",
       "resolved": "https://registry.npmjs.org/@formatjs/ts-transformer/-/ts-transformer-3.13.3.tgz",
       "integrity": "sha512-W6+huH4dLYx8eZfZue6fcreNzLZHoPboreqJSkickYCKIOicI35zC0Txb4xCT6kau/DXAKTpNEln3V2NgX6Igg==",
+      "dev": true,
       "requires": {
         "@formatjs/icu-messageformat-parser": "2.6.0",
         "@types/json-stable-stringify": "^1.0.32",
@@ -42456,6 +42441,7 @@
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
           "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
           "requires": {
             "color-convert": "^2.0.1"
           }
@@ -42464,6 +42450,7 @@
           "version": "4.1.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
           "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -42473,6 +42460,7 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
           "requires": {
             "color-name": "~1.1.4"
           }
@@ -42480,12 +42468,14 @@
         "color-name": {
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
         },
         "tslib": {
           "version": "2.6.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-          "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+          "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
+          "dev": true
         }
       }
     },
@@ -47798,6 +47788,7 @@
       "version": "7.20.0",
       "resolved": "https://registry.npmmirror.com/@types/babel__core/-/babel__core-7.20.0.tgz",
       "integrity": "sha512-+n8dL/9GWblDO0iU6eZAwEIJVr5DWigtle+Q6HLOrh/pdbXOhOtqzq8VPPE2zvNJzSKY4vH/z3iT3tn0A3ypiQ==",
+      "dev": true,
       "requires": {
         "@babel/parser": "^7.20.7",
         "@babel/types": "^7.20.7",
@@ -47810,22 +47801,16 @@
       "version": "7.6.4",
       "resolved": "https://registry.npmmirror.com/@types/babel__generator/-/babel__generator-7.6.4.tgz",
       "integrity": "sha512-tFkciB9j2K755yrTALxD44McOrk+gfpIpvC3sxHjRawj6PfnQxrse4Clq5y/Rq+G3mrBurMax/lG8Qn2t9mSsg==",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.0.0"
-      }
-    },
-    "@types/babel__helper-plugin-utils": {
-      "version": "7.10.0",
-      "resolved": "https://registry.npmmirror.com/@types/babel__helper-plugin-utils/-/babel__helper-plugin-utils-7.10.0.tgz",
-      "integrity": "sha512-60YtHzhQ9HAkToHVV+TB4VLzBn9lrfgrsOjiJMtbv/c1jPdekBxaByd6DMsGBzROXWoIL6U3lEFvvbu69RkUoA==",
-      "requires": {
-        "@types/babel__core": "*"
       }
     },
     "@types/babel__template": {
       "version": "7.4.1",
       "resolved": "https://registry.npmmirror.com/@types/babel__template/-/babel__template-7.4.1.tgz",
       "integrity": "sha512-azBFKemX6kMg5Io+/rdGT0dkGreboUVR0Cdm3fz9QJWpaQGJRQXl7C+6hOTCZcMll7KFyEQpgbYI2lHdsS4U7g==",
+      "dev": true,
       "requires": {
         "@babel/parser": "^7.1.0",
         "@babel/types": "^7.0.0"
@@ -47835,6 +47820,7 @@
       "version": "7.18.3",
       "resolved": "https://registry.npmmirror.com/@types/babel__traverse/-/babel__traverse-7.18.3.tgz",
       "integrity": "sha512-1kbcJ40lLB7MHsj39U4Sh1uTd2E7rLEa79kmDpI6cy+XiXsteB3POdQomoq4FxszMrO3ZYchkhYJw7A2862b3w==",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.3.0"
       }
@@ -48342,7 +48328,8 @@
     "@types/json-stable-stringify": {
       "version": "1.0.34",
       "resolved": "https://registry.npmjs.org/@types/json-stable-stringify/-/json-stable-stringify-1.0.34.tgz",
-      "integrity": "sha512-s2cfwagOQAS8o06TcwKfr9Wx11dNGbH2E9vJz1cqV+a/LOyhWNLUNd6JSRYNzvB4d29UuJX2M0Dj9vE1T8fRXw=="
+      "integrity": "sha512-s2cfwagOQAS8o06TcwKfr9Wx11dNGbH2E9vJz1cqV+a/LOyhWNLUNd6JSRYNzvB4d29UuJX2M0Dj9vE1T8fRXw==",
+      "dev": true
     },
     "@types/json5": {
       "version": "0.0.29",
@@ -50713,31 +50700,6 @@
       "dev": true,
       "requires": {
         "object.assign": "^4.1.0"
-      }
-    },
-    "babel-plugin-formatjs": {
-      "version": "10.5.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-formatjs/-/babel-plugin-formatjs-10.5.3.tgz",
-      "integrity": "sha512-PBeryWyN2HY2VUGNFPQS6+DPNQ/I9zDZ97y38i1+LzIpIyTHBePECq/ehEABE73PvvF2irFiN7TCYBrQQw5+lA==",
-      "requires": {
-        "@babel/core": "^7.10.4",
-        "@babel/helper-plugin-utils": "^7.10.4",
-        "@babel/plugin-syntax-jsx": "7",
-        "@babel/traverse": "7",
-        "@babel/types": "^7.12.11",
-        "@formatjs/icu-messageformat-parser": "2.6.0",
-        "@formatjs/ts-transformer": "3.13.3",
-        "@types/babel__core": "^7.1.7",
-        "@types/babel__helper-plugin-utils": "^7.10.0",
-        "@types/babel__traverse": "^7.1.7",
-        "tslib": "^2.4.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmmirror.com/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
-        }
       }
     },
     "babel-plugin-istanbul": {
@@ -59079,6 +59041,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.2.tgz",
       "integrity": "sha512-eunSSaEnxV12z+Z73y/j5N37/In40GK4GmsSy+tEHJMxknvqnA7/djeYtAgW0GsWHUfg+847WJjKaEylk2y09g==",
+      "dev": true,
       "requires": {
         "jsonify": "^0.0.1"
       }
@@ -59121,7 +59084,8 @@
     "jsonify": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
-      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg=="
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "dev": true
     },
     "jsonparse": {
       "version": "1.3.1",
@@ -66907,7 +66871,8 @@
     "typescript": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA=="
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "dev": true
     },
     "ua-parser-js": {
       "version": "0.7.35",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "apollo-link-ws": "^1.0.20",
     "apollo-utilities": "^1.3.4",
     "autosize": "^6.0.1",
-    "babel-plugin-formatjs": "^10.5.3",
     "classnames": "^2.3.2",
     "colorthief": "^2.4.0",
     "d3-array": "^2.12.1",

--- a/src/common/utils/form/image.tsx
+++ b/src/common/utils/form/image.tsx
@@ -14,7 +14,10 @@ export const validateImage = (image: File) =>
     if (isExceedSizeLimit) {
       toast.error({
         message: (
-          <FormattedMessage defaultMessage="Images have a 5 megabyte (MB) size limit." />
+          <FormattedMessage
+            defaultMessage="Images have a 5 megabyte (MB) size limit."
+            id="OyvGvT"
+          />
         ),
       })
       return resolve(false)
@@ -36,7 +39,10 @@ export const validateImage = (image: File) =>
         if (isExceedDimensionLimit) {
           toast.error({
             message: (
-              <FormattedMessage defaultMessage="Maximum image dimension is 12,000 pixels." />
+              <FormattedMessage
+                defaultMessage="Maximum image dimension is 12,000 pixels."
+                id="Y7N/Jg"
+              />
             ),
           })
           return resolve(false)
@@ -45,7 +51,10 @@ export const validateImage = (image: File) =>
         if (isExceedAreaLimit) {
           toast.error({
             message: (
-              <FormattedMessage defaultMessage="Maximum image area is limited to 100 megapixels (for example, 10,000×10,000 pixels)." />
+              <FormattedMessage
+                defaultMessage="Maximum image area is limited to 100 megapixels (for example, 10,000×10,000 pixels)."
+                id="9Vkz9W"
+              />
             ),
           })
           return resolve(false)

--- a/src/components/ArticleDigest/Archived/index.tsx
+++ b/src/components/ArticleDigest/Archived/index.tsx
@@ -38,6 +38,7 @@ export const ArticleDigestArchived = ({
         <section className={styles.right}>
           <FormattedMessage
             defaultMessage="Archived"
+            id="RNKSCj"
             description="src/components/ArticleDigest/Archive/index.tsx"
           />
         </section>

--- a/src/components/ArticleDigest/DropdownActions/AddCollectionButton.tsx
+++ b/src/components/ArticleDigest/DropdownActions/AddCollectionButton.tsx
@@ -9,7 +9,7 @@ interface AddCollectionButtonProps {
 const AddCollectionButton = ({ openDialog }: AddCollectionButtonProps) => {
   return (
     <Menu.Item
-      text={<FormattedMessage defaultMessage="Add to collection" />}
+      text={<FormattedMessage defaultMessage="Add to collection" id="ub1kHa" />}
       icon={<IconBook20 size="mdS" />}
       onClick={openDialog}
       ariaHasPopup="dialog"

--- a/src/components/ArticleDigest/DropdownActions/ArchiveArticle/Button.tsx
+++ b/src/components/ArticleDigest/DropdownActions/ArchiveArticle/Button.tsx
@@ -5,7 +5,7 @@ import { IconArchive20, Menu } from '~/components'
 const ArchiveArticleButton = ({ openDialog }: { openDialog: () => void }) => {
   return (
     <Menu.Item
-      text={<FormattedMessage defaultMessage="Archive" />}
+      text={<FormattedMessage defaultMessage="Archive" id="hrgo+E" />}
       icon={<IconArchive20 size="mdS" />}
       onClick={openDialog}
       ariaHasPopup="dialog"

--- a/src/components/ArticleDigest/DropdownActions/ArchiveArticle/Dialog.tsx
+++ b/src/components/ArticleDigest/DropdownActions/ArchiveArticle/Dialog.tsx
@@ -83,6 +83,7 @@ const ArchiveArticleDialog = ({
       message: (
         <FormattedMessage
           defaultMessage="Archived"
+          id="a/YQ1Z"
           description="src/components/ArticleDigest/DropdownActions/ArchiveArticle/Dialog.tsx"
         />
       ),
@@ -104,7 +105,9 @@ const ArchiveArticleDialog = ({
 
       <Dialog isOpen={show} onDismiss={closeDialog}>
         <Dialog.Header
-          title={<FormattedMessage defaultMessage="Archive works" />}
+          title={
+            <FormattedMessage defaultMessage="Archive works" id="KQi/UZ" />
+          }
         />
 
         <Dialog.Message>
@@ -112,16 +115,23 @@ const ArchiveArticleDialog = ({
             <p>
               <FormattedMessage
                 defaultMessage="Are you sure you want to archive ‘{article}’?"
+                id="mWcca9"
                 values={{
                   article: <span className="u-highlight">{article.title}</span>,
                 }}
               />
               <br />
-              <FormattedMessage defaultMessage="Archived articles can only be seen by you, and this operation cannot be undone. If this article has been added to collections, it will be removed. (IPFS version will not be effected)" />
+              <FormattedMessage
+                defaultMessage="Archived articles can only be seen by you, and this operation cannot be undone. If this article has been added to collections, it will be removed. (IPFS version will not be effected)"
+                id="A3g33H"
+              />
             </p>
           ) : (
             <p>
-              <FormattedMessage defaultMessage="This operation cannot be undone, confirm archiving?" />
+              <FormattedMessage
+                defaultMessage="This operation cannot be undone, confirm archiving?"
+                id="yBUiiy"
+              />
             </p>
           )}
         </Dialog.Message>
@@ -132,9 +142,12 @@ const ArchiveArticleDialog = ({
             <Dialog.RoundedButton
               text={
                 isPreConfirm ? (
-                  <FormattedMessage defaultMessage="Archive" />
+                  <FormattedMessage defaultMessage="Archive" id="hrgo+E" />
                 ) : (
-                  <FormattedMessage defaultMessage="Confirm Archiving" />
+                  <FormattedMessage
+                    defaultMessage="Confirm Archiving"
+                    id="HJ0iZJ"
+                  />
                 )
               }
               color={loading ? 'green' : 'red'}
@@ -146,9 +159,12 @@ const ArchiveArticleDialog = ({
             <Dialog.TextButton
               text={
                 isPreConfirm ? (
-                  <FormattedMessage defaultMessage="Archive" />
+                  <FormattedMessage defaultMessage="Archive" id="hrgo+E" />
                 ) : (
-                  <FormattedMessage defaultMessage="Confirm Archiving" />
+                  <FormattedMessage
+                    defaultMessage="Confirm Archiving"
+                    id="HJ0iZJ"
+                  />
                 )
               }
               color={loading ? 'green' : 'red'}

--- a/src/components/ArticleDigest/DropdownActions/EditButton.tsx
+++ b/src/components/ArticleDigest/DropdownActions/EditButton.tsx
@@ -32,6 +32,7 @@ const EditArticleButton = ({
       text={
         <FormattedMessage
           defaultMessage="Edit"
+          id="ZVoJan"
           description="src/components/ArticleDigest/DropdownActions/EditButton.tsx"
         />
       }

--- a/src/components/ArticleDigest/DropdownActions/PinButton.tsx
+++ b/src/components/ArticleDigest/DropdownActions/PinButton.tsx
@@ -53,9 +53,12 @@ const PinButton = ({ article }: PinButtonProps) => {
       onCompleted: () => {
         toast.success({
           message: article.pinned ? (
-            <FormattedMessage defaultMessage="Unpinned from profile" />
+            <FormattedMessage
+              defaultMessage="Unpinned from profile"
+              id="Ihwz5K"
+            />
           ) : (
-            <FormattedMessage defaultMessage="Pinned to profile" />
+            <FormattedMessage defaultMessage="Pinned to profile" id="XuYhBC" />
           ),
         })
       },
@@ -64,7 +67,10 @@ const PinButton = ({ article }: PinButtonProps) => {
       toastType: 'success',
       customErrors: {
         [ERROR_CODES.ACTION_LIMIT_EXCEEDED]: (
-          <FormattedMessage defaultMessage="Up to 3 articles/collections can be pinned" />
+          <FormattedMessage
+            defaultMessage="Up to 3 articles/collections can be pinned"
+            id="2oxLHg"
+          />
         ),
       },
     }
@@ -76,11 +82,13 @@ const PinButton = ({ article }: PinButtonProps) => {
         article.pinned ? (
           <FormattedMessage
             defaultMessage="Unpin from profile"
+            id="S8PcQf"
             description="src/components/ArticleDigest/DropdownActions/PinButton.tsx"
           />
         ) : (
           <FormattedMessage
             defaultMessage="Pin to profile"
+            id="qgPR68"
             description="src/components/ArticleDigest/DropdownActions/PinButton.tsx"
           />
         )

--- a/src/components/ArticleDigest/DropdownActions/RemoveArticleCollectionButton.tsx
+++ b/src/components/ArticleDigest/DropdownActions/RemoveArticleCollectionButton.tsx
@@ -13,7 +13,9 @@ const RemoveArticleCollectionButton = ({
 }: RemoveArticleCollectionButtonProps) => {
   return (
     <Menu.Item
-      text={<FormattedMessage defaultMessage="Remove from collection" />}
+      text={
+        <FormattedMessage defaultMessage="Remove from collection" id="0Om2Kl" />
+      }
       icon={<IconTrash20 size="mdS" />}
       onClick={() => {
         onClick()

--- a/src/components/ArticleDigest/DropdownActions/RemoveTagButton.tsx
+++ b/src/components/ArticleDigest/DropdownActions/RemoveTagButton.tsx
@@ -60,6 +60,7 @@ const RemoveTagButton = ({
       text={
         <FormattedMessage
           defaultMessage="Remove Article"
+          id="qlki7w"
           description="src/components/ArticleDigest/DropdownActions/RemoveTagButton.tsx"
         />
       }

--- a/src/components/ArticleDigest/DropdownActions/SetBottomCollectionButton.tsx
+++ b/src/components/ArticleDigest/DropdownActions/SetBottomCollectionButton.tsx
@@ -49,6 +49,7 @@ const SetBottomCollectionButton = ({
       text={
         <FormattedMessage
           defaultMessage="Move to bottom"
+          id="Udp4Bm"
           description="src/components/ArticleDigest/DropdownActions/SetBottomCollectionButton.tsx"
         />
       }

--- a/src/components/ArticleDigest/DropdownActions/SetTagSelectedButton.tsx
+++ b/src/components/ArticleDigest/DropdownActions/SetTagSelectedButton.tsx
@@ -53,6 +53,7 @@ const SetTagSelectedButton = ({
       text={
         <FormattedMessage
           defaultMessage="Add to Featured"
+          id="WSUAwk"
           description="src/components/ArticleDigest/DropdownActions/SetTagSelectedButton.tsx"
         />
       }
@@ -64,6 +65,7 @@ const SetTagSelectedButton = ({
           message: (
             <FormattedMessage
               defaultMessage="The article has been added to the Trending"
+              id="7xnrxG"
               description="src/components/ArticleDigest/DropdownActions/SetTagSelectedButton.tsx"
             />
           ),

--- a/src/components/ArticleDigest/DropdownActions/SetTagUnselectedButton.tsx
+++ b/src/components/ArticleDigest/DropdownActions/SetTagUnselectedButton.tsx
@@ -99,6 +99,7 @@ const SetTagUnselectedButton = ({
       message: (
         <FormattedMessage
           defaultMessage="This article has been removed from Trending"
+          id="Js/Fij"
           description="src/components/ArticleDigest/DropdownActions/SetTagUnselectedButton.tsx"
         />
       ),
@@ -110,6 +111,7 @@ const SetTagUnselectedButton = ({
       text={
         <FormattedMessage
           defaultMessage="Unpin from Trending"
+          id="aa0nss"
           description="src/components/ArticleDigest/DropdownActions/SetTagUnselectedButton.tsx"
         />
       }

--- a/src/components/ArticleDigest/DropdownActions/SetTopCollectionButton.tsx
+++ b/src/components/ArticleDigest/DropdownActions/SetTopCollectionButton.tsx
@@ -36,6 +36,7 @@ const SetTopCollectionButton = ({
       text={
         <FormattedMessage
           defaultMessage="Move to top"
+          id="+S8mxW"
           description="src/components/ArticleDigest/DropdownActions/SetTopCollectionButton.tsx"
         />
       }

--- a/src/components/ArticleDigest/Feed/FooterActions/ReadTime/index.tsx
+++ b/src/components/ArticleDigest/Feed/FooterActions/ReadTime/index.tsx
@@ -28,6 +28,7 @@ const ReadTime = ({ article }: ResponseCountProps) => {
       type="button"
       title={intl.formatMessage({
         defaultMessage: 'Accumulated read time',
+        id: 'U7o9Ba',
       })}
     >
       <TextIcon icon={<IconReadTime18 size="mdXS" />} size="xs" color="grey">

--- a/src/components/AuthMethodFeed/AuthNormalFeed.tsx
+++ b/src/components/AuthMethodFeed/AuthNormalFeed.tsx
@@ -61,7 +61,7 @@ export const AuthNormalFeed = ({ gotoEmailSignup, gotoEmailLogin }: Props) => {
             <IconMail22 size="mdM" />
           </span>
           <span className={styles.name}>
-            <FormattedMessage defaultMessage="Email" />
+            <FormattedMessage defaultMessage="Email" id="sy+pv5" />
           </span>
         </li>
         <li className={styles.item} role="button" onClick={gotoGoogle}>
@@ -103,6 +103,7 @@ export const AuthNormalFeed = ({ gotoEmailSignup, gotoEmailLogin }: Props) => {
           <span className={styles.left}>
             <FormattedMessage
               defaultMessage="No account?"
+              id="L34EMG"
               description="src/components/Forms/SelectAuthMethodForm/NormalFeed.tsx"
             />
           </span>
@@ -114,6 +115,7 @@ export const AuthNormalFeed = ({ gotoEmailSignup, gotoEmailLogin }: Props) => {
           >
             <FormattedMessage
               defaultMessage="Sign up with email"
+              id="jBx/nm"
               description="src/components/Forms/SelectAuthMethodForm/NormalFeed.tsx"
             />
           </span>
@@ -121,11 +123,13 @@ export const AuthNormalFeed = ({ gotoEmailSignup, gotoEmailLogin }: Props) => {
         <section className={styles.policy}>
           <FormattedMessage
             defaultMessage="Continued use indicates your agreement to"
+            id="3phEFL"
             description="src/components/Forms/SelectAuthMethodForm/NormalFeed.tsx"
           />
           <a href={PATHS.TOS} target="_blank">
             <FormattedMessage
               defaultMessage="the User Agreement and Privacy Policy."
+              id="zOZ77e"
               description="src/components/Forms/SelectAuthMethodForm/NormalFeed.tsx"
             />
           </a>

--- a/src/components/AuthMethodFeed/AuthWalletFeed.tsx
+++ b/src/components/AuthMethodFeed/AuthWalletFeed.tsx
@@ -111,12 +111,14 @@ export const AuthWalletFeed: React.FC<Props> = ({
             <p>
               <FormattedMessage
                 defaultMessage="Wallet is linked to a different account"
+                id="Dt1o78"
                 description="src/components/AuthMethodFeed/AuthWalletFeed.tsx"
               />
             </p>
             <p>
               <FormattedMessage
                 defaultMessage="Sign in to that account to unlink it then try again"
+                id="rqS2aA"
                 description="src/components/AuthMethodFeed/AuthWalletFeed.tsx"
               />
             </p>
@@ -127,6 +129,7 @@ export const AuthWalletFeed: React.FC<Props> = ({
             <p>
               <FormattedMessage
                 defaultMessage="Unavailable"
+                id="rADhX5"
                 description="FORBIDDEN_BY_STATE"
               />
             </p>
@@ -136,6 +139,7 @@ export const AuthWalletFeed: React.FC<Props> = ({
           <a href={PATHS.GUIDE} target="_blank">
             <FormattedMessage
               defaultMessage="What is a digital wallet?"
+              id="V5OMr4"
               description="src/components/Forms/SelectAuthMethodForm/WalletFeed.tsx"
             />
           </a>

--- a/src/components/AuthTabs/index.tsx
+++ b/src/components/AuthTabs/index.tsx
@@ -43,6 +43,7 @@ export const AuthTabs = ({
             <a
               aria-label={intl.formatMessage({
                 defaultMessage: 'Discover',
+                id: 'cE4Hfw',
               })}
             >
               {withIcon(IconMatters)({})}
@@ -57,6 +58,7 @@ export const AuthTabs = ({
           ) : (
             <FormattedMessage
               defaultMessage="Sign In"
+              id="3Tg548"
               description="src/components/Forms/SelectAuthMethodForm/AuthTabs.tsx"
             />
           )}
@@ -65,6 +67,7 @@ export const AuthTabs = ({
         <Tabs.Tab onClick={() => setType('wallet')} selected={isWallet}>
           <FormattedMessage
             defaultMessage="Wallet"
+            id="GHxtae"
             description="src/components/Forms/SelectAuthMethodForm/AuthTabs.tsx"
           />
         </Tabs.Tab>

--- a/src/components/BlockUser/Button/index.tsx
+++ b/src/components/BlockUser/Button/index.tsx
@@ -35,6 +35,7 @@ const BlockUserButton = ({
       message: (
         <FormattedMessage
           defaultMessage="User unblocked. User can now comment on your articles."
+          id="mSAY3/"
           description="src/components/BlockUser/Button/index.tsx"
         />
       ),
@@ -47,6 +48,7 @@ const BlockUserButton = ({
         text={
           <FormattedMessage
             defaultMessage="Unblock"
+            id="bBYO6x"
             description="src/components/BlockUser/Button/index.tsx"
           />
         }
@@ -62,7 +64,7 @@ const BlockUserButton = ({
       ariaHasPopup="dialog"
       textColor="greyDarker"
       textActiveColor="black"
-      text={<FormattedMessage defaultMessage="Block User" />}
+      text={<FormattedMessage defaultMessage="Block User" id="vAc1Bw" />}
       icon={<IconMute20 size="mdS" />}
     />
   )

--- a/src/components/BlockUser/Dialog/index.tsx
+++ b/src/components/BlockUser/Dialog/index.tsx
@@ -54,7 +54,7 @@ const BlockUserDialog = ({ user, children }: BlockUserDialogProps) => {
 
       <Dialog isOpen={show} onDismiss={closeDialog}>
         <Dialog.Header
-          title={<FormattedMessage defaultMessage="Block User" />}
+          title={<FormattedMessage defaultMessage="Block User" id="vAc1Bw" />}
         />
 
         <Dialog.Message>

--- a/src/components/Book/index.tsx
+++ b/src/components/Book/index.tsx
@@ -85,6 +85,7 @@ export const Book: React.FC<BookProps> & {
           <p className={styles.count}>
             <FormattedMessage
               defaultMessage="{count} articles"
+              id="b6zdPs"
               description="src/components/Book/index.tsx"
               values={{ count: articleCount }}
             />

--- a/src/components/Buttons/Bookmark/Unsubscribe.tsx
+++ b/src/components/Buttons/Bookmark/Unsubscribe.tsx
@@ -71,6 +71,7 @@ const Unsubscribe = ({
         text={
           <FormattedMessage
             defaultMessage="Undo bookmark"
+            id="ioPWl8"
             description="src/components/Buttons/Bookmark/Unsubscribe.tsx"
           />
         }
@@ -88,6 +89,7 @@ const Unsubscribe = ({
       aria-label={
         <FormattedMessage
           defaultMessage="Undo bookmark"
+          id="ioPWl8"
           description="src/components/Buttons/Bookmark/Unsubscribe.tsx"
         />
       }

--- a/src/components/Buttons/CopyButton.tsx
+++ b/src/components/Buttons/CopyButton.tsx
@@ -14,7 +14,10 @@ export const CopyButton: React.FC<
         <Button
           spacing={['xtight', 'xtight']}
           bgActiveColor="greyLighter"
-          aria-label={intl.formatMessage({ defaultMessage: 'Copy' })}
+          aria-label={intl.formatMessage({
+            defaultMessage: 'Copy',
+            id: '4l6vz1',
+          })}
         >
           <IconCopy16 color="grey" />
         </Button>

--- a/src/components/Buttons/Login/index.tsx
+++ b/src/components/Buttons/Login/index.tsx
@@ -47,6 +47,7 @@ export const LoginButton: React.FC<LoginButtonProps> = ({
     <TextIcon color={textIconColor} size={textIconSize} weight="md">
       <FormattedMessage
         defaultMessage="Log in"
+        id="skbUBl"
         description="src/components/Buttons/Login/index.tsx"
       />
     </TextIcon>

--- a/src/components/Buttons/Shuffle.tsx
+++ b/src/components/Buttons/Shuffle.tsx
@@ -26,7 +26,7 @@ export const ShuffleButton: React.FC<ShuffleButtonProps> = ({
       size="xs"
       weight="md"
     >
-      <FormattedMessage defaultMessage="Shuffle" />
+      <FormattedMessage defaultMessage="Shuffle" id="Pp/0po" />
     </TextIcon>
   </Button>
 )

--- a/src/components/Buttons/SignUp/index.tsx
+++ b/src/components/Buttons/SignUp/index.tsx
@@ -55,7 +55,7 @@ export const SignUpButton: React.FC<
   }
   const ButtonText = () => (
     <TextIcon color="white" weight="md">
-      <FormattedMessage defaultMessage="Register" />
+      <FormattedMessage defaultMessage="Register" id="deEeEI" />
     </TextIcon>
   )
 

--- a/src/components/Buttons/ViewAll/index.tsx
+++ b/src/components/Buttons/ViewAll/index.tsx
@@ -14,7 +14,7 @@ export const ViewAllButton: React.FC<ViewAllButtonProps> = ({ ...props }) => {
       {...props}
     >
       <TextIcon color="green" size="xs" weight="md" textPlacement="left">
-        <FormattedMessage defaultMessage="View All" />
+        <FormattedMessage defaultMessage="View All" id="wbcwKd" />
       </TextIcon>
     </Button>
   )

--- a/src/components/CircleDigest/Price/index.tsx
+++ b/src/components/CircleDigest/Price/index.tsx
@@ -103,7 +103,7 @@ const Price = ({ circle, onClick }: PriceProps) => {
     >
       <TextIcon weight="md" size="sm" color="white">
         {price.amount} {price.currency} /
-        <FormattedMessage defaultMessage="month" />
+        <FormattedMessage defaultMessage="month" id="Cu3Cty" />
       </TextIcon>
     </Button>
   )

--- a/src/components/CircleDigest/UserProfile/index.tsx
+++ b/src/components/CircleDigest/UserProfile/index.tsx
@@ -39,6 +39,7 @@ const UserProfile = ({
             {!hasDescription && !hasFooter && (
               <FormattedMessage
                 defaultMessage="Circle："
+                id="5iii3x"
                 description="src/components/CircleDigest/UserProfile/index.tsx"
               />
             )}
@@ -57,6 +58,7 @@ const UserProfile = ({
             <Button textColor="greyDarker" textActiveColor="green">
               <FormattedMessage
                 defaultMessage="Enter Circle"
+                id="JaLEXz"
                 description="src/components/CircleDigest/UserProfile/index.tsx"
               />
             </Button>

--- a/src/components/CollectionDigest/DropdownActions/DeleteCollection/Button.tsx
+++ b/src/components/CollectionDigest/DropdownActions/DeleteCollection/Button.tsx
@@ -5,7 +5,7 @@ import { IconTrash20, Menu } from '~/components'
 const DeleteCollectionButton = ({ openDialog }: { openDialog: () => void }) => {
   return (
     <Menu.Item
-      text={<FormattedMessage defaultMessage="Delete collection" />}
+      text={<FormattedMessage defaultMessage="Delete collection" id="m4GG4b" />}
       icon={<IconTrash20 size="mdS" />}
       onClick={openDialog}
       ariaHasPopup="dialog"

--- a/src/components/CollectionDigest/DropdownActions/DeleteCollection/Dialog.tsx
+++ b/src/components/CollectionDigest/DropdownActions/DeleteCollection/Dialog.tsx
@@ -118,6 +118,7 @@ const DeleteCollectionDialog = ({
       message: (
         <FormattedMessage
           defaultMessage="Collection is deleted"
+          id="Ft76YC"
           description="src/components/CollectionDigest/DropdownActions/DeleteCollection/Dialog.tsx"
         />
       ),
@@ -138,7 +139,9 @@ const DeleteCollectionDialog = ({
 
       <Dialog isOpen={show} onDismiss={closeDialog}>
         <Dialog.Header
-          title={<FormattedMessage defaultMessage="Delete collection" />}
+          title={
+            <FormattedMessage defaultMessage="Delete collection" id="m4GG4b" />
+          }
         />
 
         <Dialog.Message>
@@ -146,6 +149,7 @@ const DeleteCollectionDialog = ({
             <p>
               <FormattedMessage
                 defaultMessage="Are you sure you want to delete this collection ‘{collection}’?"
+                id="T9oZC8"
                 values={{
                   collection: (
                     <span className="u-highlight">{collection.title}</span>
@@ -153,12 +157,18 @@ const DeleteCollectionDialog = ({
                 }}
               />
               <br />
-              <FormattedMessage defaultMessage="(Articles in this collection will not be deleted)" />
+              <FormattedMessage
+                defaultMessage="(Articles in this collection will not be deleted)"
+                id="a/xacb"
+              />
             </p>
           )}
           {isInConfirmDelete && (
             <p>
-              <FormattedMessage defaultMessage="This action cannot be undone. Are you sure you want to delete this collection?" />
+              <FormattedMessage
+                defaultMessage="This action cannot be undone. Are you sure you want to delete this collection?"
+                id="Xi40U9"
+              />
             </p>
           )}
         </Dialog.Message>
@@ -168,7 +178,7 @@ const DeleteCollectionDialog = ({
             closeDialog={closeDialog}
             btns={
               <Dialog.RoundedButton
-                text={<FormattedMessage defaultMessage="Delete" />}
+                text={<FormattedMessage defaultMessage="Delete" id="K3r6DQ" />}
                 color="red"
                 onClick={() => {
                   setStep('confirmDelete')
@@ -177,7 +187,7 @@ const DeleteCollectionDialog = ({
             }
             smUpBtns={
               <Dialog.TextButton
-                text={<FormattedMessage defaultMessage="Delete" />}
+                text={<FormattedMessage defaultMessage="Delete" id="K3r6DQ" />}
                 color="red"
                 onClick={() => {
                   setStep('confirmDelete')
@@ -192,7 +202,12 @@ const DeleteCollectionDialog = ({
             closeDialog={closeDialog}
             btns={
               <Dialog.RoundedButton
-                text={<FormattedMessage defaultMessage="Confirm Deletion" />}
+                text={
+                  <FormattedMessage
+                    defaultMessage="Confirm Deletion"
+                    id="W8OZ3G"
+                  />
+                }
                 color={loading ? 'green' : 'red'}
                 onClick={async () => {
                   await onDelete()
@@ -203,7 +218,12 @@ const DeleteCollectionDialog = ({
             }
             smUpBtns={
               <Dialog.TextButton
-                text={<FormattedMessage defaultMessage="Confirm Deletion" />}
+                text={
+                  <FormattedMessage
+                    defaultMessage="Confirm Deletion"
+                    id="W8OZ3G"
+                  />
+                }
                 color={loading ? 'green' : 'red'}
                 onClick={async () => {
                   await onDelete()

--- a/src/components/CollectionDigest/DropdownActions/EditCollection/Button.tsx
+++ b/src/components/CollectionDigest/DropdownActions/EditCollection/Button.tsx
@@ -5,7 +5,7 @@ import { IconEdit20, Menu } from '~/components'
 const EditCollectionButton = ({ openDialog }: { openDialog: () => void }) => {
   return (
     <Menu.Item
-      text={<FormattedMessage defaultMessage="Edit collection" />}
+      text={<FormattedMessage defaultMessage="Edit collection" id="WQT8ZA" />}
       icon={<IconEdit20 size="mdS" />}
       onClick={openDialog}
       ariaHasPopup="dialog"

--- a/src/components/CollectionDigest/DropdownActions/EditCollection/Dialog/Content.tsx
+++ b/src/components/CollectionDigest/DropdownActions/EditCollection/Dialog/Content.tsx
@@ -71,6 +71,7 @@ const EditCollectionDialogContent: React.FC<FormProps> = ({
     if (!value) {
       return intl.formatMessage({
         defaultMessage: 'Required',
+        id: 'Seanpx',
       })
     }
   }
@@ -149,6 +150,7 @@ const EditCollectionDialogContent: React.FC<FormProps> = ({
         required
         placeholder={intl.formatMessage({
           defaultMessage: 'Collection name',
+          id: 'A6ozr9',
         })}
         value={values.title}
         hint={`${values.title.length}/${MAX_COLLECTION_TITLE_LENGTH}`}
@@ -165,6 +167,7 @@ const EditCollectionDialogContent: React.FC<FormProps> = ({
         name="description"
         placeholder={intl.formatMessage({
           defaultMessage: 'Description',
+          id: 'Q8Qw5B',
         })}
         maxLength={MAX_COLLECTION_DESCRIPTION_LENGTH}
         value={values.description}
@@ -182,7 +185,7 @@ const EditCollectionDialogContent: React.FC<FormProps> = ({
       type="submit"
       form={formId}
       disabled={isSubmitting || coverLoading}
-      text={<FormattedMessage defaultMessage="Confirm" />}
+      text={<FormattedMessage defaultMessage="Confirm" id="N2IrpM" />}
       loading={isSubmitting || coverLoading}
     />
   )
@@ -190,7 +193,9 @@ const EditCollectionDialogContent: React.FC<FormProps> = ({
   return (
     <>
       <Dialog.Header
-        title={<FormattedMessage defaultMessage="Edit collection" />}
+        title={
+          <FormattedMessage defaultMessage="Edit collection" id="WQT8ZA" />
+        }
         closeDialog={closeDialog}
         rightBtn={SubmitButton}
       />
@@ -201,7 +206,7 @@ const EditCollectionDialogContent: React.FC<FormProps> = ({
         smUpBtns={
           <>
             <Dialog.TextButton
-              text={<FormattedMessage defaultMessage="Cancel" />}
+              text={<FormattedMessage defaultMessage="Cancel" id="47FYwb" />}
               color="greyDarker"
               onClick={closeDialog}
             />

--- a/src/components/CollectionDigest/DropdownActions/PinButton.tsx
+++ b/src/components/CollectionDigest/DropdownActions/PinButton.tsx
@@ -59,15 +59,20 @@ const PinButton = ({
       onCompleted: () => {
         toast.success({
           message: collection.pinned ? (
-            <FormattedMessage defaultMessage="Unpinned from profile" />
+            <FormattedMessage
+              defaultMessage="Unpinned from profile"
+              id="Ihwz5K"
+            />
           ) : (
-            <FormattedMessage defaultMessage="Pinned to profile" />
+            <FormattedMessage defaultMessage="Pinned to profile" id="XuYhBC" />
           ),
           actions: collection.pinned
             ? undefined
             : [
                 {
-                  content: <FormattedMessage defaultMessage="View" />,
+                  content: (
+                    <FormattedMessage defaultMessage="View" id="FgydNe" />
+                  ),
                   href: toPath({
                     page: 'userProfile',
                     userName: collection.author.userName!,
@@ -81,7 +86,10 @@ const PinButton = ({
       toastType: 'success',
       customErrors: {
         [ERROR_CODES.ACTION_LIMIT_EXCEEDED]: (
-          <FormattedMessage defaultMessage="Up to 3 articles/collections can be pinned" />
+          <FormattedMessage
+            defaultMessage="Up to 3 articles/collections can be pinned"
+            id="2oxLHg"
+          />
         ),
       },
     }
@@ -93,11 +101,13 @@ const PinButton = ({
         collection.pinned ? (
           <FormattedMessage
             defaultMessage="Unpin from profile"
+            id="DyuHBH"
             description="src/components/CollectionDigest/DropdownActions/PinButton.tsx"
           />
         ) : (
           <FormattedMessage
             defaultMessage="Pin to profile"
+            id="xOUZu2"
             description="src/components/CollectionDigest/DropdownActions/PinButton.tsx"
           />
         )

--- a/src/components/CollectionDigest/Feed/index.tsx
+++ b/src/components/CollectionDigest/Feed/index.tsx
@@ -62,6 +62,7 @@ const BaseCollectionDigestFeed = ({
             <p className={styles.articleCount}>
               <FormattedMessage
                 defaultMessage="{articleCount} articles"
+                id="oHQmBt"
                 description="src/components/CollectionDigest/Feed/index.tsx"
                 values={{ articleCount }}
               />
@@ -79,6 +80,7 @@ const BaseCollectionDigestFeed = ({
               <span className={styles.articleCount}>
                 <FormattedMessage
                   defaultMessage="{articleCount} articles"
+                  id="oHQmBt"
                   description="src/components/CollectionDigest/Feed/index.tsx"
                   values={{ articleCount }}
                 />
@@ -91,6 +93,7 @@ const BaseCollectionDigestFeed = ({
               <span>
                 <FormattedMessage
                   defaultMessage="upadted {date}"
+                  id="C8GQaD"
                   description="src/components/CollectionDigest/Feed/index.tsx"
                   values={{
                     date: <DateTime date={updatedAt} color="grey" />,

--- a/src/components/Comment/DropdownActions/CollapseComment/Button.tsx
+++ b/src/components/Comment/DropdownActions/CollapseComment/Button.tsx
@@ -8,6 +8,7 @@ const CollapseCommentButton = ({ openDialog }: { openDialog: () => void }) => {
       text={
         <FormattedMessage
           defaultMessage="Collapse"
+          id="pRV+UD"
           description="src/components/Comment/DropdownActions/CollapseComment/Button.tsx"
         />
       }

--- a/src/components/Comment/DropdownActions/CollapseComment/Dialog.tsx
+++ b/src/components/Comment/DropdownActions/CollapseComment/Dialog.tsx
@@ -94,7 +94,7 @@ const CollapseCommentDialog = ({
           closeDialog={closeDialog}
           btns={
             <Dialog.RoundedButton
-              text={<FormattedMessage defaultMessage="Confirm" />}
+              text={<FormattedMessage defaultMessage="Confirm" id="N2IrpM" />}
               color="red"
               onClick={() => {
                 onCollapse()
@@ -104,7 +104,7 @@ const CollapseCommentDialog = ({
           }
           smUpBtns={
             <Dialog.TextButton
-              text={<FormattedMessage defaultMessage="Confirm" />}
+              text={<FormattedMessage defaultMessage="Confirm" id="N2IrpM" />}
               color="red"
               onClick={() => {
                 onCollapse()

--- a/src/components/Comment/DropdownActions/DeleteComment/Button.tsx
+++ b/src/components/Comment/DropdownActions/DeleteComment/Button.tsx
@@ -5,7 +5,7 @@ import { IconRemove24, Menu } from '~/components'
 const DeleteCommentButton = ({ openDialog }: { openDialog: () => void }) => {
   return (
     <Menu.Item
-      text={<FormattedMessage defaultMessage="Delete" />}
+      text={<FormattedMessage defaultMessage="Delete" id="K3r6DQ" />}
       icon={<IconRemove24 size="mdS" />}
       onClick={openDialog}
       ariaHasPopup="dialog"

--- a/src/components/Comment/DropdownActions/DeleteComment/Dialog.tsx
+++ b/src/components/Comment/DropdownActions/DeleteComment/Dialog.tsx
@@ -59,6 +59,7 @@ const DeleteCommentDialog = ({
       message: (
         <FormattedMessage
           defaultMessage="{commentType} has been deleted"
+          id="h9CG9E"
           description="src/components/Comment/DropdownActions/DeleteComment/Dialog.tsx"
           values={{
             commentType: COMMENT_TYPE_TEXT[lang][type],
@@ -77,6 +78,7 @@ const DeleteCommentDialog = ({
           title={
             <FormattedMessage
               defaultMessage="Delete {commentType}"
+              id="Cdkhl8"
               description="src/components/Comment/DropdownActions/DeleteComment/Dialog.tsx"
               values={{
                 commentType: COMMENT_TYPE_TEXT[lang][type],
@@ -89,6 +91,7 @@ const DeleteCommentDialog = ({
           <p>
             <FormattedMessage
               defaultMessage="After deletion, the {commentType} will be removed immediately"
+              id="77tYPg"
               description="src/components/Comment/DropdownActions/DeleteComment/Dialog.tsx"
               values={{
                 commentType: COMMENT_TYPE_TEXT[lang][type],
@@ -101,7 +104,7 @@ const DeleteCommentDialog = ({
           closeDialog={closeDialog}
           btns={
             <Dialog.RoundedButton
-              text={<FormattedMessage defaultMessage="Confirm" />}
+              text={<FormattedMessage defaultMessage="Confirm" id="N2IrpM" />}
               color="red"
               onClick={() => {
                 onDelete()
@@ -111,7 +114,7 @@ const DeleteCommentDialog = ({
           }
           smUpBtns={
             <Dialog.TextButton
-              text={<FormattedMessage defaultMessage="Confirm" />}
+              text={<FormattedMessage defaultMessage="Confirm" id="N2IrpM" />}
               color="red"
               onClick={() => {
                 onDelete()

--- a/src/components/Comment/DropdownActions/EditButton.tsx
+++ b/src/components/Comment/DropdownActions/EditButton.tsx
@@ -12,6 +12,7 @@ const EditButton = ({ openEditCommentDialog }: EditButtonProps) => {
       text={
         <FormattedMessage
           defaultMessage="Edit"
+          id="mikY/9"
           description="src/components/Comment/DropdownActions/EditButton.tsx"
         />
       }

--- a/src/components/Comment/DropdownActions/PinButton.tsx
+++ b/src/components/Comment/DropdownActions/PinButton.tsx
@@ -108,11 +108,13 @@ const PinButton = ({
           circle ? (
             <FormattedMessage
               defaultMessage="Unpin Broadcast"
+              id="RFzVUD"
               description="src/components/Comment/DropdownActions/PinButton.tsx"
             />
           ) : (
             <FormattedMessage
               defaultMessage="Unpin Comment"
+              id="X+Xvgq"
               description="src/components/Comment/DropdownActions/PinButton.tsx"
             />
           )
@@ -132,11 +134,13 @@ const PinButton = ({
         circle ? (
           <FormattedMessage
             defaultMessage="Pin Broadcast"
+            id="AGcU5J"
             description="src/components/Comment/DropdownActions/PinButton.tsx"
           />
         ) : (
           <FormattedMessage
             defaultMessage="Pin Comment"
+            id="jJ1Brc"
             description="src/components/Comment/DropdownActions/PinButton.tsx"
           />
         )

--- a/src/components/Comment/FooterActions/index.tsx
+++ b/src/components/Comment/FooterActions/index.tsx
@@ -127,7 +127,10 @@ const BaseFooterActions = ({
     onClick = () =>
       toast.error({
         message: (
-          <FormattedMessage defaultMessage="The author has disabled comments for this article" />
+          <FormattedMessage
+            defaultMessage="The author has disabled comments for this article"
+            id="7cwoRo"
+          />
         ),
       })
   }

--- a/src/components/Dialog/Footer/index.tsx
+++ b/src/components/Dialog/Footer/index.tsx
@@ -28,7 +28,9 @@ const Footer: React.FC<FooterProps> = ({
     return null
   }
 
-  const text = closeText || <FormattedMessage defaultMessage="Cancel" />
+  const text = closeText || (
+    <FormattedMessage defaultMessage="Cancel" id="47FYwb" />
+  )
 
   const footerClasses = classNames({
     [styles.footer]: true,

--- a/src/components/Dialog/Handle.tsx
+++ b/src/components/Dialog/Handle.tsx
@@ -13,7 +13,7 @@ const Handle: React.FC<HandleProps> = ({ closeDialog, ...props }) => {
     <button
       type="button"
       className={styles.handle}
-      aria-label={intl.formatMessage({ defaultMessage: 'Close' })}
+      aria-label={intl.formatMessage({ defaultMessage: 'Close', id: 'rbrahO' })}
       onClick={closeDialog}
       {...props}
     >

--- a/src/components/Dialog/Header/index.tsx
+++ b/src/components/Dialog/Header/index.tsx
@@ -32,7 +32,9 @@ const Header: React.FC<HeaderProps> = ({
   closeText,
   closeDialog,
 }) => {
-  const text = closeText || <FormattedMessage defaultMessage="Cancel" />
+  const text = closeText || (
+    <FormattedMessage defaultMessage="Cancel" id="47FYwb" />
+  )
 
   return (
     <>

--- a/src/components/DialogBeta/Footer/index.tsx
+++ b/src/components/DialogBeta/Footer/index.tsx
@@ -24,7 +24,9 @@ const Footer: React.FC<FooterProps> = ({
     return null
   }
 
-  const text = closeText || <FormattedMessage defaultMessage="Cancel" />
+  const text = closeText || (
+    <FormattedMessage defaultMessage="Cancel" id="47FYwb" />
+  )
 
   const footerClasses = classNames({
     [styles.footer]: true,

--- a/src/components/DialogBeta/Handle.tsx
+++ b/src/components/DialogBeta/Handle.tsx
@@ -13,7 +13,7 @@ const Handle: React.FC<HandleProps> = ({ closeDialog, ...props }) => {
     <button
       type="button"
       className={styles.handle}
-      aria-label={intl.formatMessage({ defaultMessage: 'Close' })}
+      aria-label={intl.formatMessage({ defaultMessage: 'Close', id: 'rbrahO' })}
       onClick={closeDialog}
       {...props}
     >

--- a/src/components/Dialogs/AddArticlesCollectionDialog/SearchInput/index.tsx
+++ b/src/components/Dialogs/AddArticlesCollectionDialog/SearchInput/index.tsx
@@ -25,7 +25,10 @@ const SearchInput: React.FC<SearchInputProps> = ({
 }) => {
   const fieldId = `search-input`
   const intl = useIntl()
-  const searchCopy = intl.formatMessage({ defaultMessage: 'Search' })
+  const searchCopy = intl.formatMessage({
+    defaultMessage: 'Search',
+    id: 'xmcVZ0',
+  })
   const { lang } = useContext(LanguageContext)
 
   return (

--- a/src/components/Dialogs/AddArticlesCollectionDialog/SearchingDialogContent.tsx
+++ b/src/components/Dialogs/AddArticlesCollectionDialog/SearchingDialogContent.tsx
@@ -46,6 +46,7 @@ const SearchingDialogContent: React.FC<SearchingDialogContentProps> = ({
       <section className={styles.emptyResult}>
         <FormattedMessage
           defaultMessage="No results"
+          id="7jjWxF"
           description="src/components/Dialogs/AddArticlesCollectionDialog/SearchingDialogContent.tsx"
         />
       </section>

--- a/src/components/Dialogs/AddArticlesCollectionDialog/index.tsx
+++ b/src/components/Dialogs/AddArticlesCollectionDialog/index.tsx
@@ -139,7 +139,7 @@ const BaseAddArticlesCollectionDialog = ({
       type="submit"
       form={formId}
       disabled={formik.isSubmitting || formik.values.checked.length === 0}
-      text={<FormattedMessage defaultMessage="Confirm" />}
+      text={<FormattedMessage defaultMessage="Confirm" id="N2IrpM" />}
       loading={formik.isSubmitting}
     />
   )
@@ -173,7 +173,9 @@ const BaseAddArticlesCollectionDialog = ({
 
       <Dialog isOpen={show} onDismiss={closeDialog}>
         <Dialog.Header
-          title={<FormattedMessage defaultMessage="Add to collection" />}
+          title={
+            <FormattedMessage defaultMessage="Add to collection" id="ub1kHa" />
+          }
           closeDialog={closeDialog}
           rightBtn={SubmitButton}
         />
@@ -210,7 +212,7 @@ const BaseAddArticlesCollectionDialog = ({
           smUpBtns={
             <>
               <Dialog.TextButton
-                text={<FormattedMessage defaultMessage="Cancel" />}
+                text={<FormattedMessage defaultMessage="Cancel" id="47FYwb" />}
                 color="greyDarker"
                 onClick={closeDialog}
               />

--- a/src/components/Dialogs/AddCollectionDialog/Content.tsx
+++ b/src/components/Dialogs/AddCollectionDialog/Content.tsx
@@ -137,6 +137,7 @@ const AddCollectionDialogContent: React.FC<FormProps> = ({
         required
         placeholder={intl.formatMessage({
           defaultMessage: 'Collection Name',
+          id: 'VZsE96',
         })}
         value={values.title}
         hint={`${values.title.length}/${maxCollectionTitle}`}
@@ -159,7 +160,7 @@ const AddCollectionDialogContent: React.FC<FormProps> = ({
       type="submit"
       form={formId}
       disabled={isSubmitting}
-      text={<FormattedMessage defaultMessage="Create" />}
+      text={<FormattedMessage defaultMessage="Create" id="VzzYJk" />}
       loading={isSubmitting}
     />
   )
@@ -167,7 +168,7 @@ const AddCollectionDialogContent: React.FC<FormProps> = ({
   return (
     <>
       <Dialog.Header
-        title={<FormattedMessage defaultMessage="New Collection" />}
+        title={<FormattedMessage defaultMessage="New Collection" id="L4Fcr8" />}
         closeDialog={closeDialog}
         rightBtn={SubmitButton}
       />
@@ -178,7 +179,7 @@ const AddCollectionDialogContent: React.FC<FormProps> = ({
         smUpBtns={
           <>
             <Dialog.TextButton
-              text={<FormattedMessage defaultMessage="Cancel" />}
+              text={<FormattedMessage defaultMessage="Cancel" id="47FYwb" />}
               color="greyDarker"
               onClick={closeDialog}
             />

--- a/src/components/Dialogs/AddCollectionsArticleDialog/SelectDialogContent.tsx
+++ b/src/components/Dialogs/AddCollectionsArticleDialog/SelectDialogContent.tsx
@@ -67,7 +67,7 @@ const SelectDialogContent: React.FC<SelectDialogContentProps> = ({
           type="submit"
           form={formId}
           disabled={formik.isSubmitting || checkingIds.length === 0}
-          text={<FormattedMessage defaultMessage="Confirm" />}
+          text={<FormattedMessage defaultMessage="Confirm" id="N2IrpM" />}
           loading={formik.isSubmitting}
         />
       </>
@@ -76,7 +76,9 @@ const SelectDialogContent: React.FC<SelectDialogContentProps> = ({
   return (
     <>
       <Dialog.Header
-        title={<FormattedMessage defaultMessage="Add to collection" />}
+        title={
+          <FormattedMessage defaultMessage="Add to collection" id="ub1kHa" />
+        }
         closeDialog={closeDialog}
         rightBtn={SubmitButton}
       />
@@ -115,7 +117,7 @@ const SelectDialogContent: React.FC<SelectDialogContentProps> = ({
 
         <button className={styles.button} onClick={switchToCreating}>
           <TextIcon icon={<IconAdd20 size="mdS" />}>
-            <FormattedMessage defaultMessage="New Collection" />
+            <FormattedMessage defaultMessage="New Collection" id="L4Fcr8" />
           </TextIcon>
         </button>
       </section>
@@ -124,7 +126,7 @@ const SelectDialogContent: React.FC<SelectDialogContentProps> = ({
         smUpBtns={
           <>
             <Dialog.TextButton
-              text={<FormattedMessage defaultMessage="Cancel" />}
+              text={<FormattedMessage defaultMessage="Cancel" id="47FYwb" />}
               color="greyDarker"
               onClick={closeDialog}
             />

--- a/src/components/Dialogs/AddCollectionsArticleDialog/index.tsx
+++ b/src/components/Dialogs/AddCollectionsArticleDialog/index.tsx
@@ -96,6 +96,7 @@ const BaseAddCollectionsArticleDialog = ({
         message: (
           <FormattedMessage
             defaultMessage="Successfully added"
+            id="6q0G5e"
             description="src/components/Dialogs/CollectionSelectDialog/index.tsx"
           />
         ),
@@ -106,6 +107,7 @@ const BaseAddCollectionsArticleDialog = ({
                   content: (
                     <FormattedMessage
                       defaultMessage="View"
+                      id="IKPYe9"
                       description="src/components/Dialogs/CollectionSelectDialog/index.tsx"
                     />
                   ),

--- a/src/components/Dialogs/AddWalletLoginDialog/Content.tsx
+++ b/src/components/Dialogs/AddWalletLoginDialog/Content.tsx
@@ -24,12 +24,13 @@ const AddWalletLoginDialogContent: React.FC<Props> = ({ closeDialog }) => {
         title={
           <FormattedMessage
             defaultMessage="Connect wallet"
+            id="Me5cJu"
             description="src/components/Dialogs/AddWalletLoginDialog/Content.tsx"
           />
         }
         leftBtn={
           <DialogBeta.TextButton
-            text={<FormattedMessage defaultMessage="Close" />}
+            text={<FormattedMessage defaultMessage="Close" id="rbrahO" />}
             color="greyDarker"
             onClick={closeDialog}
           />
@@ -53,7 +54,7 @@ const AddWalletLoginDialogContent: React.FC<Props> = ({ closeDialog }) => {
             smUpBtns={
               <>
                 <DialogBeta.TextButton
-                  text={<FormattedMessage defaultMessage="Close" />}
+                  text={<FormattedMessage defaultMessage="Close" id="rbrahO" />}
                   color="greyDarker"
                   onClick={closeDialog}
                 />

--- a/src/components/Dialogs/AppreciatorsDialog/Content.tsx
+++ b/src/components/Dialogs/AppreciatorsDialog/Content.tsx
@@ -111,7 +111,7 @@ const AppreciatorsDialogContent = ({
           />
         }
         closeDialog={closeDialog}
-        closeText={<FormattedMessage defaultMessage="Close" />}
+        closeText={<FormattedMessage defaultMessage="Close" id="rbrahO" />}
       />
 
       <Dialog.Content noSpacing>
@@ -149,7 +149,7 @@ const AppreciatorsDialogContent = ({
       <Dialog.Footer
         smUpBtns={
           <Dialog.TextButton
-            text={<FormattedMessage defaultMessage="Close" />}
+            text={<FormattedMessage defaultMessage="Close" id="rbrahO" />}
             color="greyDarker"
             onClick={closeDialog}
           />

--- a/src/components/Dialogs/BindEmailHintDialog/Content.tsx
+++ b/src/components/Dialogs/BindEmailHintDialog/Content.tsx
@@ -25,6 +25,7 @@ const Content: React.FC<Props> = ({ closeDialog }) => {
         title={
           <FormattedMessage
             defaultMessage="Please connect email"
+            id="Me4s4Q"
             description="src/components/Dialogs/BindEmailHintDialog/index.tsx"
           />
         }
@@ -33,6 +34,7 @@ const Content: React.FC<Props> = ({ closeDialog }) => {
         <p>
           <FormattedMessage
             defaultMessage="You have not connected your email yet. For security, email is required for top-up."
+            id="Dq29Hb"
             description="src/components/Dialogs/BindEmailHintDialog/index.tsx"
           />
         </p>
@@ -44,13 +46,14 @@ const Content: React.FC<Props> = ({ closeDialog }) => {
               text={
                 <FormattedMessage
                   defaultMessage="Go to Settings"
+                  id="XfRKZY"
                   description="src/components/Dialogs/BindEmailHintDialog/index.tsx"
                 />
               }
               onClick={gotoBindEmail}
             />
             <Dialog.RoundedButton
-              text={<FormattedMessage defaultMessage="Cancel" />}
+              text={<FormattedMessage defaultMessage="Cancel" id="47FYwb" />}
               color="greyDarker"
               onClick={closeDialog}
             />
@@ -59,7 +62,7 @@ const Content: React.FC<Props> = ({ closeDialog }) => {
         smUpBtns={
           <>
             <Dialog.TextButton
-              text={<FormattedMessage defaultMessage="Cancel" />}
+              text={<FormattedMessage defaultMessage="Cancel" id="47FYwb" />}
               color="greyDarker"
               onClick={closeDialog}
             />
@@ -67,6 +70,7 @@ const Content: React.FC<Props> = ({ closeDialog }) => {
               text={
                 <FormattedMessage
                   defaultMessage="Go to Settings"
+                  id="XfRKZY"
                   description="src/components/Dialogs/BindEmailHintDialog/index.tsx"
                 />
               }

--- a/src/components/Dialogs/CommentFormDialog/CommentForm/index.tsx
+++ b/src/components/Dialogs/CommentFormDialog/CommentForm/index.tsx
@@ -167,7 +167,7 @@ const CommentForm: React.FC<CommentFormProps> = ({
         smUpBtns={
           <>
             <Dialog.TextButton
-              text={<FormattedMessage defaultMessage="Cancel" />}
+              text={<FormattedMessage defaultMessage="Cancel" id="47FYwb" />}
               color="greyDarker"
               onClick={closeDialog}
             />

--- a/src/components/Dialogs/ENSDialog/LinkENS.tsx
+++ b/src/components/Dialogs/ENSDialog/LinkENS.tsx
@@ -108,7 +108,7 @@ const LinkENS = ({
 
   const CancelButton = () => (
     <Dialog.TextButton
-      text={<FormattedMessage defaultMessage="Cancel" />}
+      text={<FormattedMessage defaultMessage="Cancel" id="47FYwb" />}
       color="greyDarker"
       onClick={closeDialog}
     />
@@ -196,12 +196,18 @@ const LinkENS = ({
               <CopyToClipboard
                 text={viewer.info.ethAddress || ''}
                 successMessage={
-                  <FormattedMessage defaultMessage="Address copied" />
+                  <FormattedMessage
+                    defaultMessage="Address copied"
+                    id="+aMAeT"
+                  />
                 }
               >
                 <Button
                   spacing={['xtight', 'xtight']}
-                  aria-label={intl.formatMessage({ defaultMessage: 'Copy' })}
+                  aria-label={intl.formatMessage({
+                    defaultMessage: 'Copy',
+                    id: '4l6vz1',
+                  })}
                 >
                   <TextIcon
                     icon={<IconCopy16 color="black" size="xs" />}

--- a/src/components/Dialogs/EditProfileDialog/Content.tsx
+++ b/src/components/Dialogs/EditProfileDialog/Content.tsx
@@ -85,6 +85,7 @@ const EditProfileDialogContent: React.FC<FormProps> = ({
       return intl.formatMessage(
         {
           defaultMessage: 'Over 140 words, current {numbers}',
+          id: 'DUoV1W',
           description: 'src/components/Dialogs/EditProfileDialog/Content.tsx',
         },
         {
@@ -134,7 +135,7 @@ const EditProfileDialogContent: React.FC<FormProps> = ({
         })
 
         toast.success({
-          message: <FormattedMessage defaultMessage="Saved" />,
+          message: <FormattedMessage defaultMessage="Saved" id="fsB/4p" />,
         })
 
         setSubmitting(false)
@@ -150,6 +151,7 @@ const EditProfileDialogContent: React.FC<FormProps> = ({
               intl.formatMessage({
                 defaultMessage:
                   'Must be between 2-20 characters long. Chinese characters, letters, numbers and underscores are allowed.',
+                id: 'E8W3qa',
               })
             )
           } else {
@@ -193,6 +195,7 @@ const EditProfileDialogContent: React.FC<FormProps> = ({
         required
         placeholder={intl.formatMessage({
           defaultMessage: 'Name',
+          id: 'HAlOn1',
         })}
         value={values.displayName}
         hint={`${values.displayName.length}/${MAX_USER_DISPLAY_NAME_LENGTH}`}
@@ -209,6 +212,7 @@ const EditProfileDialogContent: React.FC<FormProps> = ({
         name="description"
         placeholder={intl.formatMessage({
           defaultMessage: 'Bio',
+          id: '2W0f9h',
         })}
         maxLength={MAX_USER_DESCRIPTION_LENGTH}
         value={values.description}
@@ -226,7 +230,7 @@ const EditProfileDialogContent: React.FC<FormProps> = ({
       type="submit"
       form={formId}
       disabled={isSubmitting || coverLoading || avatarLoading}
-      text={<FormattedMessage defaultMessage="Confirm" />}
+      text={<FormattedMessage defaultMessage="Confirm" id="N2IrpM" />}
       loading={isSubmitting || coverLoading || avatarLoading}
     />
   )
@@ -234,7 +238,7 @@ const EditProfileDialogContent: React.FC<FormProps> = ({
   return (
     <>
       <Dialog.Header
-        title={<FormattedMessage defaultMessage="Edit profile" />}
+        title={<FormattedMessage defaultMessage="Edit profile" id="nYrKWp" />}
         closeDialog={closeDialog}
         rightBtn={SubmitButton}
         hasSmUpTitle={false}
@@ -246,7 +250,7 @@ const EditProfileDialogContent: React.FC<FormProps> = ({
         smUpBtns={
           <>
             <Dialog.TextButton
-              text={<FormattedMessage defaultMessage="Cancel" />}
+              text={<FormattedMessage defaultMessage="Cancel" id="47FYwb" />}
               color="greyDarker"
               onClick={closeDialog}
             />

--- a/src/components/Dialogs/EditTagDialog/Content.tsx
+++ b/src/components/Dialogs/EditTagDialog/Content.tsx
@@ -112,7 +112,7 @@ const EditTagDialogContent: React.FC<BaseEditTagDialogContentProps> = ({
         })
 
         toast.success({
-          message: <FormattedMessage defaultMessage="Saved" />,
+          message: <FormattedMessage defaultMessage="Saved" id="fsB/4p" />,
         })
 
         setSubmitting(false)
@@ -145,10 +145,13 @@ const EditTagDialogContent: React.FC<BaseEditTagDialogContentProps> = ({
       </section>
 
       <Form.Input
-        label={intl.formatMessage({ defaultMessage: 'Tag Name' })}
+        label={intl.formatMessage({ defaultMessage: 'Tag Name', id: 'rLlTQ9' })}
         type="text"
         name="newContent"
-        placeholder={intl.formatMessage({ defaultMessage: 'Tag Name' })}
+        placeholder={intl.formatMessage({
+          defaultMessage: 'Tag Name',
+          id: 'rLlTQ9',
+        })}
         value={values.newContent}
         onBlur={handleBlur}
         onChange={(e) => {
@@ -165,9 +168,15 @@ const EditTagDialogContent: React.FC<BaseEditTagDialogContentProps> = ({
       />
 
       <Form.Textarea
-        label={intl.formatMessage({ defaultMessage: 'Tag Description' })}
+        label={intl.formatMessage({
+          defaultMessage: 'Tag Description',
+          id: 'k0ooDW',
+        })}
         name="newDescription"
-        placeholder={intl.formatMessage({ defaultMessage: 'Tag Description' })}
+        placeholder={intl.formatMessage({
+          defaultMessage: 'Tag Description',
+          id: 'k0ooDW',
+        })}
         value={values.newDescription}
         onBlur={handleBlur}
         onChange={handleChange}
@@ -184,7 +193,7 @@ const EditTagDialogContent: React.FC<BaseEditTagDialogContentProps> = ({
 
   const SubmitButton = (
     <Dialog.TextButton
-      text={<FormattedMessage defaultMessage="Confirm" />}
+      text={<FormattedMessage defaultMessage="Confirm" id="N2IrpM" />}
       type="submit"
       form={formId}
       disabled={isSubmitting || coverLoading}
@@ -195,7 +204,7 @@ const EditTagDialogContent: React.FC<BaseEditTagDialogContentProps> = ({
   return (
     <>
       <Dialog.Header
-        title={<FormattedMessage defaultMessage="Edit Tag" />}
+        title={<FormattedMessage defaultMessage="Edit Tag" id="uJkv2X" />}
         closeDialog={closeDialog}
         rightBtn={SubmitButton}
         hasSmUpTitle={false}
@@ -207,7 +216,7 @@ const EditTagDialogContent: React.FC<BaseEditTagDialogContentProps> = ({
         smUpBtns={
           <>
             <Dialog.TextButton
-              text={<FormattedMessage defaultMessage="Cancel" />}
+              text={<FormattedMessage defaultMessage="Cancel" id="47FYwb" />}
               color="greyDarker"
               onClick={closeDialog}
             />

--- a/src/components/Dialogs/FingerprintDialog/ArticleSecret.tsx
+++ b/src/components/Dialogs/FingerprintDialog/ArticleSecret.tsx
@@ -50,7 +50,10 @@ const ArticleSecretSection: React.FC<ArticleSecretSectionProps> = ({ id }) => {
       <section className={styles.key}>
         <CopyToClipboard text={secret}>
           <button
-            aria-label={intl.formatMessage({ defaultMessage: 'Copy' })}
+            aria-label={intl.formatMessage({
+              defaultMessage: 'Copy',
+              id: '4l6vz1',
+            })}
             className={styles.copyButton}
           >
             <TextIcon

--- a/src/components/Dialogs/FingerprintDialog/Content.tsx
+++ b/src/components/Dialogs/FingerprintDialog/Content.tsx
@@ -212,7 +212,10 @@ const FingerprintDialogContent = ({
               </div>
               <CopyToClipboard text={dataHash}>
                 <Button
-                  aria-label={intl.formatMessage({ defaultMessage: 'Copy' })}
+                  aria-label={intl.formatMessage({
+                    defaultMessage: 'Copy',
+                    id: '4l6vz1',
+                  })}
                 >
                   <IconCopy16 />
                 </Button>

--- a/src/components/Dialogs/FingerprintDialog/index.tsx
+++ b/src/components/Dialogs/FingerprintDialog/index.tsx
@@ -125,7 +125,7 @@ const BaseFingerprintDialog = ({
         <Dialog.Footer
           smUpBtns={
             <Dialog.TextButton
-              text={<FormattedMessage defaultMessage="Close" />}
+              text={<FormattedMessage defaultMessage="Close" id="rbrahO" />}
               color="greyDarker"
               onClick={closeDialog}
             />

--- a/src/components/Dialogs/LikeCoinDialog/Content/Complete.tsx
+++ b/src/components/Dialogs/LikeCoinDialog/Content/Complete.tsx
@@ -21,7 +21,7 @@ const Complete: React.FC = () => {
       <Dialog.Footer
         btns={
           <Dialog.RoundedButton
-            text={<FormattedMessage defaultMessage="Done" />}
+            text={<FormattedMessage defaultMessage="Done" id="JXdbo8" />}
             onClick={() => {
               redirectToTarget({
                 fallback: 'current',
@@ -31,7 +31,7 @@ const Complete: React.FC = () => {
         }
         smUpBtns={
           <Dialog.TextButton
-            text={<FormattedMessage defaultMessage="Done" />}
+            text={<FormattedMessage defaultMessage="Done" id="JXdbo8" />}
             onClick={() => {
               redirectToTarget({
                 fallback: 'current',

--- a/src/components/Dialogs/LikeCoinDialog/Content/Select/index.tsx
+++ b/src/components/Dialogs/LikeCoinDialog/Content/Select/index.tsx
@@ -21,7 +21,7 @@ const Select: React.FC<SelectProps> = ({
       <Dialog.Header
         title="setupLikeCoin"
         closeDialog={closeDialog}
-        closeText={<FormattedMessage defaultMessage="Close" />}
+        closeText={<FormattedMessage defaultMessage="Close" id="rbrahO" />}
       />
 
       <Dialog.Content>
@@ -79,7 +79,7 @@ const Select: React.FC<SelectProps> = ({
       <Dialog.Footer
         smUpBtns={
           <Dialog.TextButton
-            text={<FormattedMessage defaultMessage="Close" />}
+            text={<FormattedMessage defaultMessage="Close" id="rbrahO" />}
             color="greyDarker"
             onClick={closeDialog}
           />

--- a/src/components/Dialogs/MigrationDialog/Success.tsx
+++ b/src/components/Dialogs/MigrationDialog/Success.tsx
@@ -43,13 +43,13 @@ const MigrationDialogSuccess = () => {
       <Dialog.Footer
         btns={
           <Dialog.RoundedButton
-            text={<FormattedMessage defaultMessage="Back" />}
+            text={<FormattedMessage defaultMessage="Back" id="cyR7Kh" />}
             href={PATHS.HOME}
           />
         }
         smUpBtns={
           <Dialog.TextButton
-            text={<FormattedMessage defaultMessage="Back" />}
+            text={<FormattedMessage defaultMessage="Back" id="cyR7Kh" />}
             href={PATHS.HOME}
           />
         }

--- a/src/components/Dialogs/PaymentPointerDialog/index.tsx
+++ b/src/components/Dialogs/PaymentPointerDialog/index.tsx
@@ -49,7 +49,7 @@ const BasePaymentPointerDialog: React.FC<PaymentPointerProps> = ({
           smUpBtns={
             <>
               <Dialog.TextButton
-                text={<FormattedMessage defaultMessage="Cancel" />}
+                text={<FormattedMessage defaultMessage="Cancel" id="47FYwb" />}
                 color="greyDarker"
                 onClick={closeDialog}
               />

--- a/src/components/Dialogs/RemoveArticleCollectionDialog/index.tsx
+++ b/src/components/Dialogs/RemoveArticleCollectionDialog/index.tsx
@@ -57,6 +57,7 @@ const BaseRemoveArticleCollectionDialog = ({
       message: (
         <FormattedMessage
           defaultMessage="Successfully removed"
+          id="URljhZ"
           description="src/components/Dialogs/RemoveArticleCollectionDialog/index.tsx"
         />
       ),
@@ -70,13 +71,19 @@ const BaseRemoveArticleCollectionDialog = ({
       {children({ openDialog })}
       <Dialog isOpen={show} onDismiss={closeDialog}>
         <Dialog.Header
-          title={<FormattedMessage defaultMessage="Remove from collection" />}
+          title={
+            <FormattedMessage
+              defaultMessage="Remove from collection"
+              id="0Om2Kl"
+            />
+          }
         />
 
         <Dialog.Message>
           <p>
             <FormattedMessage
               defaultMessage="Are you sure you want to remove ‘{article}’ from this collection?"
+              id="+cS08C"
               values={{
                 article: <span className="u-highlight">{articleTitle}</span>,
               }}
@@ -92,6 +99,7 @@ const BaseRemoveArticleCollectionDialog = ({
               text={
                 <FormattedMessage
                   defaultMessage="Remove"
+                  id="kkZioy"
                   description="src/components/Dialogs/RemoveArticleCollectionDialog/index.tsx"
                 />
               }
@@ -105,6 +113,7 @@ const BaseRemoveArticleCollectionDialog = ({
               text={
                 <FormattedMessage
                   defaultMessage="Remove"
+                  id="kkZioy"
                   description="src/components/Dialogs/RemoveArticleCollectionDialog/index.tsx"
                 />
               }

--- a/src/components/Dialogs/RemoveSocialLoginDialog/Content.tsx
+++ b/src/components/Dialogs/RemoveSocialLoginDialog/Content.tsx
@@ -43,6 +43,7 @@ const RemoveSocailLoginDialogContent: React.FC<Props> = ({
         message: (
           <FormattedMessage
             defaultMessage="{type} disconnected"
+            id="wm9xNB"
             description="src/components/Dialogs/RemoveSocialLoginDialog/Content.tsx"
             values={{
               type,
@@ -63,6 +64,7 @@ const RemoveSocailLoginDialogContent: React.FC<Props> = ({
         title={
           <FormattedMessage
             defaultMessage="Disconnect from {type}"
+            id="XYUhx0"
             description="src/components/Dialogs/RemoveSocialLoginDialog/Content.tsx"
             values={{
               type,
@@ -76,6 +78,7 @@ const RemoveSocailLoginDialogContent: React.FC<Props> = ({
             {isConfirm && (
               <FormattedMessage
                 defaultMessage="Do you want to disconnect from {type}?"
+                id="5CcjZy"
                 description="src/components/Dialogs/RemoveSocialLoginDialog/Content.tsx"
                 values={{
                   type,
@@ -85,6 +88,7 @@ const RemoveSocailLoginDialogContent: React.FC<Props> = ({
             {isFailure && (
               <FormattedMessage
                 defaultMessage="Unable to disconnect from {type} temporarily because you do not have any other log in methods (Email/Crypto wallet/Social account)."
+                id="K2/mHF"
                 description="src/components/Dialogs/RemoveSocialLoginDialog/Content.tsx"
                 values={{
                   type,
@@ -103,6 +107,7 @@ const RemoveSocailLoginDialogContent: React.FC<Props> = ({
                 text={
                   <FormattedMessage
                     defaultMessage="Disconnect"
+                    id="2P5JII"
                     description="src/components/Dialogs/RemoveSocialLoginDialog/Content.tsx"
                   />
                 }
@@ -110,7 +115,7 @@ const RemoveSocailLoginDialogContent: React.FC<Props> = ({
                 onClick={remove}
               />
               <DialogBeta.RoundedButton
-                text={<FormattedMessage defaultMessage="Close" />}
+                text={<FormattedMessage defaultMessage="Close" id="rbrahO" />}
                 color="greyDarker"
                 onClick={closeDialog}
               />
@@ -119,7 +124,7 @@ const RemoveSocailLoginDialogContent: React.FC<Props> = ({
           smUpBtns={
             <>
               <DialogBeta.TextButton
-                text={<FormattedMessage defaultMessage="Cancel" />}
+                text={<FormattedMessage defaultMessage="Cancel" id="47FYwb" />}
                 color="greyDarker"
                 onClick={closeDialog}
               />
@@ -127,6 +132,7 @@ const RemoveSocailLoginDialogContent: React.FC<Props> = ({
                 text={
                   <FormattedMessage
                     defaultMessage="Disconnect"
+                    id="2P5JII"
                     description="src/components/Dialogs/RemoveSocialLoginDialog/Content.tsx"
                   />
                 }
@@ -143,7 +149,7 @@ const RemoveSocailLoginDialogContent: React.FC<Props> = ({
           btns={
             <>
               <DialogBeta.RoundedButton
-                text={<FormattedMessage defaultMessage="Close" />}
+                text={<FormattedMessage defaultMessage="Close" id="rbrahO" />}
                 color="greyDarker"
                 onClick={closeDialog}
               />
@@ -152,7 +158,7 @@ const RemoveSocailLoginDialogContent: React.FC<Props> = ({
           smUpBtns={
             <>
               <DialogBeta.TextButton
-                text={<FormattedMessage defaultMessage="Close" />}
+                text={<FormattedMessage defaultMessage="Close" id="rbrahO" />}
                 color="greyDarker"
                 onClick={closeDialog}
               />

--- a/src/components/Dialogs/RemoveWalletLoginDialog/Content.tsx
+++ b/src/components/Dialogs/RemoveWalletLoginDialog/Content.tsx
@@ -36,6 +36,7 @@ const RemoveWalletLoginDialogContent: React.FC<Props> = ({ closeDialog }) => {
         message: (
           <FormattedMessage
             defaultMessage="Wallet disconnected"
+            id="iu3XKs"
             description="src/components/Dialogs/RemoveWalletLoginDialog/Content.tsx"
           />
         ),
@@ -53,6 +54,7 @@ const RemoveWalletLoginDialogContent: React.FC<Props> = ({ closeDialog }) => {
         title={
           <FormattedMessage
             defaultMessage="Disconnect wallet"
+            id="no7l8z"
             description="src/components/Dialogs/RemoveWalletLoginDialog/Content.tsx"
           />
         }
@@ -64,12 +66,14 @@ const RemoveWalletLoginDialogContent: React.FC<Props> = ({ closeDialog }) => {
             {isConfirm && (
               <FormattedMessage
                 defaultMessage="Are you sure you want to disconnect from this?"
+                id="CoF9qv"
                 description="src/components/Dialogs/RemoveWalletLoginDialog/Content.tsx"
               />
             )}
             {isFailure && (
               <FormattedMessage
                 defaultMessage="Unable to disconnect the wallet because you have not added or associated another login (Email/Wallet/Social account)."
+                id="dSjI7E"
                 description="src/components/Dialogs/RemoveWalletLoginDialog/Content.tsx"
               />
             )}
@@ -85,6 +89,7 @@ const RemoveWalletLoginDialogContent: React.FC<Props> = ({ closeDialog }) => {
                 text={
                   <FormattedMessage
                     defaultMessage="Disconnect"
+                    id="2P5JII"
                     description="src/components/Dialogs/RemoveSocialLoginDialog/Content.tsx"
                   />
                 }
@@ -92,7 +97,7 @@ const RemoveWalletLoginDialogContent: React.FC<Props> = ({ closeDialog }) => {
                 onClick={remove}
               />
               <DialogBeta.RoundedButton
-                text={<FormattedMessage defaultMessage="Close" />}
+                text={<FormattedMessage defaultMessage="Close" id="rbrahO" />}
                 color="greyDarker"
                 onClick={closeDialog}
               />
@@ -101,7 +106,7 @@ const RemoveWalletLoginDialogContent: React.FC<Props> = ({ closeDialog }) => {
           smUpBtns={
             <>
               <DialogBeta.TextButton
-                text={<FormattedMessage defaultMessage="Cancel" />}
+                text={<FormattedMessage defaultMessage="Cancel" id="47FYwb" />}
                 color="greyDarker"
                 onClick={closeDialog}
               />
@@ -109,6 +114,7 @@ const RemoveWalletLoginDialogContent: React.FC<Props> = ({ closeDialog }) => {
                 text={
                   <FormattedMessage
                     defaultMessage="Disconnect"
+                    id="2P5JII"
                     description="src/components/Dialogs/RemoveSocialLoginDialog/Content.tsx"
                   />
                 }
@@ -125,7 +131,7 @@ const RemoveWalletLoginDialogContent: React.FC<Props> = ({ closeDialog }) => {
           btns={
             <>
               <DialogBeta.RoundedButton
-                text={<FormattedMessage defaultMessage="Close" />}
+                text={<FormattedMessage defaultMessage="Close" id="rbrahO" />}
                 color="greyDarker"
                 onClick={closeDialog}
               />
@@ -134,7 +140,7 @@ const RemoveWalletLoginDialogContent: React.FC<Props> = ({ closeDialog }) => {
           smUpBtns={
             <>
               <DialogBeta.TextButton
-                text={<FormattedMessage defaultMessage="Close" />}
+                text={<FormattedMessage defaultMessage="Close" id="rbrahO" />}
                 color="greyDarker"
                 onClick={closeDialog}
               />

--- a/src/components/Dialogs/RssFeedDialog/Content.tsx
+++ b/src/components/Dialogs/RssFeedDialog/Content.tsx
@@ -82,6 +82,7 @@ const BaseRssFeedDialogContent: React.FC<RssFeedDialogContentProps> = ({
                   <p>
                     <FormattedMessage
                       defaultMessage="Adding contents into IPFS network, and it usually takes some times, please wait. You can accelerate the process by publishing new article."
+                      id="/3kw6k"
                       description="src/components/Dialogs/RssFeedDialog/Content.tsx"
                     />
                   </p>
@@ -95,12 +96,14 @@ const BaseRssFeedDialogContent: React.FC<RssFeedDialogContentProps> = ({
               <h4 className={styles.title}>
                 <FormattedMessage
                   defaultMessage="IPNS Subscription"
+                  id="Lc/azT"
                   description="src/components/Dialogs/RssFeedDialog/Content.tsx"
                 />
               </h4>
               <p className={styles.description}>
                 <FormattedMessage
                   defaultMessage="Add hash from IPFS into compatible reader such as "
+                  id="HqnUd1"
                   description="src/components/Dialogs/RssFeedDialog/Content.tsx"
                 />
                 <a
@@ -121,6 +124,7 @@ const BaseRssFeedDialogContent: React.FC<RssFeedDialogContentProps> = ({
                     <Button
                       aria-label={intl.formatMessage({
                         defaultMessage: 'Copy Link',
+                        id: 'u5aHb4',
                       })}
                     >
                       <IconCopy16 />
@@ -138,6 +142,7 @@ const BaseRssFeedDialogContent: React.FC<RssFeedDialogContentProps> = ({
                     >
                       <FormattedMessage
                         defaultMessage="Waiting ..."
+                        id="zxlwbc"
                         description="src/components/Dialogs/RssFeedDialog/Content.tsx"
                       />
                     </TextIcon>
@@ -155,12 +160,14 @@ const BaseRssFeedDialogContent: React.FC<RssFeedDialogContentProps> = ({
               <h4 className={styles.title}>
                 <FormattedMessage
                   defaultMessage="RSS Subscription"
+                  id="gMZfHO"
                   description="src/components/Dialogs/RssFeedDialog/Content.tsx"
                 />
               </h4>
               <p className={styles.description}>
                 <FormattedMessage
                   defaultMessage="Add any URL in the following list into RSS reader"
+                  id="D2Sw/t"
                   description="src/components/Dialogs/RssFeedDialog/Content.tsx"
                 />
               </p>
@@ -194,6 +201,7 @@ const BaseRssFeedDialogContent: React.FC<RssFeedDialogContentProps> = ({
                             disabled={!ipnsKey}
                             aria-label={intl.formatMessage({
                               defaultMessage: 'Copy Link',
+                              id: 'u5aHb4',
                             })}
                           >
                             <IconCopy16 />
@@ -213,7 +221,7 @@ const BaseRssFeedDialogContent: React.FC<RssFeedDialogContentProps> = ({
         smUpBtns={
           <Dialog.TextButton
             color="greyDarker"
-            text={<FormattedMessage defaultMessage="Close" />}
+            text={<FormattedMessage defaultMessage="Close" id="rbrahO" />}
             onClick={closeDialog}
           />
         }

--- a/src/components/Dialogs/RssFeedDialog/index.tsx
+++ b/src/components/Dialogs/RssFeedDialog/index.tsx
@@ -84,7 +84,7 @@ const BaseRssFeedDialog = ({ user, children }: RssFeedDialogProps) => {
         <Dialog.Header
           title="contentFeedEntrance"
           closeDialog={closeDialog}
-          closeText={<FormattedMessage defaultMessage="Close" />}
+          closeText={<FormattedMessage defaultMessage="Close" id="rbrahO" />}
         />
 
         <DynamicContent

--- a/src/components/Dialogs/SetEmailDialog/Content.tsx
+++ b/src/components/Dialogs/SetEmailDialog/Content.tsx
@@ -123,6 +123,7 @@ const SetEmailDialogContent: React.FC<FormProps> = ({ closeDialog }) => {
               'email',
               intl.formatMessage({
                 defaultMessage: 'Unavailable',
+                id: 'rADhX5',
                 description: 'FORBIDDEN_BY_STATE',
               })
             )
@@ -165,7 +166,7 @@ const SetEmailDialogContent: React.FC<FormProps> = ({ closeDialog }) => {
       disabled={
         isSubmitting || values.email === '' || presetEmail === values.email
       }
-      text={<FormattedMessage defaultMessage="Confirm" />}
+      text={<FormattedMessage defaultMessage="Confirm" id="N2IrpM" />}
       loading={isSubmitting}
     />
   )
@@ -176,6 +177,7 @@ const SetEmailDialogContent: React.FC<FormProps> = ({ closeDialog }) => {
         title={
           <FormattedMessage
             defaultMessage="Email address"
+            id="FEI5Fv"
             description="src/components/Dialogs/SetEmailDialog/Content.tsx"
           />
         }
@@ -189,12 +191,14 @@ const SetEmailDialogContent: React.FC<FormProps> = ({ closeDialog }) => {
             <p>
               <FormattedMessage
                 defaultMessage="For security, we will {resetHint} for this. You can set your password again after verifying new email address."
+                id="h9A6AT"
                 description="src/components/Dialogs/SetEmailDialog/Content.tsx"
                 values={{
                   resetHint: (
                     <span className="u-highlight">
                       <FormattedMessage
                         defaultMessage="reset your login password"
+                        id="vsD2wm"
                         description="src/components/Dialogs/SetEmailDialog/Content.tsx"
                       ></FormattedMessage>
                     </span>
@@ -210,6 +214,7 @@ const SetEmailDialogContent: React.FC<FormProps> = ({ closeDialog }) => {
             <p>
               <FormattedMessage
                 defaultMessage="Email can be modified up to {count} times per day."
+                id="0e1xjL"
                 description="src/components/Dialogs/SetEmailDialog/Content.tsx"
                 values={{
                   count: MAX_CHANGE_EMAIL_TIME_DAILY,
@@ -227,7 +232,7 @@ const SetEmailDialogContent: React.FC<FormProps> = ({ closeDialog }) => {
           smUpBtns={
             <>
               <Dialog.TextButton
-                text={<FormattedMessage defaultMessage="Cancel" />}
+                text={<FormattedMessage defaultMessage="Cancel" id="47FYwb" />}
                 color="greyDarker"
                 onClick={closeDialog}
               />
@@ -241,7 +246,7 @@ const SetEmailDialogContent: React.FC<FormProps> = ({ closeDialog }) => {
           smUpBtns={
             <>
               <Dialog.TextButton
-                text={<FormattedMessage defaultMessage="Close" />}
+                text={<FormattedMessage defaultMessage="Close" id="rbrahO" />}
                 color="greyDarker"
                 onClick={closeDialog}
               />

--- a/src/components/Dialogs/SetPasswordDialog/Content.tsx
+++ b/src/components/Dialogs/SetPasswordDialog/Content.tsx
@@ -81,6 +81,7 @@ const SetPasswordDialogContent: React.FC<FormProps> = ({ closeDialog }) => {
           message: (
             <FormattedMessage
               defaultMessage="Set password succeed"
+              id="pHg5Ju"
               description="src/components/Dialogs/SetPasswordDialog/Content.tsx"
             />
           ),
@@ -105,7 +106,10 @@ const SetPasswordDialogContent: React.FC<FormProps> = ({ closeDialog }) => {
         name="password"
         autoFocus
         required
-        placeholder={intl.formatMessage({ defaultMessage: 'Password' })}
+        placeholder={intl.formatMessage({
+          defaultMessage: 'Password',
+          id: '5sg7KC',
+        })}
         value={values.password}
         error={touched.password && errors.password}
         // onBlur={handleBlur}
@@ -128,7 +132,7 @@ const SetPasswordDialogContent: React.FC<FormProps> = ({ closeDialog }) => {
       type="submit"
       form={formId}
       disabled={isSubmitting || values.password.length < 8}
-      text={<FormattedMessage defaultMessage="Confirm" />}
+      text={<FormattedMessage defaultMessage="Confirm" id="N2IrpM" />}
       loading={isSubmitting}
     />
   )
@@ -139,6 +143,7 @@ const SetPasswordDialogContent: React.FC<FormProps> = ({ closeDialog }) => {
         title={
           <FormattedMessage
             defaultMessage="Login password"
+            id="KIQUHo"
             description="src/components/Dialogs/SetPasswordDialog/Content.tsx"
           />
         }
@@ -151,6 +156,7 @@ const SetPasswordDialogContent: React.FC<FormProps> = ({ closeDialog }) => {
           <p>
             <FormattedMessage
               defaultMessage="Password must be at least 8 characters long, support letter, numbers and symbols."
+              id="W66Eyq"
               description="src/components/Dialogs/SetPasswordDialog/Content.tsx"
             />
           </p>
@@ -163,7 +169,7 @@ const SetPasswordDialogContent: React.FC<FormProps> = ({ closeDialog }) => {
         smUpBtns={
           <>
             <DialogBeta.TextButton
-              text={<FormattedMessage defaultMessage="Cancel" />}
+              text={<FormattedMessage defaultMessage="Cancel" id="47FYwb" />}
               color="greyDarker"
               onClick={closeDialog}
             />

--- a/src/components/Dialogs/SetUserNameDialog/ConfirmStep.tsx
+++ b/src/components/Dialogs/SetUserNameDialog/ConfirmStep.tsx
@@ -43,6 +43,7 @@ const ConfirmStep: React.FC<Props> = ({ userName, back, closeDialog }) => {
         message: (
           <FormattedMessage
             defaultMessage="Matters ID has been set up. More account info can be found in Settings"
+            id="0CyECR"
             description="src/components/Dialogs/SetUserNameDialog/ConfirmStep.tsx"
           />
         ),
@@ -51,6 +52,7 @@ const ConfirmStep: React.FC<Props> = ({ userName, back, closeDialog }) => {
             content: (
               <FormattedMessage
                 defaultMessage="Take a look"
+                id="1QrwIl"
                 description="src/components/Dialogs/SetUserNameDialog/ConfirmStep.tsx"
               />
             ),
@@ -72,6 +74,7 @@ const ConfirmStep: React.FC<Props> = ({ userName, back, closeDialog }) => {
         title={
           <FormattedMessage
             defaultMessage="Confirm Matters ID"
+            id="202PEj"
             description="src/components/Dialogs/SetUserNameDialog/ConfirmStep.tsx"
           />
         }
@@ -81,6 +84,7 @@ const ConfirmStep: React.FC<Props> = ({ userName, back, closeDialog }) => {
           <p>
             <FormattedMessage
               defaultMessage="This ID cannot be modified. Are you sure you want to use {id} as your Matters ID?"
+              id="FxrSCh"
               description="src/components/Dialogs/SetUserNameDialog/ConfirmStep.tsx"
               values={{
                 id: <span className="u-highlight">{userName}</span>,
@@ -98,6 +102,7 @@ const ConfirmStep: React.FC<Props> = ({ userName, back, closeDialog }) => {
               text={
                 <FormattedMessage
                   defaultMessage="Confirm use"
+                  id="IPqNCS"
                   description="src/components/Dialogs/SetUserNameDialog/ConfirmStep.tsx"
                 />
               }
@@ -105,7 +110,7 @@ const ConfirmStep: React.FC<Props> = ({ userName, back, closeDialog }) => {
               onClick={confirmUse}
             />
             <DialogBeta.RoundedButton
-              text={<FormattedMessage defaultMessage="Back" />}
+              text={<FormattedMessage defaultMessage="Back" id="cyR7Kh" />}
               color="greyDarker"
               onClick={back}
             />
@@ -114,7 +119,7 @@ const ConfirmStep: React.FC<Props> = ({ userName, back, closeDialog }) => {
         smUpBtns={
           <>
             <DialogBeta.TextButton
-              text={<FormattedMessage defaultMessage="Back" />}
+              text={<FormattedMessage defaultMessage="Back" id="cyR7Kh" />}
               color="greyDarker"
               onClick={back}
             />
@@ -123,6 +128,7 @@ const ConfirmStep: React.FC<Props> = ({ userName, back, closeDialog }) => {
               text={
                 <FormattedMessage
                   defaultMessage="Confirm use"
+                  id="IPqNCS"
                   description="src/components/Dialogs/SetUserNameDialog/ConfirmStep.tsx"
                 />
               }

--- a/src/components/Dialogs/SetUserNameDialog/InputStep.tsx
+++ b/src/components/Dialogs/SetUserNameDialog/InputStep.tsx
@@ -80,6 +80,7 @@ const InputStep: React.FC<Props> = ({ userName, gotoConfirm }) => {
             'mattersID',
             intl.formatMessage({
               defaultMessage: 'This ID has been taken, please try another one',
+              id: 'x7O1/5',
               description:
                 'src/components/Dialogs/SetUserNameDialog/Content.tsx',
             })
@@ -109,6 +110,7 @@ const InputStep: React.FC<Props> = ({ userName, gotoConfirm }) => {
         autoFocus
         placeholder={intl.formatMessage({
           defaultMessage: 'English letters, numbers, and underscores',
+          id: 'kf5NAv',
           description: 'src/components/Dialogs/SetUserNameDialog/Content.tsx',
         })}
         value={values.mattersID}
@@ -161,7 +163,7 @@ const InputStep: React.FC<Props> = ({ userName, gotoConfirm }) => {
         values.mattersID.length < MIN_USER_NAME_LENGTH ||
         values.mattersID.length > MAX_USER_NAME_LENGTH
       }
-      text={<FormattedMessage defaultMessage="Confirm" />}
+      text={<FormattedMessage defaultMessage="Confirm" id="N2IrpM" />}
       loading={isSubmitting}
     />
   )
@@ -173,11 +175,13 @@ const InputStep: React.FC<Props> = ({ userName, gotoConfirm }) => {
           isLegacyUserConfirm ? (
             <FormattedMessage
               defaultMessage="Confirm Matters ID"
+              id="1hyiZ8"
               description="src/components/Dialogs/SetUserNameDialog/Content.tsx"
             />
           ) : (
             <FormattedMessage
               defaultMessage="Last step: Set Matters ID"
+              id="l0/EvT"
               description="src/components/Dialogs/SetUserNameDialog/Content.tsx"
             />
           )
@@ -189,11 +193,13 @@ const InputStep: React.FC<Props> = ({ userName, gotoConfirm }) => {
             {isLegacyUserConfirm ? (
               <FormattedMessage
                 defaultMessage="In order to ensure the identity security of the citizens of Matters City, we've upgraded some security settings. Please confirm your Matters ID (cannot be modified once confirmation)."
+                id="ySSF/a"
                 description="src/components/Dialogs/SetUserNameDialog/Content.tsx"
               />
             ) : (
               <FormattedMessage
                 defaultMessage="Matters ID is your unique identifier, and cannot be modified once set."
+                id="LwFJTy"
                 description="src/components/Dialogs/SetUserNameDialog/Content.tsx"
               />
             )}
@@ -212,7 +218,7 @@ const InputStep: React.FC<Props> = ({ userName, gotoConfirm }) => {
               disabled={
                 isSubmitting || values.mattersID.length < MIN_USER_NAME_LENGTH
               }
-              text={<FormattedMessage defaultMessage="Confirm" />}
+              text={<FormattedMessage defaultMessage="Confirm" id="N2IrpM" />}
               loading={isSubmitting}
             />
           </>

--- a/src/components/Dialogs/ShareDialog/Content.tsx
+++ b/src/components/Dialogs/ShareDialog/Content.tsx
@@ -86,14 +86,14 @@ const ShareDialogContent: React.FC<ShareDialogContentProps> = ({
         <Dialog.Footer
           btns={
             <Dialog.RoundedButton
-              text={<FormattedMessage defaultMessage="Close" />}
+              text={<FormattedMessage defaultMessage="Close" id="rbrahO" />}
               color="greyDarker"
               onClick={closeDialog}
             />
           }
           smUpBtns={
             <Dialog.TextButton
-              text={<FormattedMessage defaultMessage="Close" />}
+              text={<FormattedMessage defaultMessage="Close" id="rbrahO" />}
               color="greyDarker"
               onClick={closeDialog}
             />

--- a/src/components/Dialogs/ShareDialog/Copy.tsx
+++ b/src/components/Dialogs/ShareDialog/Copy.tsx
@@ -20,6 +20,7 @@ const Copy = ({ link }: { link: string }) => {
         <button
           aria-label={intl.formatMessage({
             defaultMessage: 'Copy Link',
+            id: 'u5aHb4',
           })}
           onClick={() => {
             analytics.trackEvent('share', {
@@ -30,7 +31,7 @@ const Copy = ({ link }: { link: string }) => {
           <TextIcon icon={<IconLink16 color="grey" />} spacing="base">
             <div className={styles.text}>
               <span>
-                <FormattedMessage defaultMessage="Copy Link" />
+                <FormattedMessage defaultMessage="Copy Link" id="u5aHb4" />
               </span>
             </div>
           </TextIcon>

--- a/src/components/Dialogs/SupportersDialog/Content.tsx
+++ b/src/components/Dialogs/SupportersDialog/Content.tsx
@@ -78,7 +78,7 @@ const SupportersDialogContent = ({
           </>
         }
         closeDialog={closeDialog}
-        closeText={<FormattedMessage defaultMessage="Close" />}
+        closeText={<FormattedMessage defaultMessage="Close" id="rbrahO" />}
       />
 
       <Dialog.Content noSpacing>
@@ -108,7 +108,7 @@ const SupportersDialogContent = ({
       <Dialog.Footer
         smUpBtns={
           <Dialog.TextButton
-            text={<FormattedMessage defaultMessage="Close" />}
+            text={<FormattedMessage defaultMessage="Close" id="rbrahO" />}
             color="greyDarker"
             onClick={closeDialog}
           />

--- a/src/components/Dialogs/TagEditorDialog/List/index.tsx
+++ b/src/components/Dialogs/TagEditorDialog/List/index.tsx
@@ -202,7 +202,7 @@ const TagEditorList = ({ id, closeDialog, toAddStep, toRemoveStep }: Props) => {
           smUpBtns={
             <>
               <Dialog.TextButton
-                text={<FormattedMessage defaultMessage="Cancel" />}
+                text={<FormattedMessage defaultMessage="Cancel" id="47FYwb" />}
                 color="greyDarker"
                 onClick={closeDialog}
               />

--- a/src/components/Dialogs/TagEditorDialog/SearchSelect/index.tsx
+++ b/src/components/Dialogs/TagEditorDialog/SearchSelect/index.tsx
@@ -101,7 +101,7 @@ const TagSearchSelectEditor = ({ id, closeDialog, toListStep }: Props) => {
   const SubmitButton = (
     <Dialog.TextButton
       onClick={onClickSave}
-      text={<FormattedMessage defaultMessage="Confirm" />}
+      text={<FormattedMessage defaultMessage="Confirm" id="N2IrpM" />}
       loading={loading}
     />
   )
@@ -135,7 +135,7 @@ const TagSearchSelectEditor = ({ id, closeDialog, toListStep }: Props) => {
         smUpBtns={
           <>
             <Dialog.TextButton
-              text={<FormattedMessage defaultMessage="Cancel" />}
+              text={<FormattedMessage defaultMessage="Cancel" id="47FYwb" />}
               color="greyDarker"
               onClick={closeDialog}
             />

--- a/src/components/Dialogs/UnsubscribeCircleDialog/index.tsx
+++ b/src/components/Dialogs/UnsubscribeCircleDialog/index.tsx
@@ -67,7 +67,7 @@ const BaseUnsubscribeCircleDialog = ({
           btns={
             isUnsubscribed ? null : (
               <Dialog.RoundedButton
-                text={<FormattedMessage defaultMessage="Confirm" />}
+                text={<FormattedMessage defaultMessage="Confirm" id="N2IrpM" />}
                 color={loading ? 'green' : 'red'}
                 loading={loading}
                 onClick={() => unsubscribe()}
@@ -77,7 +77,7 @@ const BaseUnsubscribeCircleDialog = ({
           smUpBtns={
             isUnsubscribed ? null : (
               <Dialog.TextButton
-                text={<FormattedMessage defaultMessage="Confirm" />}
+                text={<FormattedMessage defaultMessage="Confirm" id="N2IrpM" />}
                 color={loading ? 'green' : 'red'}
                 loading={loading}
                 onClick={() => unsubscribe()}

--- a/src/components/DraftDigest/Feed/DeleteButton.tsx
+++ b/src/components/DraftDigest/Feed/DeleteButton.tsx
@@ -92,7 +92,7 @@ const DeleteButton = ({ draft }: DeleteButtonProps) => {
           closeDialog={closeDialog}
           btns={
             <Dialog.RoundedButton
-              text={<FormattedMessage defaultMessage="Confirm" />}
+              text={<FormattedMessage defaultMessage="Confirm" id="N2IrpM" />}
               color="red"
               onClick={() => {
                 onDelete()
@@ -102,7 +102,7 @@ const DeleteButton = ({ draft }: DeleteButtonProps) => {
           }
           smUpBtns={
             <Dialog.TextButton
-              text={<FormattedMessage defaultMessage="Confirm" />}
+              text={<FormattedMessage defaultMessage="Confirm" id="N2IrpM" />}
               color="red"
               onClick={() => {
                 onDelete()

--- a/src/components/Editor/Article/BubbleMenu/index.tsx
+++ b/src/components/Editor/Article/BubbleMenu/index.tsx
@@ -358,7 +358,7 @@ export const BubbleMenu: React.FC<BubbleMenuProps> = ({
               type="button"
               onClick={onUrlInputSubmit}
             >
-              <FormattedMessage defaultMessage="Confirm" />
+              <FormattedMessage defaultMessage="Confirm" id="N2IrpM" />
             </button>
           </>
         )}

--- a/src/components/Editor/ArticleCustomStagingArea/ConfirmDialog.tsx
+++ b/src/components/Editor/ArticleCustomStagingArea/ConfirmDialog.tsx
@@ -29,14 +29,14 @@ const ConfirmDialog = ({ removeArticle, children }: ConfirmDialogProps) => {
           closeDialog={closeDialog}
           btns={
             <Dialog.RoundedButton
-              text={<FormattedMessage defaultMessage="Delete" />}
+              text={<FormattedMessage defaultMessage="Delete" id="K3r6DQ" />}
               color="red"
               onClick={removeArticle}
             />
           }
           smUpBtns={
             <Dialog.TextButton
-              text={<FormattedMessage defaultMessage="Delete" />}
+              text={<FormattedMessage defaultMessage="Delete" id="K3r6DQ" />}
               color="red"
               onClick={removeArticle}
             />

--- a/src/components/Editor/BottomBar/AccessDialog/index.tsx
+++ b/src/components/Editor/BottomBar/AccessDialog/index.tsx
@@ -29,7 +29,7 @@ const BaseAccessDialog = ({
   const CloseButton = () => (
     <Dialog.TextButton
       onClick={closeDialog}
-      text={<FormattedMessage defaultMessage="Done" />}
+      text={<FormattedMessage defaultMessage="Done" id="JXdbo8" />}
     />
   )
 

--- a/src/components/Editor/SetCover/Uploader.tsx
+++ b/src/components/Editor/SetCover/Uploader.tsx
@@ -173,7 +173,10 @@ const Uploader: React.FC<UploaderProps> = ({
       </h3>
 
       <p>
-        <FormattedMessage defaultMessage="Recommended square image." />
+        <FormattedMessage
+          defaultMessage="Recommended square image."
+          id="CxYcYR"
+        />
       </p>
 
       <VisuallyHidden>

--- a/src/components/Editor/SetCover/index.tsx
+++ b/src/components/Editor/SetCover/index.tsx
@@ -58,7 +58,7 @@ const SetCover: React.FC<SetCoverProps> & { Dialog: typeof SetCoverDialog } = ({
   const SubmitButton = (
     <Dialog.TextButton
       onClick={onSave}
-      text={<FormattedMessage defaultMessage="Confirm" />}
+      text={<FormattedMessage defaultMessage="Confirm" id="N2IrpM" />}
       loading={coverSaving}
     />
   )
@@ -71,7 +71,7 @@ const SetCover: React.FC<SetCoverProps> & { Dialog: typeof SetCoverDialog } = ({
         leftBtn={
           back ? (
             <Dialog.TextButton
-              text={<FormattedMessage defaultMessage="Back" />}
+              text={<FormattedMessage defaultMessage="Back" id="cyR7Kh" />}
               onClick={back}
             />
           ) : undefined
@@ -98,7 +98,11 @@ const SetCover: React.FC<SetCoverProps> & { Dialog: typeof SetCoverDialog } = ({
           <>
             <Dialog.TextButton
               text={
-                back ? 'back' : <FormattedMessage defaultMessage="Cancel" />
+                back ? (
+                  'back'
+                ) : (
+                  <FormattedMessage defaultMessage="Cancel" id="47FYwb" />
+                )
               }
               color="greyDarker"
               onClick={back || closeDialog}

--- a/src/components/Editor/SettingsDialog/List/index.tsx
+++ b/src/components/Editor/SettingsDialog/List/index.tsx
@@ -91,7 +91,10 @@ const SettingsList = ({
           <ListItem
             title={<Translate id="setCover" />}
             subTitle={
-              <FormattedMessage defaultMessage="Recommended square image." />
+              <FormattedMessage
+                defaultMessage="Recommended square image."
+                id="CxYcYR"
+              />
             }
             hint
             onClick={() => forward('cover')}

--- a/src/components/Editor/ToggleAccess/SupportSettingDialog/Content.tsx
+++ b/src/components/Editor/ToggleAccess/SupportSettingDialog/Content.tsx
@@ -150,7 +150,7 @@ const SupportSettingDialogContent: React.FC<FormProps> = ({
       type="submit"
       form={formId}
       disabled={!isValid || isSubmitting || supportSettingSaving}
-      text={<FormattedMessage defaultMessage="Confirm" />}
+      text={<FormattedMessage defaultMessage="Confirm" id="N2IrpM" />}
       loading={isSubmitting}
     />
   )
@@ -163,7 +163,7 @@ const SupportSettingDialogContent: React.FC<FormProps> = ({
         leftBtn={
           back ? (
             <Dialog.TextButton
-              text={<FormattedMessage defaultMessage="Back" />}
+              text={<FormattedMessage defaultMessage="Back" id="cyR7Kh" />}
               onClick={back}
             />
           ) : null

--- a/src/components/Editor/ToggleAccess/index.tsx
+++ b/src/components/Editor/ToggleAccess/index.tsx
@@ -195,6 +195,7 @@ const ToggleAccess: React.FC<ToggleAccessProps> = ({
         <p className={styles.hint}>
           <FormattedMessage
             defaultMessage="Upon activation, the main text will be temporarily obscured, displaying only the title and summary. Readers can choose whether to continue reading. (Contains explicit content, violence, gore, etc.)"
+            id="Vn5KLr"
             description="src/components/Editor/ToggleAccess/index.tsx"
           />
         </p>

--- a/src/components/Empty/EmptyArticle.tsx
+++ b/src/components/Empty/EmptyArticle.tsx
@@ -18,6 +18,7 @@ export const EmptyArticle = ({
         description ||
         intl.formatMessage({
           defaultMessage: 'No published articles yet',
+          id: 'yIlC0R',
           description: 'src/components/Empty/EmptyArticle.tsx',
         })
       }

--- a/src/components/Empty/EmptyCollection.tsx
+++ b/src/components/Empty/EmptyCollection.tsx
@@ -11,6 +11,7 @@ export const EmptyCollection = () => {
       icon={<IconBook88 size="xxxlM" />}
       description={intl.formatMessage({
         defaultMessage: 'No collection created yet',
+        id: 'GU6vV0',
         description: 'src/components/Empty/EmptyCollection.tsx',
       })}
     />

--- a/src/components/Forms/ChangeEmailForm/Complete.tsx
+++ b/src/components/Forms/ChangeEmailForm/Complete.tsx
@@ -34,7 +34,7 @@ const Complete = ({
       {!isInPage && closeDialog && (
         <Dialog.Footer
           closeDialog={closeDialog}
-          closeText={<FormattedMessage defaultMessage="Close" />}
+          closeText={<FormattedMessage defaultMessage="Close" id="rbrahO" />}
         />
       )}
     </>

--- a/src/components/Forms/ChangeEmailForm/Confirm.tsx
+++ b/src/components/Forms/ChangeEmailForm/Confirm.tsx
@@ -165,7 +165,7 @@ const Confirm: React.FC<FormProps> = ({
       type="submit"
       form={formId}
       disabled={isSubmitting}
-      text={<FormattedMessage defaultMessage="Confirm" />}
+      text={<FormattedMessage defaultMessage="Confirm" id="N2IrpM" />}
       loading={isSubmitting}
     />
   )
@@ -182,7 +182,7 @@ const Confirm: React.FC<FormProps> = ({
                 type="submit"
                 form={formId}
                 disabled={isSubmitting}
-                text={<FormattedMessage defaultMessage="Confirm" />}
+                text={<FormattedMessage defaultMessage="Confirm" id="N2IrpM" />}
                 loading={isSubmitting}
               />
             </>
@@ -208,7 +208,7 @@ const Confirm: React.FC<FormProps> = ({
         smUpBtns={
           <>
             <Dialog.TextButton
-              text={<FormattedMessage defaultMessage="Cancel" />}
+              text={<FormattedMessage defaultMessage="Cancel" id="47FYwb" />}
               color="greyDarker"
               onClick={closeDialog}
             />

--- a/src/components/Forms/ChangeEmailForm/Request.tsx
+++ b/src/components/Forms/ChangeEmailForm/Request.tsx
@@ -137,7 +137,7 @@ const Request: React.FC<FormProps> = ({
       type="submit"
       form={formId}
       disabled={isSubmitting}
-      text={<FormattedMessage defaultMessage="Next Step" />}
+      text={<FormattedMessage defaultMessage="Next Step" id="8cv9D4" />}
       loading={isSubmitting}
     />
   )
@@ -154,7 +154,9 @@ const Request: React.FC<FormProps> = ({
                 type="submit"
                 form={formId}
                 disabled={isSubmitting}
-                text={<FormattedMessage defaultMessage="Next Step" />}
+                text={
+                  <FormattedMessage defaultMessage="Next Step" id="8cv9D4" />
+                }
                 loading={isSubmitting}
               />
             </>
@@ -180,7 +182,7 @@ const Request: React.FC<FormProps> = ({
         smUpBtns={
           <>
             <Dialog.TextButton
-              text={<FormattedMessage defaultMessage="Cancel" />}
+              text={<FormattedMessage defaultMessage="Cancel" id="47FYwb" />}
               color="greyDarker"
               onClick={closeDialog}
             />

--- a/src/components/Forms/ChangePasswordForm/Complete.tsx
+++ b/src/components/Forms/ChangePasswordForm/Complete.tsx
@@ -37,7 +37,7 @@ const Complete: React.FC<Props> = ({ type, purpose, closeDialog }) => {
       {!isInPage && (
         <Dialog.Footer
           closeDialog={closeDialog}
-          closeText={<FormattedMessage defaultMessage="Close" />}
+          closeText={<FormattedMessage defaultMessage="Close" id="rbrahO" />}
           btns={
             isForget ? (
               <Dialog.RoundedButton

--- a/src/components/Forms/ChangePasswordForm/Confirm.tsx
+++ b/src/components/Forms/ChangePasswordForm/Confirm.tsx
@@ -160,7 +160,7 @@ const Confirm: React.FC<FormProps> = ({
       type="submit"
       form={formId}
       disabled={isSubmitting}
-      text={<FormattedMessage defaultMessage="Confirm" />}
+      text={<FormattedMessage defaultMessage="Confirm" id="N2IrpM" />}
       loading={isSubmitting}
     />
   )
@@ -177,7 +177,7 @@ const Confirm: React.FC<FormProps> = ({
                 type="submit"
                 form={formId}
                 disabled={isSubmitting}
-                text={<FormattedMessage defaultMessage="Confirm" />}
+                text={<FormattedMessage defaultMessage="Confirm" id="N2IrpM" />}
                 loading={isSubmitting}
               />
             </>

--- a/src/components/Forms/ChangePasswordForm/Request.tsx
+++ b/src/components/Forms/ChangePasswordForm/Request.tsx
@@ -96,7 +96,7 @@ const Request: React.FC<FormProps> = ({
   const InnerForm = (
     <Form id={formId} onSubmit={handleSubmit}>
       <Form.Input
-        label={<FormattedMessage defaultMessage="Email" />}
+        label={<FormattedMessage defaultMessage="Email" id="sy+pv5" />}
         type="email"
         name="email"
         required
@@ -104,9 +104,11 @@ const Request: React.FC<FormProps> = ({
           isForget
             ? intl.formatMessage({
                 defaultMessage: 'Enter your email',
+                id: '5MDGuM',
               })
             : intl.formatMessage({
                 defaultMessage: 'Email',
+                id: 'sy+pv5',
               })
         }
         value={values.email}
@@ -123,7 +125,7 @@ const Request: React.FC<FormProps> = ({
       type="submit"
       form={formId}
       disabled={isSubmitting}
-      text={<FormattedMessage defaultMessage="Next Step" />}
+      text={<FormattedMessage defaultMessage="Next Step" id="8cv9D4" />}
       loading={isSubmitting}
     />
   )
@@ -140,7 +142,9 @@ const Request: React.FC<FormProps> = ({
                 type="submit"
                 form={formId}
                 disabled={isSubmitting}
-                text={<FormattedMessage defaultMessage="Next Step" />}
+                text={
+                  <FormattedMessage defaultMessage="Next Step" id="8cv9D4" />
+                }
                 loading={isSubmitting}
               />
             </>
@@ -159,7 +163,7 @@ const Request: React.FC<FormProps> = ({
         leftBtn={
           back ? (
             <Dialog.TextButton
-              text={<FormattedMessage defaultMessage="Back" />}
+              text={<FormattedMessage defaultMessage="Back" id="cyR7Kh" />}
               onClick={back}
             />
           ) : null

--- a/src/components/Forms/ChangeUserNameForm/Complete.tsx
+++ b/src/components/Forms/ChangeUserNameForm/Complete.tsx
@@ -33,7 +33,7 @@ const Complete = ({
       {!isInPage && closeDialog && (
         <Dialog.Footer
           closeDialog={closeDialog}
-          closeText={<FormattedMessage defaultMessage="Close" />}
+          closeText={<FormattedMessage defaultMessage="Close" id="rbrahO" />}
         />
       )}
     </>

--- a/src/components/Forms/ChangeUserNameForm/Confirm.tsx
+++ b/src/components/Forms/ChangeUserNameForm/Confirm.tsx
@@ -165,7 +165,7 @@ const Confirm: React.FC<FormProps> = ({
       type="submit"
       form={formId}
       disabled={isSubmitting}
-      text={<FormattedMessage defaultMessage="Next Step" />}
+      text={<FormattedMessage defaultMessage="Next Step" id="8cv9D4" />}
       loading={isSubmitting}
     />
   )
@@ -181,7 +181,9 @@ const Confirm: React.FC<FormProps> = ({
                 type="submit"
                 form={formId}
                 disabled={isSubmitting}
-                text={<FormattedMessage defaultMessage="Next Step" />}
+                text={
+                  <FormattedMessage defaultMessage="Next Step" id="8cv9D4" />
+                }
                 loading={isSubmitting}
               />
             </>
@@ -207,7 +209,7 @@ const Confirm: React.FC<FormProps> = ({
         smUpBtns={
           <>
             <Dialog.TextButton
-              text={<FormattedMessage defaultMessage="Cancel" />}
+              text={<FormattedMessage defaultMessage="Cancel" id="47FYwb" />}
               color="greyDarker"
               onClick={closeDialog}
             />

--- a/src/components/Forms/CreateCircleForm/Init.tsx
+++ b/src/components/Forms/CreateCircleForm/Init.tsx
@@ -108,6 +108,7 @@ const Init: React.FC<FormProps> = ({
               intl.formatMessage({
                 defaultMessage:
                   'This URL name has already been used, try another one',
+                id: 'VwuiYK',
                 description: 'src/components/Forms/CreateCircleForm/Init.tsx',
               })
             )
@@ -117,6 +118,7 @@ const Init: React.FC<FormProps> = ({
               intl.formatMessage({
                 defaultMessage:
                   'Must be between 2-20 characters long. Only lowercase letters, numbers and underline are allowed.',
+                id: 'CBDDR5',
               })
             )
           } else if (code === 'DISPLAYNAME_INVALID') {
@@ -124,6 +126,7 @@ const Init: React.FC<FormProps> = ({
               'name',
               intl.formatMessage({
                 defaultMessage: 'Must be between 2-12 characters long.',
+                id: '+7SAix',
               })
             )
           } else {
@@ -137,13 +140,14 @@ const Init: React.FC<FormProps> = ({
   const InnerForm = (
     <Form id={formId} onSubmit={handleSubmit}>
       <Form.Input
-        label={<FormattedMessage defaultMessage="Circle Name" />}
+        label={<FormattedMessage defaultMessage="Circle Name" id="q9oMKE" />}
         hasLabel
         type="text"
         name="displayName"
         required
         placeholder={intl.formatMessage({
           defaultMessage: 'Enter the name of your Circle',
+          id: 'wXzTZ0',
         })}
         value={values.displayName}
         hint={`${values.displayName.length}/${MAX_CIRCLE_DISPLAY_NAME_LENGTH}`}
@@ -160,6 +164,7 @@ const Init: React.FC<FormProps> = ({
           label={
             <FormattedMessage
               defaultMessage="Set the Circle URL (cannot be modified after creation)"
+              id="QZXKhG"
               description="src/components/Forms/CreateCircleForm/Init.tsx"
             />
           }
@@ -169,6 +174,7 @@ const Init: React.FC<FormProps> = ({
           required
           placeholder={intl.formatMessage({
             defaultMessage: 'Custom URL Name',
+            id: 'eov+J2',
           })}
           value={values.name}
           hint={`${values.name.length}/${MAX_CIRCLE_NAME_LENGTH}`}
@@ -189,6 +195,7 @@ const Init: React.FC<FormProps> = ({
         label={
           <FormattedMessage
             defaultMessage="Set threshold for circle (per month)"
+            id="6BXcdo"
             description="src/components/Forms/CreateCircleForm/Init.tsx"
           />
         }
@@ -224,7 +231,7 @@ const Init: React.FC<FormProps> = ({
       type="submit"
       form={formId}
       disabled={isSubmitting}
-      text={<FormattedMessage defaultMessage="Next Step" />}
+      text={<FormattedMessage defaultMessage="Next Step" id="8cv9D4" />}
       loading={isSubmitting}
     />
   )
@@ -240,7 +247,9 @@ const Init: React.FC<FormProps> = ({
                 type="submit"
                 form={formId}
                 disabled={isSubmitting}
-                text={<FormattedMessage defaultMessage="Next Step" />}
+                text={
+                  <FormattedMessage defaultMessage="Next Step" id="8cv9D4" />
+                }
                 loading={isSubmitting}
               />
             </>
@@ -266,7 +275,7 @@ const Init: React.FC<FormProps> = ({
         smUpBtns={
           <>
             <Dialog.TextButton
-              text={<FormattedMessage defaultMessage="Cancel" />}
+              text={<FormattedMessage defaultMessage="Cancel" id="47FYwb" />}
               color="greyDarker"
               onClick={closeDialog}
             />

--- a/src/components/Forms/CreateCircleForm/Profile.tsx
+++ b/src/components/Forms/CreateCircleForm/Profile.tsx
@@ -113,10 +113,11 @@ const Init: React.FC<FormProps> = ({ circle, type, purpose, closeDialog }) => {
           message: isCreate ? (
             <FormattedMessage
               defaultMessage="Circle successfully created"
+              id="KLQ1/z"
               description="src/components/Forms/CreateCircleForm/Profile.tsx"
             />
           ) : (
-            <FormattedMessage defaultMessage="Saved" />
+            <FormattedMessage defaultMessage="Saved" id="fsB/4p" />
           ),
         })
 
@@ -158,7 +159,10 @@ const Init: React.FC<FormProps> = ({ circle, type, purpose, closeDialog }) => {
         />
 
         <p className={styles.hint}>
-          <FormattedMessage defaultMessage="Recommended size: 1600px x 900px" />
+          <FormattedMessage
+            defaultMessage="Recommended size: 1600px x 900px"
+            id="rfz/fN"
+          />
         </p>
       </section>
 
@@ -175,13 +179,14 @@ const Init: React.FC<FormProps> = ({ circle, type, purpose, closeDialog }) => {
 
       {!isCreate && (
         <Form.Input
-          label={<FormattedMessage defaultMessage="Circle Name" />}
+          label={<FormattedMessage defaultMessage="Circle Name" id="q9oMKE" />}
           hasLabel
           type="text"
           name="displayName"
           required
           placeholder={intl.formatMessage({
             defaultMessage: 'Enter the name of your Circle',
+            id: 'wXzTZ0',
           })}
           value={values.displayName}
           hint={`${values.displayName.length}/${MAX_CIRCLE_DISPLAY_NAME_LENGTH}`}
@@ -200,6 +205,7 @@ const Init: React.FC<FormProps> = ({ circle, type, purpose, closeDialog }) => {
         label={
           <FormattedMessage
             defaultMessage="Circle Description"
+            id="m/Wg7b"
             description="src/components/Forms/CreateCircleForm/Profile.tsx"
           />
         }
@@ -208,6 +214,7 @@ const Init: React.FC<FormProps> = ({ circle, type, purpose, closeDialog }) => {
         required
         placeholder={intl.formatMessage({
           defaultMessage: 'Describe more about your Circle',
+          id: 'QUqfbW',
           description: 'src/components/Forms/CreateCircleForm/Profile.tsx',
         })}
         value={values.description}
@@ -226,7 +233,7 @@ const Init: React.FC<FormProps> = ({ circle, type, purpose, closeDialog }) => {
       type="submit"
       form={formId}
       disabled={isSubmitting || coverLoading || avatarLoading}
-      text={<FormattedMessage defaultMessage="Confirm" />}
+      text={<FormattedMessage defaultMessage="Confirm" id="N2IrpM" />}
       loading={isSubmitting || coverLoading || avatarLoading}
     />
   )
@@ -243,7 +250,7 @@ const Init: React.FC<FormProps> = ({ circle, type, purpose, closeDialog }) => {
                 type="submit"
                 form={formId}
                 disabled={isSubmitting || coverLoading}
-                text={<FormattedMessage defaultMessage="Confirm" />}
+                text={<FormattedMessage defaultMessage="Confirm" id="N2IrpM" />}
                 loading={isSubmitting || coverLoading}
               />
             </>
@@ -269,7 +276,7 @@ const Init: React.FC<FormProps> = ({ circle, type, purpose, closeDialog }) => {
         smUpBtns={
           <>
             <Dialog.TextButton
-              text={<FormattedMessage defaultMessage="Cancel" />}
+              text={<FormattedMessage defaultMessage="Cancel" id="47FYwb" />}
               color="greyDarker"
               onClick={closeDialog}
             />

--- a/src/components/Forms/EditorSearchSelectForm/index.tsx
+++ b/src/components/Forms/EditorSearchSelectForm/index.tsx
@@ -218,7 +218,11 @@ const EditorSearchSelectForm = ({
           <>
             <Dialog.TextButton
               text={
-                back ? 'back' : <FormattedMessage defaultMessage="Cancel" />
+                back ? (
+                  'back'
+                ) : (
+                  <FormattedMessage defaultMessage="Cancel" id="47FYwb" />
+                )
               }
               color="greyDarker"
               onClick={back || closeDialog}

--- a/src/components/Forms/EmailLoginForm/OtherOptions.tsx
+++ b/src/components/Forms/EmailLoginForm/OtherOptions.tsx
@@ -14,11 +14,13 @@ export const SendLoginCodeButton = ({
   <section className={styles.option}>
     <FormattedMessage
       defaultMessage="Forgot password?"
+      id="O2Nqk8"
       description="src/components/Forms/EmailLoginForm/Buttons.tsx"
     />
     <Button aria-haspopup="dialog" onClick={sendLoginCode} disabled={disabled}>
       <FormattedMessage
         defaultMessage="Send login code"
+        id="qNuRmA"
         description="src/components/Forms/EmailLoginForm/Buttons.tsx"
       />
     </Button>
@@ -46,6 +48,7 @@ const OtherOptions = ({
         <section className={styles.hasSendCode}>
           <FormattedMessage
             defaultMessage="The login code has been sent to your inbox"
+            id="wbIHgJ"
             description="src/components/Forms/EmailLoginForm/OtherOptions.tsx"
           />
         </section>

--- a/src/components/Forms/EmailLoginForm/index.tsx
+++ b/src/components/Forms/EmailLoginForm/index.tsx
@@ -165,6 +165,7 @@ export const EmailLoginForm: React.FC<FormProps> = ({
           ) {
             const m = intl.formatMessage({
               defaultMessage: 'Incorrect email or password',
+              id: 'c/z318',
               description: 'src/components/Forms/EmailLoginForm/index.tsx',
             })
             setFieldError('password', m)
@@ -177,6 +178,7 @@ export const EmailLoginForm: React.FC<FormProps> = ({
               intl.formatMessage({
                 defaultMessage:
                   'This login code has expired, please try to resend',
+                id: 'TF1OhT',
               })
             )
           } else if (code.includes(ERROR_CODES.FORBIDDEN_BY_STATE)) {
@@ -184,6 +186,7 @@ export const EmailLoginForm: React.FC<FormProps> = ({
               'email',
               intl.formatMessage({
                 defaultMessage: 'Unavailable',
+                id: 'rADhX5',
                 description: 'FORBIDDEN_BY_STATE',
               })
             )
@@ -235,6 +238,7 @@ export const EmailLoginForm: React.FC<FormProps> = ({
             'email',
             intl.formatMessage({
               defaultMessage: 'Unavailable',
+              id: 'rADhX5',
               description: 'FORBIDDEN_BY_STATE',
             })
           )
@@ -249,12 +253,13 @@ export const EmailLoginForm: React.FC<FormProps> = ({
     <>
       <Form id={formId} onSubmit={handleSubmit}>
         <Form.Input
-          label={<FormattedMessage defaultMessage="Email" />}
+          label={<FormattedMessage defaultMessage="Email" id="sy+pv5" />}
           type="email"
           name="email"
           required
           placeholder={intl.formatMessage({
             defaultMessage: 'Email',
+            id: 'sy+pv5',
           })}
           value={values.email}
           error={errors.email}
@@ -268,12 +273,13 @@ export const EmailLoginForm: React.FC<FormProps> = ({
 
         <Form.Input
           // ref={passwordRef}
-          label={<FormattedMessage defaultMessage="Password" />}
+          label={<FormattedMessage defaultMessage="Password" id="5sg7KC" />}
           type="password"
           name="password"
           required
           placeholder={intl.formatMessage({
             defaultMessage: 'Password',
+            id: '5sg7KC',
           })}
           value={values.password}
           error={touched.password && errors.password}
@@ -289,6 +295,7 @@ export const EmailLoginForm: React.FC<FormProps> = ({
                   {countdown}&nbsp;
                   <FormattedMessage
                     defaultMessage="Resend"
+                    id="dzF4ci"
                     description="src/components/Forms/EmailLoginForm/index.tsx"
                   />
                 </span>
@@ -305,6 +312,7 @@ export const EmailLoginForm: React.FC<FormProps> = ({
                   >
                     <FormattedMessage
                       defaultMessage="Resend"
+                      id="dzF4ci"
                       description="src/components/Forms/EmailLoginForm/index.tsx"
                     />
                   </button>
@@ -345,6 +353,7 @@ export const EmailLoginForm: React.FC<FormProps> = ({
       text={
         <FormattedMessage
           defaultMessage="Sign in"
+          id="tBt9u0"
           description="src/components/Forms/EmailLoginForm/index.tsx"
         />
       }
@@ -359,11 +368,11 @@ export const EmailLoginForm: React.FC<FormProps> = ({
     <>
       {!isSelectMethod && (
         <DialogBeta.Header
-          title={<FormattedMessage defaultMessage="Sign In" />}
+          title={<FormattedMessage defaultMessage="Sign In" id="Ub+AGc" />}
           hasSmUpTitle={false}
           leftBtn={
             <DialogBeta.TextButton
-              text={<FormattedMessage defaultMessage="Back" />}
+              text={<FormattedMessage defaultMessage="Back" id="cyR7Kh" />}
               color="greyDarker"
               onClick={() => {
                 setIsSelectMethod(true)
@@ -409,7 +418,7 @@ export const EmailLoginForm: React.FC<FormProps> = ({
               <DialogBeta.TextButton
                 text={
                   <TextIcon icon={<IconLeft20 size="mdS" />} spacing="xxxtight">
-                    <FormattedMessage defaultMessage="Back" />
+                    <FormattedMessage defaultMessage="Back" id="cyR7Kh" />
                   </TextIcon>
                 }
                 color="greyDarker"
@@ -427,7 +436,7 @@ export const EmailLoginForm: React.FC<FormProps> = ({
           smUpBtns={
             <DialogBeta.TextButton
               color="greyDarker"
-              text={<FormattedMessage defaultMessage="Close" />}
+              text={<FormattedMessage defaultMessage="Close" id="rbrahO" />}
               onClick={closeDialog}
             />
           }

--- a/src/components/Forms/EmailSignUpForm/Complete/index.tsx
+++ b/src/components/Forms/EmailSignUpForm/Complete/index.tsx
@@ -25,6 +25,7 @@ const Complete = ({
       text={
         <FormattedMessage
           defaultMessage="Enter Community"
+          id="/asuIY"
           description="src/components/Forms/EmailSignUpForm/Complete.tsx"
         />
       }
@@ -65,6 +66,7 @@ const Complete = ({
           <h2>
             <FormattedMessage
               defaultMessage="Welcome to Matters!"
+              id="XH0Lb6"
               description="src/components/Forms/EmailSignUpForm/Complete.tsx"
             />
           </h2>
@@ -72,6 +74,7 @@ const Complete = ({
           <p>
             <FormattedMessage
               defaultMessage="Now, go like the authors you support! Your Likes will become their income"
+              id="stjoBH"
               description="src/components/Forms/EmailSignUpForm/Complete.tsx"
             />
           </p>
@@ -79,6 +82,7 @@ const Complete = ({
           <p>
             <FormattedMessage
               defaultMessage="You have created your personal creative space. Publish your first work!"
+              id="reOeq5"
               description="src/components/Forms/EmailSignUpForm/Complete.tsx"
             />
           </p>
@@ -86,6 +90,7 @@ const Complete = ({
           <p>
             <FormattedMessage
               defaultMessage="Start creating now!"
+              id="ANhCde"
               description="src/components/Forms/EmailSignUpForm/Complete.tsx"
             />
           </p>

--- a/src/components/Forms/EmailSignUpForm/Init.tsx
+++ b/src/components/Forms/EmailSignUpForm/Init.tsx
@@ -128,6 +128,7 @@ const Init: React.FC<FormProps> = ({
             'email',
             intl.formatMessage({
               defaultMessage: 'Unavailable',
+              id: 'rADhX5',
               description: 'FORBIDDEN_BY_STATE',
             })
           )
@@ -168,12 +169,13 @@ const Init: React.FC<FormProps> = ({
         }}
       />
       <Form.Input
-        label={<FormattedMessage defaultMessage="Email" />}
+        label={<FormattedMessage defaultMessage="Email" id="sy+pv5" />}
         type="email"
         name="email"
         required
         placeholder={intl.formatMessage({
           defaultMessage: 'Email',
+          id: 'sy+pv5',
         })}
         hintSize="sm"
         hintAlign="center"
@@ -199,6 +201,7 @@ const Init: React.FC<FormProps> = ({
       text={
         <FormattedMessage
           defaultMessage="Continue"
+          id="wK4kLf"
           description="src/components/Forms/EmailSignUpForm/Init.tsx"
         />
       }
@@ -209,11 +212,11 @@ const Init: React.FC<FormProps> = ({
   return (
     <>
       <DialogBeta.Header
-        title={<FormattedMessage defaultMessage="Sign Up" />}
+        title={<FormattedMessage defaultMessage="Sign Up" id="39AHJm" />}
         hasSmUpTitle={false}
         leftBtn={
           <DialogBeta.TextButton
-            text={<FormattedMessage defaultMessage="Back" />}
+            text={<FormattedMessage defaultMessage="Back" id="cyR7Kh" />}
             color="greyDarker"
             onClick={back}
           />
@@ -229,7 +232,9 @@ const Init: React.FC<FormProps> = ({
             purpose={purpose}
             type={authFeedType}
             setType={setAuthFeedType}
-            normalText={<FormattedMessage defaultMessage="Sign Up" />}
+            normalText={
+              <FormattedMessage defaultMessage="Sign Up" id="39AHJm" />
+            }
           />
           {isNormal && <>{InnerForm}</>}
           {isWallet && <AuthWalletFeed submitCallback={gotoWalletConnect} />}
@@ -243,7 +248,7 @@ const Init: React.FC<FormProps> = ({
               <DialogBeta.TextButton
                 text={
                   <TextIcon icon={<IconLeft20 size="mdS" />} spacing="xxxtight">
-                    <FormattedMessage defaultMessage="Back" />
+                    <FormattedMessage defaultMessage="Back" id="cyR7Kh" />
                   </TextIcon>
                 }
                 color="greyDarker"
@@ -260,7 +265,7 @@ const Init: React.FC<FormProps> = ({
           smUpBtns={
             <DialogBeta.TextButton
               color="greyDarker"
-              text={<FormattedMessage defaultMessage="Close" />}
+              text={<FormattedMessage defaultMessage="Close" id="rbrahO" />}
               onClick={closeDialog}
             />
           }

--- a/src/components/Forms/EmailSignUpForm/Password.tsx
+++ b/src/components/Forms/EmailSignUpForm/Password.tsx
@@ -154,19 +154,23 @@ const Password: React.FC<FormProps> = ({
   const InnerForm = (
     <Form id={formId} onSubmit={handleSubmit}>
       <Form.Input
-        label={<FormattedMessage defaultMessage="Password" />}
+        label={<FormattedMessage defaultMessage="Password" id="5sg7KC" />}
         type="password"
         name="password"
         required
         placeholder={intl.formatMessage({
           defaultMessage: 'Enter Password',
+          id: 'A41QIy',
         })}
         value={values.password}
         error={touched.password && errors.password}
         onBlur={handleBlur}
         onChange={handleChange}
         hint={
-          <FormattedMessage defaultMessage="Minimum 8 characters. Uppercase/lowercase letters, numbers and symbols are allowed" />
+          <FormattedMessage
+            defaultMessage="Minimum 8 characters. Uppercase/lowercase letters, numbers and symbols are allowed"
+            id="ml3SZN"
+          />
         }
         spacingBottom="base"
       />
@@ -175,6 +179,7 @@ const Password: React.FC<FormProps> = ({
         label={
           <FormattedMessage
             defaultMessage="Enter password again"
+            id="NzfL1d"
             description="src/components/Forms/EmailSignUpForm/Password.tsx"
           />
         }
@@ -183,12 +188,16 @@ const Password: React.FC<FormProps> = ({
         required
         placeholder={intl.formatMessage({
           defaultMessage: 'Enter password again',
+          id: 'NzfL1d',
           description: 'src/components/Forms/EmailSignUpForm/Password.tsx',
         })}
         value={values.comparedPassword}
         error={touched.comparedPassword && errors.comparedPassword}
         hint={
-          <FormattedMessage defaultMessage="Minimum 8 characters. Uppercase/lowercase letters, numbers and symbols are allowed" />
+          <FormattedMessage
+            defaultMessage="Minimum 8 characters. Uppercase/lowercase letters, numbers and symbols are allowed"
+            id="ml3SZN"
+          />
         }
         onBlur={handleBlur}
         onChange={handleChange}
@@ -201,7 +210,7 @@ const Password: React.FC<FormProps> = ({
       type="submit"
       form={formId}
       disabled={isSubmitting}
-      text={<FormattedMessage defaultMessage="Confirm" />}
+      text={<FormattedMessage defaultMessage="Confirm" id="N2IrpM" />}
       loading={isSubmitting}
     />
   )
@@ -216,7 +225,7 @@ const Password: React.FC<FormProps> = ({
               type="submit"
               form={formId}
               disabled={isSubmitting}
-              text={<FormattedMessage defaultMessage="Confirm" />}
+              text={<FormattedMessage defaultMessage="Confirm" id="N2IrpM" />}
               loading={isSubmitting}
             />
           }
@@ -241,7 +250,7 @@ const Password: React.FC<FormProps> = ({
         smUpBtns={
           <>
             <Dialog.TextButton
-              text={<FormattedMessage defaultMessage="Cancel" />}
+              text={<FormattedMessage defaultMessage="Cancel" id="47FYwb" />}
               color="greyDarker"
               onClick={closeDialog}
             />

--- a/src/components/Forms/PaymentForm/AddCredit/index.tsx
+++ b/src/components/Forms/PaymentForm/AddCredit/index.tsx
@@ -263,7 +263,11 @@ const BaseAddCredit: React.FC<FormProps> = ({
         <Dialog.Footer
           btns={
             <Dialog.RoundedButton
-              text={callbackText || <FormattedMessage defaultMessage="Done" />}
+              text={
+                callbackText || (
+                  <FormattedMessage defaultMessage="Done" id="JXdbo8" />
+                )
+              }
               onClick={callback || closeDialog}
             />
           }
@@ -272,7 +276,7 @@ const BaseAddCredit: React.FC<FormProps> = ({
               <Dialog.TextButton text={callbackText} onClick={callback} />
             ) : (
               <Dialog.TextButton
-                text={<FormattedMessage defaultMessage="Done" />}
+                text={<FormattedMessage defaultMessage="Done" id="JXdbo8" />}
                 color="greyDarker"
                 onClick={closeDialog}
               />
@@ -323,7 +327,7 @@ const BaseAddCredit: React.FC<FormProps> = ({
         smUpBtns={
           <>
             <Dialog.TextButton
-              text={<FormattedMessage defaultMessage="Cancel" />}
+              text={<FormattedMessage defaultMessage="Cancel" id="47FYwb" />}
               color="greyDarker"
               onClick={closeDialog}
             />

--- a/src/components/Forms/PaymentForm/ConnectStripeAccount/Request.tsx
+++ b/src/components/Forms/PaymentForm/ConnectStripeAccount/Request.tsx
@@ -52,7 +52,7 @@ const Request: React.FC<Props> = ({ back, nextStep, closeDialog }) => {
         closeDialog={closeDialog}
         leftBtn={
           <Dialog.TextButton
-            text={<FormattedMessage defaultMessage="Back" />}
+            text={<FormattedMessage defaultMessage="Back" id="cyR7Kh" />}
             onClick={back}
           />
         }
@@ -68,14 +68,14 @@ const Request: React.FC<Props> = ({ back, nextStep, closeDialog }) => {
           <>
             {back && (
               <Dialog.TextButton
-                text={<FormattedMessage defaultMessage="Back" />}
+                text={<FormattedMessage defaultMessage="Back" id="cyR7Kh" />}
                 color="greyDarker"
                 onClick={back}
               />
             )}
 
             <Dialog.TextButton
-              text={<FormattedMessage defaultMessage="Next Step" />}
+              text={<FormattedMessage defaultMessage="Next Step" id="8cv9D4" />}
               onClick={request}
               disabled={loading}
               loading={loading}

--- a/src/components/Forms/PaymentForm/PayTo/CurrencyChoice/index.tsx
+++ b/src/components/Forms/PaymentForm/PayTo/CurrencyChoice/index.tsx
@@ -167,7 +167,7 @@ const CurrencyChoice: React.FC<FormProps> = ({
       <Dialog.Footer
         smUpBtns={
           <Dialog.TextButton
-            text={<FormattedMessage defaultMessage="Cancel" />}
+            text={<FormattedMessage defaultMessage="Cancel" id="47FYwb" />}
             color="greyDarker"
             onClick={closeDialog}
           />

--- a/src/components/Forms/PaymentForm/PayTo/SetAmount/SetAmountHeader/WhyPolygonDialog/index.tsx
+++ b/src/components/Forms/PaymentForm/PayTo/SetAmount/SetAmountHeader/WhyPolygonDialog/index.tsx
@@ -39,7 +39,9 @@ const WhyPolygonDialog = ({ children }: WhyPolygonDialogProps) => {
             />
           }
           closeDialog={closeDialog}
-          closeText={<FormattedMessage defaultMessage="Understood" />}
+          closeText={
+            <FormattedMessage defaultMessage="Understood" id="GcvLBC" />
+          }
         />
 
         <Dialog.Message align="left" smUpAlign="left">
@@ -84,7 +86,9 @@ const WhyPolygonDialog = ({ children }: WhyPolygonDialogProps) => {
         <Dialog.Footer
           smUpBtns={
             <Dialog.TextButton
-              text={<FormattedMessage defaultMessage="Understood" />}
+              text={
+                <FormattedMessage defaultMessage="Understood" id="GcvLBC" />
+              }
               color="green"
               onClick={closeDialog}
             />

--- a/src/components/Forms/PaymentForm/PayTo/SetAmount/SubmitButton.tsx
+++ b/src/components/Forms/PaymentForm/PayTo/SetAmount/SubmitButton.tsx
@@ -83,7 +83,7 @@ const HKDSubmitButton: React.FC<SubmitButtonProps> = ({
   return (
     <WrapperButton
       mode={mode}
-      text={<FormattedMessage defaultMessage="Next Step" />}
+      text={<FormattedMessage defaultMessage="Next Step" id="8cv9D4" />}
       type="submit"
       form={formId}
       disabled={!isValid || isSubmitting || isBalanceInsufficient}
@@ -108,7 +108,7 @@ const LIKESubmitButton: React.FC<SubmitButtonProps> = ({
 
       <WrapperButton
         mode={mode}
-        text={<FormattedMessage defaultMessage="Next Step" />}
+        text={<FormattedMessage defaultMessage="Next Step" id="8cv9D4" />}
         type="submit"
         form={formId}
         disabled={!isValid || isSubmitting || isBalanceInsufficient}
@@ -196,7 +196,7 @@ const USDTSubmitButton: React.FC<SubmitButtonProps> = ({
     return (
       <WrapperButton
         mode={mode}
-        text={<FormattedMessage defaultMessage="Next Step" />}
+        text={<FormattedMessage defaultMessage="Next Step" id="8cv9D4" />}
         type="submit"
         form={formId}
         disabled={!isValid || isSubmitting || isBalanceInsufficient}

--- a/src/components/Forms/PaymentForm/PayTo/SetAmount/index.tsx
+++ b/src/components/Forms/PaymentForm/PayTo/SetAmount/index.tsx
@@ -404,12 +404,18 @@ const SetAmount: React.FC<FormProps> = ({
               <CopyToClipboard
                 text={viewer.info.ethAddress || ''}
                 successMessage={
-                  <FormattedMessage defaultMessage="Address copied" />
+                  <FormattedMessage
+                    defaultMessage="Address copied"
+                    id="+aMAeT"
+                  />
                 }
               >
                 <Button
                   spacing={['xtight', 'xtight']}
-                  aria-label={intl.formatMessage({ defaultMessage: 'Copy' })}
+                  aria-label={intl.formatMessage({
+                    defaultMessage: 'Copy',
+                    id: '4l6vz1',
+                  })}
                 >
                   <TextIcon
                     icon={<IconCopy16 color="black" size="xs" />}
@@ -430,7 +436,7 @@ const SetAmount: React.FC<FormProps> = ({
           <>
             <SubmitButton mode="rounded" {...submitButtonProps} />
             <Dialog.RoundedButton
-              text={<FormattedMessage defaultMessage="Back" />}
+              text={<FormattedMessage defaultMessage="Back" id="cyR7Kh" />}
               color="greyDarker"
               onClick={back}
             />
@@ -439,7 +445,7 @@ const SetAmount: React.FC<FormProps> = ({
         smUpBtns={
           <>
             <Dialog.TextButton
-              text={<FormattedMessage defaultMessage="Back" />}
+              text={<FormattedMessage defaultMessage="Back" id="cyR7Kh" />}
               color="greyDarker"
               onClick={back}
             />

--- a/src/components/Forms/PaymentForm/PaymentInfo/index.tsx
+++ b/src/components/Forms/PaymentForm/PaymentInfo/index.tsx
@@ -48,13 +48,16 @@ const PaymentInfo: React.FC<PaymentInfoProps> = ({
           <CopyToClipboard
             text={address}
             successMessage={
-              <FormattedMessage defaultMessage="Address copied" />
+              <FormattedMessage defaultMessage="Address copied" id="+aMAeT" />
             }
           >
             <Button
               spacing={['xxtight', 'tight']}
               bgColor="greenLighter"
-              aria-label={intl.formatMessage({ defaultMessage: 'Copy' })}
+              aria-label={intl.formatMessage({
+                defaultMessage: 'Copy',
+                id: '4l6vz1',
+              })}
             >
               <TextIcon
                 icon={<IconCopy16 color="green" size="sm" />}

--- a/src/components/Forms/PaymentForm/Payout/Confirm.tsx
+++ b/src/components/Forms/PaymentForm/Payout/Confirm.tsx
@@ -119,7 +119,7 @@ const BaseConfirm: React.FC<FormProps> = ({
 
   const SubmitButton = (
     <Dialog.TextButton
-      text={<FormattedMessage defaultMessage="Confirm" />}
+      text={<FormattedMessage defaultMessage="Confirm" id="N2IrpM" />}
       type="submit"
       form={formId}
       disabled={isSubmitting}
@@ -135,7 +135,7 @@ const BaseConfirm: React.FC<FormProps> = ({
         leftBtn={
           back ? (
             <Dialog.TextButton
-              text={<FormattedMessage defaultMessage="Back" />}
+              text={<FormattedMessage defaultMessage="Back" id="cyR7Kh" />}
               onClick={back}
             />
           ) : undefined

--- a/src/components/Forms/PaymentForm/Processing/index.tsx
+++ b/src/components/Forms/PaymentForm/Processing/index.tsx
@@ -287,7 +287,7 @@ const USDTProcessingForm: React.FC<Props> = ({
     <>
       <Dialog.Header
         closeDialog={closeDialog}
-        closeText={<FormattedMessage defaultMessage="Close" />}
+        closeText={<FormattedMessage defaultMessage="Close" id="rbrahO" />}
         title="donation"
       />
 

--- a/src/components/Forms/PaymentForm/ResetPassword/Confirm.tsx
+++ b/src/components/Forms/PaymentForm/ResetPassword/Confirm.tsx
@@ -174,7 +174,7 @@ const Confirm: React.FC<FormProps> = ({
         leftBtn={
           back ? (
             <Dialog.TextButton
-              text={<FormattedMessage defaultMessage="Back" />}
+              text={<FormattedMessage defaultMessage="Back" id="cyR7Kh" />}
               onClick={back}
             />
           ) : undefined
@@ -186,7 +186,7 @@ const Confirm: React.FC<FormProps> = ({
       <Dialog.Footer
         smUpBtns={
           <Dialog.TextButton
-            text={<FormattedMessage defaultMessage="Cancel" />}
+            text={<FormattedMessage defaultMessage="Cancel" id="47FYwb" />}
             color="greyDarker"
             onClick={closeDialog}
           />

--- a/src/components/Forms/PaymentForm/ResetPassword/Request.tsx
+++ b/src/components/Forms/PaymentForm/ResetPassword/Request.tsx
@@ -140,7 +140,7 @@ const Request: React.FC<FormProps> = ({
 
   const SubmitButton = (
     <Dialog.TextButton
-      text={<FormattedMessage defaultMessage="Next Step" />}
+      text={<FormattedMessage defaultMessage="Next Step" id="8cv9D4" />}
       type="submit"
       form={formId}
       disabled={isSubmitting}
@@ -156,7 +156,7 @@ const Request: React.FC<FormProps> = ({
         leftBtn={
           back ? (
             <Dialog.TextButton
-              text={<FormattedMessage defaultMessage="Back" />}
+              text={<FormattedMessage defaultMessage="Back" id="cyR7Kh" />}
               onClick={back}
             />
           ) : undefined

--- a/src/components/Forms/PaymentForm/SetPassword/index.tsx
+++ b/src/components/Forms/PaymentForm/SetPassword/index.tsx
@@ -206,7 +206,7 @@ const PaymentSetPasswordForm: React.FC<FormProps> = ({
       <Dialog.Footer
         smUpBtns={
           <Dialog.TextButton
-            text={<FormattedMessage defaultMessage="Cancel" />}
+            text={<FormattedMessage defaultMessage="Cancel" id="47FYwb" />}
             color="greyDarker"
             onClick={closeDialog}
           />

--- a/src/components/Forms/PaymentForm/SubscribeCircle/CardPayment.tsx
+++ b/src/components/Forms/PaymentForm/SubscribeCircle/CardPayment.tsx
@@ -182,7 +182,7 @@ const BaseCardPayment: React.FC<CardPaymentProps> = ({
           <>
             <Dialog.TextButton
               color="greyDarker"
-              text={<FormattedMessage defaultMessage="Cancel" />}
+              text={<FormattedMessage defaultMessage="Cancel" id="47FYwb" />}
               onClick={closeDialog}
             />
             <Dialog.TextButton

--- a/src/components/Forms/PaymentForm/SubscribeCircle/PasswordPayment.tsx
+++ b/src/components/Forms/PaymentForm/SubscribeCircle/PasswordPayment.tsx
@@ -165,7 +165,7 @@ const Confirm: React.FC<FormProps> = ({
           <>
             <Dialog.TextButton
               color="greyDarker"
-              text={<FormattedMessage defaultMessage="Cancel" />}
+              text={<FormattedMessage defaultMessage="Cancel" id="47FYwb" />}
               onClick={closeDialog}
             />
             <Dialog.TextButton

--- a/src/components/Forms/SearchSelectForm/index.tsx
+++ b/src/components/Forms/SearchSelectForm/index.tsx
@@ -114,7 +114,9 @@ const SearchSelectForm = ({
       onClick={onClickSave}
       // disabled={stagingNodes.length <= 0}
       text={
-        headerRightButtonText || <FormattedMessage defaultMessage="Confirm" />
+        headerRightButtonText || (
+          <FormattedMessage defaultMessage="Confirm" id="N2IrpM" />
+        )
       }
       loading={saving}
     />
@@ -155,7 +157,7 @@ const SearchSelectForm = ({
         smUpBtns={
           <>
             <Dialog.TextButton
-              text={<FormattedMessage defaultMessage="Cancel" />}
+              text={<FormattedMessage defaultMessage="Cancel" id="47FYwb" />}
               color="greyDarker"
               onClick={closeDialog}
             />

--- a/src/components/Forms/SelectAuthMethodForm/index.tsx
+++ b/src/components/Forms/SelectAuthMethodForm/index.tsx
@@ -81,7 +81,7 @@ export const SelectAuthMethodForm: React.FC<FormProps> = ({
           smUpBtns={
             <DialogBeta.TextButton
               color="greyDarker"
-              text={<FormattedMessage defaultMessage="Close" />}
+              text={<FormattedMessage defaultMessage="Close" id="rbrahO" />}
               onClick={closeDialog}
             />
           }

--- a/src/components/Forms/Verification/LinkSent.tsx
+++ b/src/components/Forms/Verification/LinkSent.tsx
@@ -27,11 +27,12 @@ export const VerificationLinkSent = ({
           title={
             <FormattedMessage
               defaultMessage="Check your inbox"
+              id="5JN+nl"
               description="src/components/Forms/Verification/LinkSent.tsx"
             />
           }
           closeDialog={closeDialog}
-          closeText={<FormattedMessage defaultMessage="Close" />}
+          closeText={<FormattedMessage defaultMessage="Close" id="rbrahO" />}
         />
 
         <DialogBeta.Content>
@@ -39,6 +40,7 @@ export const VerificationLinkSent = ({
             <p>
               <FormattedMessage
                 defaultMessage="The login link has been sent to {email}"
+                id="zAK5G+"
                 description="src/components/Forms/Verification/LinkSent.tsx"
                 values={{
                   email: <span className={styles.email}>{email}</span>,
@@ -52,7 +54,7 @@ export const VerificationLinkSent = ({
           <DialogBeta.Footer
             smUpBtns={
               <DialogBeta.TextButton
-                text={<FormattedMessage defaultMessage="Close" />}
+                text={<FormattedMessage defaultMessage="Close" id="rbrahO" />}
                 color="greyDarker"
                 onClick={closeDialog}
               />
@@ -64,13 +66,23 @@ export const VerificationLinkSent = ({
           <DialogBeta.Footer
             btns={
               <DialogBeta.RoundedButton
-                text={<FormattedMessage defaultMessage="Enter Matters" />}
+                text={
+                  <FormattedMessage
+                    defaultMessage="Enter Matters"
+                    id="A6r2p1"
+                  />
+                }
                 onClick={() => router.push(PATHS.HOME)}
               />
             }
             smUpBtns={
               <DialogBeta.TextButton
-                text={<FormattedMessage defaultMessage="Enter Matters" />}
+                text={
+                  <FormattedMessage
+                    defaultMessage="Enter Matters"
+                    id="A6r2p1"
+                  />
+                }
                 onClick={() => router.push(PATHS.HOME)}
               />
             }
@@ -88,7 +100,9 @@ export const VerificationLinkSent = ({
         <Dialog.Header
           title="register"
           closeDialog={closeDialog}
-          closeText={<FormattedMessage defaultMessage="Understood" />}
+          closeText={
+            <FormattedMessage defaultMessage="Understood" id="GcvLBC" />
+          }
         />
       )}
 
@@ -112,7 +126,9 @@ export const VerificationLinkSent = ({
         <Dialog.Footer
           smUpBtns={
             <Dialog.TextButton
-              text={<FormattedMessage defaultMessage="Understood" />}
+              text={
+                <FormattedMessage defaultMessage="Understood" id="GcvLBC" />
+              }
               color="green"
               onClick={closeDialog}
             />

--- a/src/components/Forms/WalletAuthForm/Connect.tsx
+++ b/src/components/Forms/WalletAuthForm/Connect.tsx
@@ -224,6 +224,7 @@ const Connect: React.FC<FormProps> = ({
             message: (
               <FormattedMessage
                 defaultMessage="Wallet connected"
+                id="KlJEP9"
                 description="src/components/Forms/WalletAuthForm/Connect.tsx"
               />
             ),
@@ -262,7 +263,7 @@ const Connect: React.FC<FormProps> = ({
           leftBtn={
             back ? (
               <DialogBeta.TextButton
-                text={<FormattedMessage defaultMessage="Back" />}
+                text={<FormattedMessage defaultMessage="Back" id="cyR7Kh" />}
                 onClick={onBack}
                 color="greyDarker"
               />
@@ -303,6 +304,7 @@ const Connect: React.FC<FormProps> = ({
           <span>
             <FormattedMessage
               defaultMessage="Please sign message in your wallet"
+              id="WDZndZ"
               description="src/components/Forms/WalletAuthForm/Connect.tsx"
             />
           </span>
@@ -317,6 +319,7 @@ const Connect: React.FC<FormProps> = ({
                 <TextIcon icon={<IconLeft20 size="mdS" />} spacing="xxxtight">
                   <FormattedMessage
                     defaultMessage="Switch wallet"
+                    id="HkozYU"
                     description="src/components/Forms/WalletAuthForm/Connect.tsx"
                   />
                 </TextIcon>
@@ -327,7 +330,7 @@ const Connect: React.FC<FormProps> = ({
 
             {isInDialog && (
               <DialogBeta.TextButton
-                text={<FormattedMessage defaultMessage="Close" />}
+                text={<FormattedMessage defaultMessage="Close" id="rbrahO" />}
                 color="greyDarker"
                 onClick={onCloseDialog}
               />

--- a/src/components/Forms/WalletAuthForm/Select.tsx
+++ b/src/components/Forms/WalletAuthForm/Select.tsx
@@ -38,6 +38,7 @@ const Hint = () => {
         <p>
           <FormattedMessage
             defaultMessage="Have wallet questions on mobile device ? Click the "
+            id="70UCEy"
             description="src/components/Forms/WalletAuthForm/Select.tsx"
           />
           <a
@@ -46,7 +47,7 @@ const Hint = () => {
             target="_blank"
             rel="noreferrer"
           >
-            <FormattedMessage defaultMessage="tutorial" />
+            <FormattedMessage defaultMessage="tutorial" id="uw32VR" />
           </a>
         </p>
       </Media>
@@ -54,6 +55,7 @@ const Hint = () => {
         <p>
           <FormattedMessage
             defaultMessage="Don't have a wallet yet? Check the "
+            id="vCt85u"
             description="src/components/Forms/WalletAuthForm/Select.tsx"
           />
           <a
@@ -62,7 +64,7 @@ const Hint = () => {
             target="_blank"
             rel="noreferrer"
           >
-            <FormattedMessage defaultMessage="tutorial" />
+            <FormattedMessage defaultMessage="tutorial" id="uw32VR" />
           </a>
         </p>
       </Media>
@@ -128,6 +130,7 @@ const Select: React.FC<FormProps> = ({
             <li>
               <FormattedMessage
                 defaultMessage="Matters continues to provide services that combine creativity with blockchain technology. You will be the first to experience them after completing connecting wallet."
+                id="HxcjQl"
                 description="src/components/Forms/WalletAuthForm/Select.tsx"
               />
             </li>
@@ -135,6 +138,7 @@ const Select: React.FC<FormProps> = ({
               <strong>
                 <FormattedMessage
                   defaultMessage="Wallet address will be part of your digital identity and shown in your profile page."
+                  id="LqxIEU"
                   description="src/components/Forms/WalletAuthForm/Select.tsx"
                 />
               </strong>
@@ -142,6 +146,7 @@ const Select: React.FC<FormProps> = ({
             <li>
               <FormattedMessage
                 defaultMessage="The original login via email will be kept for you. Please note that your wallet cannot be reset once it is connected because of your account security."
+                id="UOdEqi"
                 description="src/components/Forms/WalletAuthForm/Select.tsx"
               />
             </li>
@@ -149,6 +154,7 @@ const Select: React.FC<FormProps> = ({
               <strong>
                 <FormattedMessage
                   defaultMessage="Matters will never ask your wallet key through any channel."
+                  id="VrOoVf"
                   description="src/components/Forms/WalletAuthForm/Select.tsx"
                 />
               </strong>
@@ -172,6 +178,7 @@ const Select: React.FC<FormProps> = ({
             groupName={
               <FormattedMessage
                 defaultMessage="Account"
+                id="v6YjIn"
                 description="src/components/Forms/WalletAuthForm/Select.tsx"
               />
             }
@@ -182,7 +189,9 @@ const Select: React.FC<FormProps> = ({
         )}
 
         <TableView
-          groupName={<FormattedMessage defaultMessage="Connect Wallet" />}
+          groupName={
+            <FormattedMessage defaultMessage="Connect Wallet" id="cg1VJ2" />
+          }
           spacingX={isInPage ? 0 : 'base'}
         >
           {injectedConnector?.ready ? (
@@ -217,6 +226,7 @@ const Select: React.FC<FormProps> = ({
                 >
                   <FormattedMessage
                     defaultMessage="Install MetaMask"
+                    id="FaTb0A"
                     description="src/components/Forms/WalletAuthForm/Select.tsx"
                   />
                 </TextIcon>
@@ -290,16 +300,16 @@ const Select: React.FC<FormProps> = ({
         leftBtn={
           back ? (
             <Dialog.TextButton
-              text={<FormattedMessage defaultMessage="Back" />}
+              text={<FormattedMessage defaultMessage="Back" id="cyR7Kh" />}
               onClick={onBack}
             />
           ) : null
         }
         title={
           isConnect ? (
-            <FormattedMessage defaultMessage="Connect Wallet" />
+            <FormattedMessage defaultMessage="Connect Wallet" id="cg1VJ2" />
           ) : (
-            <FormattedMessage defaultMessage="Enter" />
+            <FormattedMessage defaultMessage="Enter" id="H8KGyc" />
           )
         }
       />

--- a/src/components/GQL/error.tsx
+++ b/src/components/GQL/error.tsx
@@ -29,207 +29,257 @@ export const getErrorCodes = (error?: ApolloError): ERROR_CODES[] => {
 export const ERROR_MESSAGES: { [key in ERROR_CODES]: MessageDescriptor } = {
   [ERROR_CODES.UNKNOWN_ERROR]: defineMessage({
     defaultMessage: 'Unknown error. Please try again later.',
+    id: '/TXBJR',
     description: 'UNKNOWN_ERROR',
   }),
   [ERROR_CODES.NETWORK_ERROR]: defineMessage({
     defaultMessage: 'Please refresh the page and try again.',
+    id: 'yToCTn',
     description: 'NETWORK_ERROR',
   }),
   [ERROR_CODES.INTERNAL_SERVER_ERROR]: defineMessage({
     defaultMessage: 'Oops. Something went wrong. Please try again later.',
+    id: '0jvbdb',
     description: 'INTERNAL_SERVER_ERROR',
   }),
   [ERROR_CODES.BAD_USER_INPUT]: defineMessage({
     defaultMessage: 'Oops. Something went wrong. Please try again later.',
+    id: '73iajM',
     description: 'BAD_USER_INPUT',
   }),
   [ERROR_CODES.ACTION_LIMIT_EXCEEDED]: defineMessage({
     defaultMessage: 'Operation too frequent, please try again later.',
+    id: 'zvNfwL',
     description: 'ACTION_LIMIT_EXCEEDED',
   }),
   [ERROR_CODES.ACTION_FAILED]: defineMessage({
     defaultMessage: 'Operation failed, please try again later.',
+    id: 'MPEeBy',
     description: 'ACTION_FAILED',
   }),
   [ERROR_CODES.UNABLE_TO_UPLOAD_FROM_URL]: defineMessage({
     defaultMessage:
       'File upload failed, please verify the file link is valid, or manually download and upload again.',
+    id: '+o9W2T',
     description: 'UNABLE_TO_UPLOAD_FROM_URL',
   }),
   [ERROR_CODES.NAME_INVALID]: defineMessage({
     defaultMessage: 'Invalid name',
+    id: 'n3shsQ',
     description: 'NAME_INVALID',
   }),
   [ERROR_CODES.NAME_EXISTS]: defineMessage({
     defaultMessage: 'This name is already taken.',
+    id: 'y4Lyf1',
     description: 'NAME_EXISTS',
   }),
   [ERROR_CODES.DISPLAYNAME_INVALID]: defineMessage({
     defaultMessage: 'Invalid display name',
+    id: 'xxDjET',
     description: 'DISPLAYNAME_INVALID',
   }),
   [ERROR_CODES.UNAUTHENTICATED]: defineMessage({
     defaultMessage: 'Please log in.',
+    id: 'YPMn9n',
     description: 'UNAUTHENTICATED',
   }),
   [ERROR_CODES.FORBIDDEN]: defineMessage({
     defaultMessage: 'You do not have permission to perform this operation',
+    id: 'Ro0CuW',
     description: 'FORBIDDEN',
   }),
   [ERROR_CODES.FORBIDDEN_BY_STATE]: defineMessage({
     defaultMessage: 'You do not have permission to perform this operation',
+    id: 'EoeUjA',
     description: 'FORBIDDEN_BY_STATE',
   }),
   [ERROR_CODES.FORBIDDEN_BY_TARGET_STATE]: defineMessage({
     defaultMessage: 'You do not have permissionn to perform this operation',
+    id: 'LmiUWG',
     description: 'FORBIDDEN_BY_TARGET_STATE',
   }),
   [ERROR_CODES.TOKEN_INVALID]: defineMessage({
     defaultMessage: 'Please log in again.',
+    id: 'QXJQ5G',
     description: 'TOKEN_INVALID',
   }),
   [ERROR_CODES.ENTITY_NOT_FOUND]: defineMessage({
     defaultMessage: 'Entity not found',
+    id: '8iciCA',
     description: 'ENTITY_NOT_FOUND',
   }),
   [ERROR_CODES.USER_NOT_FOUND]: defineMessage({
     defaultMessage: 'User not found',
+    id: 'S/hoJx',
     description: 'USER_NOT_FOUND',
   }),
   [ERROR_CODES.COMMENT_NOT_FOUND]: defineMessage({
     defaultMessage: 'Comment not found',
+    id: 'vJd1we',
     description: 'COMMENT_NOT_FOUND',
   }),
   [ERROR_CODES.ARTICLE_NOT_FOUND]: defineMessage({
     defaultMessage: 'Article not found',
+    id: '+rB5Am',
     description: 'ARTICLE_NOT_FOUND',
   }),
   [ERROR_CODES.ASSET_NOT_FOUND]: defineMessage({
     defaultMessage: 'Asset not found',
+    id: '4KuZ0o',
     description: 'ASSET_NOT_FOUND',
   }),
   [ERROR_CODES.DRAFT_NOT_FOUND]: defineMessage({
     defaultMessage: 'Draft not found',
+    id: 'wDX7zn',
     description: 'DRAFT_NOT_FOUND',
   }),
   [ERROR_CODES.TAG_NOT_FOUND]: defineMessage({
     defaultMessage: 'Tag not found',
+    id: 'NNF+3f',
     description: 'TAG_NOT_FOUND',
   }),
   [ERROR_CODES.NOTICE_NOT_FOUND]: defineMessage({
     defaultMessage: 'Notification not found',
+    id: 'wMNZJa',
     description: 'NOTICE_NOT_FOUND',
   }),
   [ERROR_CODES.CIRCLE_NOT_FOUND]: defineMessage({
     defaultMessage: 'Circle not found',
+    id: '/pnYHM',
     description: 'CIRCLE_NOT_FOUND',
   }),
   [ERROR_CODES.ARTICLE_REVISION_CONTENT_INVALID]: defineMessage({
     defaultMessage: 'Article revision content is invalid',
+    id: 'SzrjpI',
     description: 'ARTICLE_REVISION_CONTENT_INVALID',
   }),
   [ERROR_CODES.ARTICLE_REVISION_REACH_LIMIT]: defineMessage({
     defaultMessage: 'Article revision count reach limit',
+    id: 'xjHiYx',
     description: 'ARTICLE_REVISION_REACH_LIMIT',
   }),
   [ERROR_CODES.USER_EMAIL_INVALID]: defineMessage({
     defaultMessage: 'Invalid Email',
+    id: 'nozN+j',
     description: 'USER_EMAIL_INVALID',
   }),
   [ERROR_CODES.USER_EMAIL_EXISTS]: defineMessage({
     defaultMessage:
       'This email has been used, please go to login or try another one',
+    id: 'sg3nVO',
     description: 'USER_EMAIL_EXISTS',
   }),
   [ERROR_CODES.USER_EMAIL_NOT_FOUND]: defineMessage({
     defaultMessage: 'Incorrect email or password',
+    id: 'PtV68+',
     description: 'USER_EMAIL_NOT_FOUND',
   }),
   [ERROR_CODES.USER_PASSWORD_INVALID]: defineMessage({
     defaultMessage: 'Incorrect email or password',
+    id: '+63O1f',
     description: 'USER_PASSWORD_INVALID',
   }),
   [ERROR_CODES.CRYPTO_WALLET_EXISTS]: defineMessage({
     defaultMessage: 'Wallet is linked to a different account',
+    id: 'v8dGSd',
     description: 'CRYPTO_WALLET_EXISTS',
   }),
   [ERROR_CODES.USER_SOCIAL_ACCOUNT_EXISTS]: defineMessage({
     defaultMessage:
       'This Google account is connected to a Matters account. Sign in to that account to disconnect it then try again',
+    id: 'AEiogR',
     description: 'USER_SOCIAL_ACCOUNT_EXISTS',
   }),
   [ERROR_CODES.DUPLICATE_TAG]: defineMessage({
     defaultMessage: 'This tag is already taken',
+    id: '5MDA6O',
     description: 'DUPLICATE_TAG',
   }),
   [ERROR_CODES.TOO_MANY_TAGS_FOR_ARTICLE]: defineMessage({
     defaultMessage: 'Add up to 5 tags',
+    id: 'tQ3+Xo',
     description: 'TOO_MANY_TAGS_FOR_ARTICLE',
   }),
   [ERROR_CODES.TAG_EDITORS_REACH_LIMIT]: defineMessage({
     defaultMessage: 'Maximum 4 editors allowed for each tag',
+    id: 'XmnzQT',
     description: 'TAG_EDITORS_REACH_LIMIT',
   }),
   [ERROR_CODES.CIRCLE_CREATION_REACH_LIMIT]: defineMessage({
     defaultMessage: 'Each user can only create one circle.',
+    id: 'T2kMnM',
     description: 'CIRCLE_CREATION_REACH_LIMIT',
   }),
   [ERROR_CODES.DUPLICATE_CIRCLE]: defineMessage({
     defaultMessage: 'This circle is already taken.',
+    id: 'n6ZdqD',
     description: 'DUPLICATE_CIRCLE',
   }),
   [ERROR_CODES.DUPLICATE_CIRCLE_SUBSCRIPTION]: defineMessage({
     defaultMessage: 'Already subscribed to this circle.',
+    id: 'cYvIpp',
     description: 'DUPLICATE_CIRCLE_SUBSCRIPTION',
   }),
   [ERROR_CODES.CODE_INVALID]: defineMessage({
     defaultMessage:
       'Incorrect verification code. Please check your input, or try resend',
+    id: 'lI2l2/',
     description: 'CODE_INVALID',
   }),
   [ERROR_CODES.CODE_INACTIVE]: defineMessage({
     defaultMessage:
       'Verification code is no longer valid. Please use the latest code we sent, or try resend',
+    id: 'mu01Gw',
     description: 'CODE_INACTIVE',
   }),
   [ERROR_CODES.CODE_EXPIRED]: defineMessage({
     defaultMessage: 'Verification code expired, try resend',
+    id: 'rZyVay',
     description: 'CODE_EXPIRED',
   }),
   [ERROR_CODES.LIKER_EMAIL_EXISTS]: defineMessage({
     defaultMessage: 'Liker ID email is already taken.',
+    id: '5sWnog',
     description: 'LIKER_EMAIL_EXISTS',
   }),
   [ERROR_CODES.LIKER_USER_ID_EXISTS]: defineMessage({
     defaultMessage: 'Liker ID is already taken.',
+    id: '1y1U9f',
     description: 'LIKER_USER_ID_EXISTS',
   }),
   [ERROR_CODES.OAUTH_TOKEN_INVALID]: defineMessage({
     defaultMessage: 'Please log in again.',
+    id: '6N2LKY',
     description: 'OAUTH_TOKEN_INVALID',
   }),
   [ERROR_CODES.MIGRATION_REACH_LIMIT]: defineMessage({
     defaultMessage: '1 MB maximum',
+    id: 'pjunBi',
     description: 'MIGRATION_REACH_LIMIT',
   }),
   [ERROR_CODES.PAYMENT_AMOUNT_TOO_SMALL]: defineMessage({
     defaultMessage: 'The payment amount is too small, please re-enter.',
+    id: 'Avukw5',
     description: 'PAYMENT_AMOUNT_TOO_SMALL',
   }),
   [ERROR_CODES.PAYMENT_AMOUNT_INVALID]: defineMessage({
     defaultMessage: 'The payment amount is invalid, please re-enter.',
+    id: 'ggS9L7',
     description: 'PAYMENT_AMOUNT_INVALID',
   }),
   [ERROR_CODES.PAYMENT_BALANCE_INSUFFICIENT]: defineMessage({
     defaultMessage: 'Insufficient wallet balance.',
+    id: 'XdLnXf',
     description: 'PAYMENT_BALANCE_INSUFFICIENT',
   }),
   [ERROR_CODES.PAYMENT_PASSWORD_NOT_SET]: defineMessage({
     defaultMessage: 'Please set your transcation password.',
+    id: 'AwQHHA',
     description: 'PAYMENT_PASSWORD_NOT_SET',
   }),
   [ERROR_CODES.PAYMENT_REACH_MAXIMUM_LIMIT]: defineMessage({
     defaultMessage: 'The daily limit is 5000 HKD',
+    id: 'cufo9X',
     description: 'PAYMENT_REACH_MAXIMUM_LIMIT',
   }),
 }
@@ -292,6 +342,7 @@ export const toastMutationErrors = (
           content: (
             <FormattedMessage
               defaultMessage="Log in"
+              id="skbUBl"
               description="src/components/Buttons/Login/index.tsx"
             />
           ),

--- a/src/components/GlobalToasts/EmailVerificationToast/ResendAction.tsx
+++ b/src/components/GlobalToasts/EmailVerificationToast/ResendAction.tsx
@@ -69,6 +69,7 @@ const ResendAction = ({ initCountdown }: Props) => {
         {countdown}&nbsp;
         <FormattedMessage
           defaultMessage="Resend"
+          id="dzF4ci"
           description="src/components/Forms/EmailLoginForm/index.tsx"
         />
       </span>
@@ -77,7 +78,7 @@ const ResendAction = ({ initCountdown }: Props) => {
 
   return (
     <span onClick={resend} className={styles.resendButton}>
-      <FormattedMessage defaultMessage="Resend" />
+      <FormattedMessage defaultMessage="Resend" id="IXycMo" />
     </span>
   )
 }

--- a/src/components/GlobalToasts/EmailVerificationToast/index.tsx
+++ b/src/components/GlobalToasts/EmailVerificationToast/index.tsx
@@ -23,6 +23,7 @@ const EmailVerificationToast = () => {
       message: (
         <FormattedMessage
           defaultMessage="The email verification link has been sent to {email}, please check your inbox"
+          id="OAc8+i"
           description="src/components/GlobalToast/index.tsx"
           values={{
             email: viewer.info.email,

--- a/src/components/Hook/useUnloadConfirm.tsx
+++ b/src/components/Hook/useUnloadConfirm.tsx
@@ -18,6 +18,7 @@ export const useUnloadConfirm = ({
     hint ||
     intl.formatMessage({
       defaultMessage: 'Saving draft, are you sure you want to leave?',
+      id: 'LWE7oq',
     })
 
   const onRouteChange = () => {

--- a/src/components/Interaction/InfiniteScroll/EndOfResults/index.tsx
+++ b/src/components/Interaction/InfiniteScroll/EndOfResults/index.tsx
@@ -12,6 +12,7 @@ const EndOfResults: React.FC<EndOfResultsProps> = ({ message }) => {
       {typeof message === 'boolean' && message ? (
         <FormattedMessage
           defaultMessage="That's all"
+          id="B2As08"
           description="src/components/Interaction/InfiniteScroll/EndOfResults/index.tsx"
         />
       ) : (

--- a/src/components/Layout/Header/MeButton/SideDrawerNav/DrawerContent/MeMenu/index.tsx
+++ b/src/components/Layout/Header/MeButton/SideDrawerNav/DrawerContent/MeMenu/index.tsx
@@ -48,7 +48,7 @@ const Top: React.FC = () => {
     <Menu>
       <Menu.Item
         {...menuItemProps}
-        text={<FormattedMessage defaultMessage="Profile" />}
+        text={<FormattedMessage defaultMessage="Profile" id="itPgxd" />}
         icon={<IconProfile24 size="md" />}
         {...viewerPath}
         is="link"
@@ -56,7 +56,7 @@ const Top: React.FC = () => {
 
       <Menu.Item
         {...menuItemProps}
-        text={<FormattedMessage defaultMessage="History" />}
+        text={<FormattedMessage defaultMessage="History" id="djJp6c" />}
         icon={<IconHistory24 size="md" />}
         href={PATHS.ME_HISTORY}
         is="link"
@@ -64,7 +64,7 @@ const Top: React.FC = () => {
 
       <Menu.Item
         {...menuItemProps}
-        text={<FormattedMessage defaultMessage="Bookmarks" />}
+        text={<FormattedMessage defaultMessage="Bookmarks" id="nGBrvw" />}
         icon={<IconBookmark24 size="md" />}
         href={PATHS.ME_BOOKMARKS}
         is="link"
@@ -72,7 +72,7 @@ const Top: React.FC = () => {
 
       <Menu.Item
         {...menuItemProps}
-        text={<FormattedMessage defaultMessage="Drafts" />}
+        text={<FormattedMessage defaultMessage="Drafts" id="2atspc" />}
         icon={<IconDraft24 size="md" />}
         href={PATHS.ME_DRAFTS}
         is="link"
@@ -81,7 +81,7 @@ const Top: React.FC = () => {
       {circlePath && (
         <Menu.Item
           {...menuItemProps}
-          text={<FormattedMessage defaultMessage="Circle" />}
+          text={<FormattedMessage defaultMessage="Circle" id="vH8sCb" />}
           icon={<IconCircle24 size="md" />}
           href={circlePath.href}
           is="link"
@@ -90,7 +90,7 @@ const Top: React.FC = () => {
 
       <Menu.Item
         {...menuItemProps}
-        text={<FormattedMessage defaultMessage="Wallet" />}
+        text={<FormattedMessage defaultMessage="Wallet" id="3yk8fB" />}
         icon={<IconWallet24 size="md" />}
         href={PATHS.ME_WALLET}
         is="link"
@@ -98,7 +98,7 @@ const Top: React.FC = () => {
 
       <Menu.Item
         {...menuItemProps}
-        text={<FormattedMessage defaultMessage="Stats" />}
+        text={<FormattedMessage defaultMessage="Stats" id="U86B6w" />}
         icon={<IconAnalytics24 size="md" />}
         href={PATHS.ME_ANALYTICS}
         is="link"
@@ -127,7 +127,10 @@ const Bottom = () => {
     } catch (e) {
       toast.error({
         message: (
-          <FormattedMessage defaultMessage="Failed to log out, please try again." />
+          <FormattedMessage
+            defaultMessage="Failed to log out, please try again."
+            id="Szd1tH"
+          />
         ),
       })
     }
@@ -137,7 +140,7 @@ const Bottom = () => {
     <Menu>
       <Menu.Item
         {...menuItemProps}
-        text={<FormattedMessage defaultMessage="Settings" />}
+        text={<FormattedMessage defaultMessage="Settings" id="D3idYv" />}
         icon={<IconSettings24 size="md" />}
         href={PATHS.ME_SETTINGS}
         is="link"
@@ -145,7 +148,7 @@ const Bottom = () => {
 
       <Menu.Item
         {...menuItemProps}
-        text={<FormattedMessage defaultMessage="Log Out" />}
+        text={<FormattedMessage defaultMessage="Log Out" id="H0JBH6" />}
         icon={<IconLogout24 size="md" />}
         onClick={onClickLogout}
       />

--- a/src/components/Layout/Header/MeButton/SideDrawerNav/DrawerContent/index.tsx
+++ b/src/components/Layout/Header/MeButton/SideDrawerNav/DrawerContent/index.tsx
@@ -46,7 +46,10 @@ const DrawerContent: React.FC<DrawerContentProps> = ({
       <VisuallyHidden>
         <Button
           onClick={onDismiss}
-          aria-label={intl.formatMessage({ defaultMessage: 'Close' })}
+          aria-label={intl.formatMessage({
+            defaultMessage: 'Close',
+            id: 'rbrahO',
+          })}
         />
       </VisuallyHidden>
 

--- a/src/components/Layout/Header/ShareButton/index.tsx
+++ b/src/components/Layout/Header/ShareButton/index.tsx
@@ -17,6 +17,7 @@ export const ShareButton: React.FC<Omit<ShareDialogProps, 'children'>> = (
         <Button
           aria-label={intl.formatMessage({
             defaultMessage: 'Share',
+            id: 'OKhRC6',
           })}
           aria-haspopup="dialog"
           bgColor="halfBlack"

--- a/src/components/Layout/SideFooter/index.tsx
+++ b/src/components/Layout/SideFooter/index.tsx
@@ -10,18 +10,20 @@ const CommunityMenu = () => {
   return (
     <Menu>
       <Menu.Item
-        text={<FormattedMessage defaultMessage="Matters Community" />}
+        text={
+          <FormattedMessage defaultMessage="Matters Community" id="FhWC22" />
+        }
         href={PATHS.COMMUNITY}
       />
 
       <Menu.Item
-        text={<FormattedMessage defaultMessage="Open Source" />}
+        text={<FormattedMessage defaultMessage="Open Source" id="Xd0J7Y" />}
         htmlHref={EXTERNAL_LINKS.DEVELOPER_RESOURCE}
         htmlTarget="_blank"
       />
 
       <Menu.Item
-        text={<FormattedMessage defaultMessage="Bug Report" />}
+        text={<FormattedMessage defaultMessage="Bug Report" id="9Fpc9S" />}
         htmlHref={EXTERNAL_LINKS.BUG_REPORT}
         htmlTarget="_blank"
       />
@@ -41,21 +43,21 @@ const SideFooter = () => {
       <section className={styles.links}>
         <Link href={PATHS.ABOUT} legacyBehavior>
           <a>
-            <FormattedMessage defaultMessage="About" />
+            <FormattedMessage defaultMessage="About" id="g5pX+a" />
             <Dot />
           </a>
         </Link>
 
         <Link href={PATHS.GUIDE} legacyBehavior>
           <a>
-            <FormattedMessage defaultMessage="Explore" />
+            <FormattedMessage defaultMessage="Explore" id="7JlauX" />
             <Dot />
           </a>
         </Link>
 
         <Link href={PATHS.TOS} legacyBehavior>
           <a>
-            <FormattedMessage defaultMessage="Terms" />
+            <FormattedMessage defaultMessage="Terms" id="xkr+zo" />
             <Dot />
           </a>
         </Link>
@@ -63,7 +65,7 @@ const SideFooter = () => {
         <Dropdown content={<CommunityMenu />} zIndex={Z_INDEX.OVER_DIALOG}>
           {({ openDropdown, ref }) => (
             <button onClick={openDropdown} ref={ref}>
-              <FormattedMessage defaultMessage="Community" />
+              <FormattedMessage defaultMessage="Community" id="4CrCbD" />
             </button>
           )}
         </Dropdown>

--- a/src/components/Layout/SideNav/Items.tsx
+++ b/src/components/Layout/SideNav/Items.tsx
@@ -18,7 +18,7 @@ export const NavListItemHome = () => {
 
   return (
     <NavListItem
-      name={<FormattedMessage defaultMessage="Discover" />}
+      name={<FormattedMessage defaultMessage="Discover" id="cE4Hfw" />}
       icon={<IconNavHome32 size="lg" />}
       activeIcon={<IconNavHomeActive32 size="lg" />}
       active={isInHome}
@@ -33,7 +33,7 @@ export const NavListItemSearch = () => {
 
   return (
     <NavListItem
-      name={<FormattedMessage defaultMessage="Search" />}
+      name={<FormattedMessage defaultMessage="Search" id="xmcVZ0" />}
       icon={<IconNavSearch32 size="lg" />}
       activeIcon={<IconNavSearchActive32 size="lg" />}
       active={isInSearch}

--- a/src/components/Layout/SideNav/Logo.tsx
+++ b/src/components/Layout/SideNav/Logo.tsx
@@ -15,6 +15,7 @@ const Logo = () => {
         <a
           aria-label={intl.formatMessage({
             defaultMessage: 'Discover',
+            id: 'cE4Hfw',
           })}
         >
           <IconLogoGraph />

--- a/src/components/Layout/SideNav/MeMenu.tsx
+++ b/src/components/Layout/SideNav/MeMenu.tsx
@@ -56,7 +56,10 @@ const MeMenu: React.FC = () => {
     } catch (e) {
       toast.error({
         message: (
-          <FormattedMessage defaultMessage="Failed to log out, please try again." />
+          <FormattedMessage
+            defaultMessage="Failed to log out, please try again."
+            id="Szd1tH"
+          />
         ),
       })
     }
@@ -65,28 +68,28 @@ const MeMenu: React.FC = () => {
   return (
     <Menu>
       <Menu.Item
-        text={<FormattedMessage defaultMessage="Profile" />}
+        text={<FormattedMessage defaultMessage="Profile" id="itPgxd" />}
         icon={<IconProfile24 size="mdS" />}
         {...viewerPath}
         is="link"
       />
 
       <Menu.Item
-        text={<FormattedMessage defaultMessage="History" />}
+        text={<FormattedMessage defaultMessage="History" id="djJp6c" />}
         icon={<IconHistory24 size="mdS" />}
         href={PATHS.ME_HISTORY}
         is="link"
       />
 
       <Menu.Item
-        text={<FormattedMessage defaultMessage="Bookmarks" />}
+        text={<FormattedMessage defaultMessage="Bookmarks" id="nGBrvw" />}
         icon={<IconBookmark24 size="mdS" />}
         href={PATHS.ME_BOOKMARKS}
         is="link"
       />
 
       <Menu.Item
-        text={<FormattedMessage defaultMessage="Drafts" />}
+        text={<FormattedMessage defaultMessage="Drafts" id="2atspc" />}
         icon={<IconDraft24 size="mdS" />}
         href={PATHS.ME_DRAFTS}
         is="link"
@@ -94,7 +97,7 @@ const MeMenu: React.FC = () => {
 
       {circlePath && (
         <Menu.Item
-          text={<FormattedMessage defaultMessage="Circle" />}
+          text={<FormattedMessage defaultMessage="Circle" id="vH8sCb" />}
           icon={<IconCircle24 size="mdS" />}
           href={circlePath.href}
           is="link"
@@ -102,14 +105,14 @@ const MeMenu: React.FC = () => {
       )}
 
       <Menu.Item
-        text={<FormattedMessage defaultMessage="Wallet" />}
+        text={<FormattedMessage defaultMessage="Wallet" id="3yk8fB" />}
         icon={<IconWallet24 size="mdS" />}
         href={PATHS.ME_WALLET}
         is="link"
       />
 
       <Menu.Item
-        text={<FormattedMessage defaultMessage="Stats" />}
+        text={<FormattedMessage defaultMessage="Stats" id="U86B6w" />}
         icon={<IconAnalytics24 size="mdS" />}
         href={PATHS.ME_ANALYTICS}
         is="link"
@@ -118,14 +121,14 @@ const MeMenu: React.FC = () => {
       <Menu.Divider />
 
       <Menu.Item
-        text={<FormattedMessage defaultMessage="Settings" />}
+        text={<FormattedMessage defaultMessage="Settings" id="D3idYv" />}
         icon={<IconSettings24 size="mdS" />}
         href={PATHS.ME_SETTINGS}
         is="link"
       />
 
       <Menu.Item
-        text={<FormattedMessage defaultMessage="Log Out" />}
+        text={<FormattedMessage defaultMessage="Log Out" id="H0JBH6" />}
         icon={<IconLogout24 size="mdS" />}
         onClick={onClickLogout}
       />

--- a/src/components/Layout/SideNav/index.tsx
+++ b/src/components/Layout/SideNav/index.tsx
@@ -46,6 +46,7 @@ const SideNavMenu = () => {
         name={
           <FormattedMessage
             defaultMessage="Following"
+            id="32bml8"
             description="src/components/Layout/SideNav/index.tsx"
           />
         }
@@ -56,7 +57,7 @@ const SideNavMenu = () => {
       />
 
       <NavListItem
-        name={<FormattedMessage defaultMessage="Notifications" />}
+        name={<FormattedMessage defaultMessage="Notifications" id="NAidKb" />}
         icon={<UnreadIcon.Notification />}
         activeIcon={<UnreadIcon.Notification active />}
         active={isInNotification}
@@ -73,7 +74,7 @@ const SideNavMenu = () => {
           <section>
             <VisuallyHidden>
               <button type="button">
-                <FormattedMessage defaultMessage="Cancel" />
+                <FormattedMessage defaultMessage="Cancel" id="47FYwb" />
               </button>
             </VisuallyHidden>
             <MeMenu />
@@ -87,7 +88,7 @@ const SideNavMenu = () => {
         {({ openDropdown, ref }) => (
           <NavListItem
             onClick={openDropdown}
-            name={<FormattedMessage defaultMessage="My Page" />}
+            name={<FormattedMessage defaultMessage="My Page" id="enMIYK" />}
             icon={<IconNavMe32 size="lg" />}
             activeIcon={<IconNavMeActive32 size="lg" />}
             active={isInMe}

--- a/src/components/Notice/ArticleArticleNotice/ArticleNewCollectedNotice.tsx
+++ b/src/components/Notice/ArticleArticleNotice/ArticleNewCollectedNotice.tsx
@@ -26,6 +26,7 @@ const ArticleNewCollectedNotice = ({
       action={
         <FormattedMessage
           defaultMessage="connected"
+          id="YlPCRU"
           description="src/components/Notice/ArticleArticleNotice/ArticleNewCollectedNotice.tsx"
         />
       }

--- a/src/components/Notice/ArticleNotice/ArticleMentionedYouNotice.tsx
+++ b/src/components/Notice/ArticleNotice/ArticleMentionedYouNotice.tsx
@@ -22,6 +22,7 @@ const ArticleMentionedYouNotice = ({
       action={
         <FormattedMessage
           defaultMessage="mentioned you in {article}"
+          id="8w3GEA"
           description="src/components/Notice/ArticleNotice/ArticleMentionedYouNotice.tsx"
           values={{
             article: <NoticeArticleTitle article={notice.article} />,

--- a/src/components/Notice/ArticleNotice/ArticleNewAppreciationNotice.tsx
+++ b/src/components/Notice/ArticleNotice/ArticleNewAppreciationNotice.tsx
@@ -22,6 +22,7 @@ const ArticleNewAppreciationNotice = ({
       action={
         <FormattedMessage
           defaultMessage="liked"
+          id="p5qZnJ"
           description="src/components/Notice/ArticleNotice/ArticleNewAppreciationNotice.tsx"
         />
       }

--- a/src/components/Notice/ArticleNotice/ArticleNewSubscriberNotice.tsx
+++ b/src/components/Notice/ArticleNotice/ArticleNewSubscriberNotice.tsx
@@ -22,6 +22,7 @@ const ArticleNewSubscriberNotice = ({
       action={
         <FormattedMessage
           defaultMessage="bookmarked"
+          id="CD688y"
           description="src/components/Notice/ArticleNotice/ArticleNewSubscriberNotice.tsx"
         />
       }

--- a/src/components/Notice/ArticleNotice/ArticlePublishedNotice.tsx
+++ b/src/components/Notice/ArticleNotice/ArticlePublishedNotice.tsx
@@ -22,6 +22,7 @@ const ArticlePublishedNotice = ({
       <section className={styles.noticeActorsNameAndTitleInfo}>
         <FormattedMessage
           defaultMessage="Your work {articleTitle} has been published to decentralized network"
+          id="tEeEJT"
           description="src/components/Notice/ArticleNotice/ArticlePublishedNotice.tsx"
           values={{
             articleTitle: <NoticeArticleTitle article={notice.article} />,

--- a/src/components/Notice/ArticleNotice/CircleNewArticle.tsx
+++ b/src/components/Notice/ArticleNotice/CircleNewArticle.tsx
@@ -30,6 +30,7 @@ const CircleNewArticle = ({
         <FormattedMessage
           description="src/components/Notice/ArticleNotice/CircleNewArticle.tsx"
           defaultMessage="published in {circleName}"
+          id="GVes61"
           values={{
             circleName: <NoticeCircleName circle={circle} />,
           }}

--- a/src/components/Notice/ArticleNotice/RevisedArticleNotPublishedNotice.tsx
+++ b/src/components/Notice/ArticleNotice/RevisedArticleNotPublishedNotice.tsx
@@ -28,6 +28,7 @@ const RevisedArticleNotPublishedNotice = ({
         <NoticeHead>
           <FormattedMessage
             defaultMessage="Failed to republish article"
+            id="QV19cI"
             description="src/components/Notice/ArticleNotice/RevisedArticleNotPublishedNotice.tsx"
           />
         </NoticeHead>

--- a/src/components/Notice/ArticleNotice/RevisedArticlePublishedNotice.tsx
+++ b/src/components/Notice/ArticleNotice/RevisedArticlePublishedNotice.tsx
@@ -22,6 +22,7 @@ const RevisedArticlePublishedNotice = ({
       <section className={styles.noticeActorsNameAndTitleInfo}>
         <FormattedMessage
           defaultMessage="Your work {articleTitle} has been republished to decentralized network"
+          id="gN4jLB"
           description="src/components/Notice/ArticleNotice/RevisedArticlePublishedNotice.tsx"
           values={{
             articleTitle: <NoticeArticleTitle article={notice.article} />,

--- a/src/components/Notice/CircleNotice/CircleInvitationNotice.tsx
+++ b/src/components/Notice/CircleNotice/CircleInvitationNotice.tsx
@@ -27,6 +27,7 @@ const CircleInvitationNotice = ({
       action={
         <FormattedMessage
           defaultMessage="invites you to join the circle {circleName} , and you can experience it for {freePeriod} days for free"
+          id="ItUuuX"
           description="src/components/Notice/CircleNotice/CircleInvitationNotice.tsx"
           values={{
             circleName: <NoticeCircleName circle={notice.circle} />,

--- a/src/components/Notice/CircleNotice/CircleNewBroadcastComments.tsx
+++ b/src/components/Notice/CircleNotice/CircleNewBroadcastComments.tsx
@@ -60,12 +60,14 @@ const CircleNewBroadcastComments = ({
             {replyCount && !mentionCount && (
               <FormattedMessage
                 defaultMessage="commented in your circle broadcast"
+                id="Y+spJC"
                 description="src/components/Notice/CircleNotice/CircleNewBroadcastComments.tsx"
               />
             )}
             {replyCount && mentionCount && (
               <FormattedMessage
                 defaultMessage="mentioned you in your circle broadcast comment"
+                id="XQTBu6"
                 description="src/components/Notice/CircleNotice/CircleNewBroadcastComments.tsx"
               />
             )}
@@ -91,6 +93,7 @@ const CircleNewBroadcastComments = ({
           {replyCount && !mentionCount && (
             <FormattedMessage
               defaultMessage="commented broadcast in {circleName}"
+              id="EZMrtJ"
               description="src/components/Notice/CircleNotice/CircleNewBroadcastComments.tsx"
               values={{
                 circleName: (
@@ -105,6 +108,7 @@ const CircleNewBroadcastComments = ({
           {replyCount && mentionCount && (
             <FormattedMessage
               defaultMessage="mentioned you in broadcast comment in {circleName}"
+              id="r66dXx"
               description="src/components/Notice/CircleNotice/CircleNewBroadcastComments.tsx"
               values={{
                 circleName: (

--- a/src/components/Notice/CircleNotice/CircleNewDiscussionComments.tsx
+++ b/src/components/Notice/CircleNotice/CircleNewDiscussionComments.tsx
@@ -62,6 +62,7 @@ const CircleNewDiscussionComments = ({
             {(newDiscussionCount || replyCount) && !mentionCount && (
               <FormattedMessage
                 defaultMessage="left a comment in your circle"
+                id="6Vznnt"
                 description="src/components/Notice/CircleNotice/CircleNewDiscussionComments.tsx"
               />
             )}
@@ -69,6 +70,7 @@ const CircleNewDiscussionComments = ({
             {(newDiscussionCount || replyCount) && mentionCount && (
               <FormattedMessage
                 defaultMessage="left comments and mentioned you in your circle"
+                id="V8msLJ"
                 description="src/components/Notice/CircleNotice/CircleNewDiscussionComments.tsx"
               />
             )}
@@ -87,6 +89,7 @@ const CircleNewDiscussionComments = ({
           {(newDiscussionCount || replyCount) && !mentionCount && (
             <FormattedMessage
               defaultMessage="left a comment in {circleName}"
+              id="zllCbU"
               description="src/components/Notice/CircleNotice/CircleNewDiscussionComments.tsx"
               values={{
                 circleName: (
@@ -101,6 +104,7 @@ const CircleNewDiscussionComments = ({
           {(newDiscussionCount || replyCount) && mentionCount && (
             <FormattedMessage
               defaultMessage="left a comment in {circleName} and mentioned you"
+              id="wER32z"
               description="src/components/Notice/CircleNotice/CircleNewDiscussionComments.tsx"
               values={{
                 circleName: (

--- a/src/components/Notice/CircleNotice/CircleNewUserNotice.tsx
+++ b/src/components/Notice/CircleNotice/CircleNewUserNotice.tsx
@@ -30,6 +30,7 @@ const CircleNewUserNotice = ({ notice, userType }: CircleNewUserNotice) => {
         action={
           <FormattedMessage
             defaultMessage="followed your circle"
+            id="hk2aiz"
             description="src/components/Notice/CircleNotice/CircleNewUserNotice.tsx"
           />
         }
@@ -45,6 +46,7 @@ const CircleNewUserNotice = ({ notice, userType }: CircleNewUserNotice) => {
         action={
           <FormattedMessage
             defaultMessage="subscribed your circle"
+            id="mPe6DK"
             description="src/components/Notice/CircleNotice/CircleNewUserNotice.tsx"
           />
         }
@@ -59,6 +61,7 @@ const CircleNewUserNotice = ({ notice, userType }: CircleNewUserNotice) => {
       action={
         <FormattedMessage
           defaultMessage="unsubscribed your circle"
+          id="qYzBk8"
           description="src/components/Notice/CircleNotice/CircleNewUserNotice.tsx"
         />
       }

--- a/src/components/Notice/CommentCommentNotice/CommentNewReplyNotice.tsx
+++ b/src/components/Notice/CommentCommentNotice/CommentNewReplyNotice.tsx
@@ -37,6 +37,7 @@ const CommentNewReplyNotice = ({
           action={
             <FormattedMessage
               defaultMessage="replied your comment in"
+              id="nNB7KU"
               description="src/components/Notice/CommentCommentNotice/CommentNewReplyNotice.tsx"
             />
           }
@@ -44,6 +45,7 @@ const CommentNewReplyNotice = ({
           secondAction={
             <FormattedMessage
               defaultMessage="comment"
+              id="ZUPQzl"
               description="src/components/Notice/CommentCommentNotice/CommentNewReplyNotice.tsx"
             />
           }
@@ -61,6 +63,7 @@ const CommentNewReplyNotice = ({
           action={
             <FormattedMessage
               defaultMessage=" replied to your discussion on"
+              id="8rMZWb"
               description="src/components/Notice/CommentCommentNotice/CommentNewReplyNotice.tsx"
             />
           }
@@ -68,6 +71,7 @@ const CommentNewReplyNotice = ({
           secondAction={
             <FormattedMessage
               defaultMessage="comment_circle"
+              id="aaUBvF"
               description="src/components/Notice/CommentCommentNotice/CommentNewReplyNotice.tsx"
             />
           }

--- a/src/components/Notice/CommentNotice/ArticleNewCommentNotice.tsx
+++ b/src/components/Notice/CommentNotice/ArticleNewCommentNotice.tsx
@@ -30,6 +30,7 @@ const ArticleNewCommentNotice = ({
       action={
         <FormattedMessage
           defaultMessage="commented"
+          id="lZukEr"
           description="src/components/Notice/CommentNotice/ArticleNewCommentNotice.tsx"
         />
       }

--- a/src/components/Notice/CommentNotice/CircleNewBroadcastNotice.tsx
+++ b/src/components/Notice/CommentNotice/CircleNewBroadcastNotice.tsx
@@ -40,6 +40,7 @@ const CircleNewBroadcastNotice = ({
       action={
         <FormattedMessage
           defaultMessage="broadcast in {circlename}"
+          id="jy3tx0"
           values={{
             circlename: commentCircle && (
               <NoticeCircleName

--- a/src/components/Notice/CommentNotice/CommentMentionedYouNotice.tsx
+++ b/src/components/Notice/CommentNotice/CommentMentionedYouNotice.tsx
@@ -53,6 +53,7 @@ const CommentMentionedYouNotice = ({
           action={
             <FormattedMessage
               defaultMessage="mentioned you in a comment at {commentArticle}"
+              id="1zVIWy"
               description="src/components/Notice/CommentNotice/CommentMentionedYouNotice.tsx"
               values={{
                 commentArticle: <NoticeArticleTitle article={commentArticle} />,
@@ -69,6 +70,7 @@ const CommentMentionedYouNotice = ({
           action={
             <FormattedMessage
               defaultMessage="commented in {commentCircle}"
+              id="BHFHeY"
               description="src/components/Notice/CommentNotice/CommentMentionedYouNotice.tsx"
               values={{
                 commentCircle: (
@@ -84,11 +86,13 @@ const CommentMentionedYouNotice = ({
             commentCircleDiscussion ? (
               <FormattedMessage
                 defaultMessage="discussion and mentioned you"
+                id="yZfKI4"
                 description="src/components/Notice/CommentNotice/CommentMentionedYouNotice.tsx"
               />
             ) : commentCircleBroadcast ? (
               <FormattedMessage
                 defaultMessage="broadcast and mentioned you"
+                id="Xz/AHp"
                 description="src/components/Notice/CommentNotice/CommentMentionedYouNotice.tsx"
               />
             ) : undefined

--- a/src/components/Notice/CommentNotice/CommentPinnedNotice.tsx
+++ b/src/components/Notice/CommentNotice/CommentPinnedNotice.tsx
@@ -27,6 +27,7 @@ const CommentPinnedNotice = ({
       action={
         <FormattedMessage
           defaultMessage="pinned your comment in {commentArticle}"
+          id="cAP9g5"
           description="src/components/Notice/CommentNotice/CommentPinnedNotice.tsx"
           values={{
             commentArticle: commentArticle && (

--- a/src/components/Notice/TransactionNotice/PaymentReceivedDonationNotice.tsx
+++ b/src/components/Notice/TransactionNotice/PaymentReceivedDonationNotice.tsx
@@ -28,6 +28,7 @@ const PaymentReceivedDonationNotice = ({
       action={
         <FormattedMessage
           defaultMessage="supported"
+          id="vLEnrs"
           description="src/components/Notice/TransactionNotice/PaymentReceivedDonationNotice.tsx"
         />
       }

--- a/src/components/Notice/UserNotice/UserNewFollowerNotice.tsx
+++ b/src/components/Notice/UserNotice/UserNewFollowerNotice.tsx
@@ -20,6 +20,7 @@ const UserNewFollowerNotice = ({
       action={
         <FormattedMessage
           defaultMessage="followed you"
+          id="k5NnNF"
           description="src/components/Notice/UserNotice/UserNewFollowerNotice.tsx"
         />
       }

--- a/src/components/Search/SearchBar/index.tsx
+++ b/src/components/Search/SearchBar/index.tsx
@@ -44,6 +44,7 @@ const SearchButton = () => {
       type="submit"
       aria-label={intl.formatMessage({
         defaultMessage: 'Search',
+        id: 'xmcVZ0',
       })}
     >
       <IconSearch16 color="greyDark" />
@@ -84,9 +85,11 @@ export const SearchBar: React.FC<SearchBarProps> = ({
 
   const textAriaLabel = intl.formatMessage({
     defaultMessage: 'Search',
+    id: 'xmcVZ0',
   })
   const textPlaceholder = intl.formatMessage({
     defaultMessage: 'Search',
+    id: 'xmcVZ0',
   })
 
   const searchTextInput = useRef<HTMLInputElement>(null)

--- a/src/components/Share/Buttons/Douban.tsx
+++ b/src/components/Share/Buttons/Douban.tsx
@@ -46,6 +46,7 @@ const Douban = ({
         <TextIcon icon={withIcon(IconShareDouban)({})} spacing="base">
           <FormattedMessage
             defaultMessage="Douban"
+            id="NONfAh"
             description="src/components/Share/Buttons/Douban.tsx"
           />
         </TextIcon>

--- a/src/components/Share/Buttons/Email.tsx
+++ b/src/components/Share/Buttons/Email.tsx
@@ -41,7 +41,7 @@ const Email = ({
 
       {!circle && (
         <TextIcon icon={withIcon(IconShareEmail)({})} spacing="base">
-          <FormattedMessage defaultMessage="Email" />
+          <FormattedMessage defaultMessage="Email" id="sy+pv5" />
         </TextIcon>
       )}
     </button>

--- a/src/components/Share/Buttons/Weibo.tsx
+++ b/src/components/Share/Buttons/Weibo.tsx
@@ -43,6 +43,7 @@ const Weibo = ({
         <TextIcon icon={withIcon(IconShareWeibo)({})} spacing="base">
           <FormattedMessage
             defaultMessage="Weibo"
+            id="rBjwQy"
             description="src/components/Share/Buttons/Weibo.tsx"
           />
         </TextIcon>

--- a/src/components/Transaction/PurposeTitle/index.tsx
+++ b/src/components/Transaction/PurposeTitle/index.tsx
@@ -34,12 +34,14 @@ const PurposeTitle = ({ tx }: { tx: DigestTransactionFragment }) => {
           isViewerRecipient && (
             <FormattedMessage
               defaultMessage="Circle Revenue"
+              id="R7yHDl"
               description="src/components/Transaction/index.tsx"
             />
           )}
         {purpose === TransactionPurpose.SubscriptionSplit && isViewerSender && (
           <FormattedMessage
             defaultMessage="Circle Subscription"
+            id="0qagOO"
             description="src/components/Transaction/index.tsx"
           />
         )}
@@ -47,6 +49,7 @@ const PurposeTitle = ({ tx }: { tx: DigestTransactionFragment }) => {
         {purpose === TransactionPurpose.AddCredit && (
           <FormattedMessage
             defaultMessage="Top Up"
+            id="yOKEVx"
             description="src/components/Transaction/index.tsx"
           />
         )}
@@ -54,6 +57,7 @@ const PurposeTitle = ({ tx }: { tx: DigestTransactionFragment }) => {
         {purpose === TransactionPurpose.Refund && (
           <FormattedMessage
             defaultMessage="Refund"
+            id="yoRaUc"
             description="src/components/Transaction/index.tsx"
           />
         )}
@@ -61,6 +65,7 @@ const PurposeTitle = ({ tx }: { tx: DigestTransactionFragment }) => {
         {purpose === TransactionPurpose.Payout && (
           <FormattedMessage
             defaultMessage="Payout"
+            id="Sep44m"
             description="src/components/Transaction/index.tsx"
           />
         )}
@@ -68,6 +73,7 @@ const PurposeTitle = ({ tx }: { tx: DigestTransactionFragment }) => {
         {purpose === TransactionPurpose.PayoutReversal && (
           <FormattedMessage
             defaultMessage="Payout Canceled"
+            id="79Ydsg"
             description="src/components/Transaction/index.tsx"
           />
         )}
@@ -76,6 +82,7 @@ const PurposeTitle = ({ tx }: { tx: DigestTransactionFragment }) => {
           <>
             <FormattedMessage
               defaultMessage="Dispute Refund"
+              id="up6Uh/"
               description="src/components/Transaction/index.tsx"
             />
 
@@ -83,6 +90,7 @@ const PurposeTitle = ({ tx }: { tx: DigestTransactionFragment }) => {
               content={
                 <FormattedMessage
                   defaultMessage="Payment suspended or returned by card issuer when there are doubts about the transaction"
+                  id="AB5rDl"
                   description="src/components/Transaction/index.tsx"
                 />
               }

--- a/src/components/Transaction/State/index.tsx
+++ b/src/components/Transaction/State/index.tsx
@@ -52,7 +52,7 @@ const State = ({ state, message, blockchainTx }: StateProps) => {
           color="grey"
           textPlacement="left"
         >
-          <FormattedMessage defaultMessage="On-chain records" />
+          <FormattedMessage defaultMessage="On-chain records" id="6kMb9Z" />
         </TextIcon>
       </Button>
     )
@@ -82,6 +82,7 @@ const State = ({ state, message, blockchainTx }: StateProps) => {
         return (
           <FormattedMessage
             defaultMessage="Cancelled"
+            id="6uavsa"
             description="src/components/Transaction/State/index.tsx"
           />
         )
@@ -89,6 +90,7 @@ const State = ({ state, message, blockchainTx }: StateProps) => {
         return (
           <FormattedMessage
             defaultMessage="Failed"
+            id="1COpAA"
             description="src/components/Transaction/State/index.tsx"
           />
         )
@@ -96,6 +98,7 @@ const State = ({ state, message, blockchainTx }: StateProps) => {
         return (
           <FormattedMessage
             defaultMessage="Processing"
+            id="awW+lk"
             description="src/components/Transaction/State/index.tsx"
           />
         )

--- a/src/views/ArticleDetail/EditMode/Header/ConfirmRevisedPublishDialogContent/index.tsx
+++ b/src/views/ArticleDetail/EditMode/Header/ConfirmRevisedPublishDialogContent/index.tsx
@@ -31,7 +31,7 @@ const ConfirmRevisedPublishDialogContent = ({
         title={<Translate zh_hant="發布須知" zh_hans="發布须知" en="Notice" />}
         leftBtn={
           <Dialog.TextButton
-            text={<FormattedMessage defaultMessage="Back" />}
+            text={<FormattedMessage defaultMessage="Back" id="cyR7Kh" />}
             onClick={onBack}
           />
         }
@@ -67,7 +67,7 @@ const ConfirmRevisedPublishDialogContent = ({
           <>
             <Dialog.TextButton
               color="greyDarker"
-              text={<FormattedMessage defaultMessage="Back" />}
+              text={<FormattedMessage defaultMessage="Back" id="cyR7Kh" />}
               onClick={onBack}
             />
             {SubmitButton}

--- a/src/views/ArticleDetail/EditMode/Header/index.tsx
+++ b/src/views/ArticleDetail/EditMode/Header/index.tsx
@@ -100,6 +100,7 @@ const EditModeHeader = ({
         message: (
           <FormattedMessage
             defaultMessage={`Content length exceeds limit ({length}/{limit})`}
+            id="VefaFQ"
             values={{ length: contentCount, limit: MAX_ARTICLE_CONTENT_LENGTH }}
           />
         ),
@@ -227,7 +228,7 @@ const EditModeHeader = ({
             disabled={isEditDisabled || isOverDiffLimit}
           >
             <TextIcon color="white" size="md" weight="md">
-              <FormattedMessage defaultMessage="Next Step" />
+              <FormattedMessage defaultMessage="Next Step" id="8cv9D4" />
             </TextIcon>
           </Button>
         )}

--- a/src/views/ArticleDetail/Toolbar/CommentBar/index.tsx
+++ b/src/views/ArticleDetail/Toolbar/CommentBar/index.tsx
@@ -159,7 +159,10 @@ const CommentBar = ({ article, disabled }: CommentBarProps) => {
         onClick={() => {
           toast.error({
             message: (
-              <FormattedMessage defaultMessage="The author has disabled comments for this article" />
+              <FormattedMessage
+                defaultMessage="The author has disabled comments for this article"
+                id="7cwoRo"
+              />
             ),
           })
         }}

--- a/src/views/ArticleDetail/Wall/Sensitive/index.tsx
+++ b/src/views/ArticleDetail/Wall/Sensitive/index.tsx
@@ -20,6 +20,7 @@ const SensitiveWall = ({
       <p className={styles.bgBlurContent}>
         <FormattedMessage
           defaultMessage="Caution: The following content may include age-restricted or explicit content, violence, gore, etc. Some may experience discomfort and psychological distress."
+          id="0JLcHr"
           description="src/views/ArticleDetail/Wall/Sensitive/index.tsx"
         />
       </p>
@@ -27,6 +28,7 @@ const SensitiveWall = ({
         <section className={styles.header}>
           <FormattedMessage
             defaultMessage="This post may include sensitive content and has been marked by the {actor} as restricted content. Are you sure you want to expand the full text?"
+            id="s5JCCO"
             description="src/views/ArticleDetail/Wall/Sensitive/index.tsx"
             values={{
               actor: sensitiveByAuthor ? (
@@ -40,6 +42,7 @@ const SensitiveWall = ({
         <section className={styles.content}>
           <FormattedMessage
             defaultMessage="Caution: The following content may include age-restricted or explicit content, violence, gore, etc. Some may experience discomfort and psychological distress."
+            id="0JLcHr"
             description="src/views/ArticleDetail/Wall/Sensitive/index.tsx"
           />
         </section>

--- a/src/views/ArticleDetail/Wall/Visitor/index.tsx
+++ b/src/views/ArticleDetail/Wall/Visitor/index.tsx
@@ -70,7 +70,10 @@ const VisitorWall = ({ show }: VisitorWallProps) => {
           <div className={styles.close}>
             <Button
               onClick={closeDialog}
-              aria-label={intl.formatMessage({ defaultMessage: 'Close' })}
+              aria-label={intl.formatMessage({
+                defaultMessage: 'Close',
+                id: 'rbrahO',
+              })}
             >
               <IconClear16 color="grey" />
             </Button>

--- a/src/views/Callback/SocialCallback.tsx
+++ b/src/views/Callback/SocialCallback.tsx
@@ -113,6 +113,7 @@ const SocialCallback = ({ type }: Props) => {
                 message: (
                   <FormattedMessage
                     defaultMessage="Unavailable"
+                    id="rADhX5"
                     description="FORBIDDEN_BY_STATE"
                   />
                 ),

--- a/src/views/Callback/UI.tsx
+++ b/src/views/Callback/UI.tsx
@@ -21,17 +21,20 @@ const UI = ({ hasError }: Props) => {
             <section className={styles.title}>
               <FormattedMessage
                 defaultMessage="Oops！This link has expired"
+                id="EwbNbl"
                 description="src/views/Callback/GoogleCallback.tsx"
               />
             </section>
             <section className={styles.content}>
               <FormattedMessage
                 defaultMessage="Please go to the relevant page to resend the link. You can also "
+                id="GG9uXH"
                 description="src/views/Callback/GoogleCallback.tsx"
               />
               <a className={styles.link} href={PATHS.HOME}>
                 <FormattedMessage
                   defaultMessage="go to the homepage"
+                  id="tQimre"
                   description="src/views/Callback/GoogleCallback.tsx"
                 />
               </a>

--- a/src/views/Circle/Analytics/ContentAnalytics/ContentDigest/index.tsx
+++ b/src/views/Circle/Analytics/ContentAnalytics/ContentDigest/index.tsx
@@ -24,7 +24,7 @@ interface CircleAnalyticsContentProps {
 const Count = ({ count }: { count: number }) => {
   return (
     <Tooltip
-      content={<FormattedMessage defaultMessage="Read Counts" />}
+      content={<FormattedMessage defaultMessage="Read Counts" id="8KFsZN" />}
       trigger="click"
     >
       <button type="button" className={styles.count}>

--- a/src/views/Circle/Analytics/ContentAnalytics/ContentTabs/index.tsx
+++ b/src/views/Circle/Analytics/ContentAnalytics/ContentTabs/index.tsx
@@ -21,6 +21,7 @@ const ContentTabs: React.FC<Props> = ({ type, setType }) => {
       >
         <FormattedMessage
           defaultMessage="Paywalled"
+          id="LOefol"
           description="src/views/Circle/Analytics/ContentAnalytics/ContentTabs/index.tsx"
         />
       </SegmentedTabs.Tab>
@@ -28,6 +29,7 @@ const ContentTabs: React.FC<Props> = ({ type, setType }) => {
       <SegmentedTabs.Tab onClick={() => setType('public')} selected={isPublic}>
         <FormattedMessage
           defaultMessage="Public"
+          id="/podGX"
           description="src/views/Circle/Analytics/ContentAnalytics/ContentTabs/index.tsx"
         />
       </SegmentedTabs.Tab>

--- a/src/views/Circle/Analytics/ContentAnalytics/index.tsx
+++ b/src/views/Circle/Analytics/ContentAnalytics/index.tsx
@@ -97,6 +97,7 @@ const CircleContentAnalytics = () => {
         title={
           <FormattedMessage
             defaultMessage="Hottest"
+            id="mCAIcg"
             description="src/views/Circle/Analytics/ContentAnalytics/index.tsx"
           />
         }

--- a/src/views/Circle/Analytics/FollowerAnalytics/index.tsx
+++ b/src/views/Circle/Analytics/FollowerAnalytics/index.tsx
@@ -59,6 +59,7 @@ const Content = () => {
             title={
               <FormattedMessage
                 defaultMessage="followers_empty"
+                id="Bjdw71"
                 description="src/views/Circle/Analytics/FollowerAnalytics/index.tsx"
               />
             }
@@ -66,6 +67,7 @@ const Content = () => {
             unit={
               <FormattedMessage
                 defaultMessage={`{follower, plural, =1 {follower} other {followers}}`}
+                id="xWZr13"
                 description="src/views/Circle/Analytics/FollowerAnalytics/index.tsx"
                 values={{
                   follower: follower.current,
@@ -77,6 +79,7 @@ const Content = () => {
             title={
               <FormattedMessage
                 defaultMessage="New Followers This Month"
+                id="GugBCe"
                 description="src/views/Circle/Analytics/FollowerAnalytics/index.tsx"
               />
             }
@@ -84,6 +87,7 @@ const Content = () => {
             unit={
               <FormattedMessage
                 defaultMessage="followers"
+                id="MDNaxs"
                 description="src/views/Circle/Analytics/FollowerAnalytics/index.tsx"
               />
             }
@@ -95,6 +99,7 @@ const Content = () => {
             title={
               <FormattedMessage
                 defaultMessage="Conversion Rate of Followers"
+                id="zKOr2x"
                 description="src/views/Circle/Analytics/FollowerAnalytics/index.tsx"
               />
             }
@@ -120,6 +125,7 @@ const Content = () => {
                   formatter={(datum: any) =>
                     `<span>&nbsp;${datum.value}${intl.formatMessage({
                       defaultMessage: 'followers',
+                      id: 'MDNaxs',
                       description:
                         'src/views/Circle/Analytics/FollowerAnalytics/index.tsx',
                     })}&nbsp;</span>`
@@ -143,6 +149,7 @@ const FollowerAnalytics = () => {
           <FormattedMessage
             description="src/views/Circle/Analytics/FollowerAnalytics/index.tsx"
             defaultMessage="Followers"
+            id="AYTnjk"
           />
         }
       />

--- a/src/views/Circle/Analytics/IncomeAnalytics/index.tsx
+++ b/src/views/Circle/Analytics/IncomeAnalytics/index.tsx
@@ -64,6 +64,7 @@ const Content = () => {
             title={
               <FormattedMessage
                 defaultMessage="This Month"
+                id="sPgUkN"
                 description="src/views/Circle/Analytics/IncomeAnalytics/index.tsx"
               />
             }
@@ -75,6 +76,7 @@ const Content = () => {
             title={
               <FormattedMessage
                 defaultMessage="Next Month (Estimation)"
+                id="Fe682o"
                 description="src/views/Circle/Analytics/IncomeAnalytics/index.tsx"
               />
             }
@@ -88,6 +90,7 @@ const Content = () => {
             title={
               <FormattedMessage
                 defaultMessage="Total"
+                id="L4NXXh"
                 description="src/views/Circle/Analytics/IncomeAnalytics/index.tsx"
               />
             }
@@ -132,6 +135,7 @@ const IncomeAnalytics = () => {
         title={
           <FormattedMessage
             defaultMessage="Income"
+            id="d4waan"
             description="src/views/Circle/Analytics/IncomeAnalytics/index.tsx"
           />
         }

--- a/src/views/Circle/Analytics/SubscriberAnalytics/index.tsx
+++ b/src/views/Circle/Analytics/SubscriberAnalytics/index.tsx
@@ -84,6 +84,7 @@ const Content = () => {
         <span class="indicator rect" style="color: #EDEDED"></span>
         ${intl.formatMessage({
           defaultMessage: 'Total',
+          id: '2CqWQE',
           description:
             'src/views/Circle/Analytics/SubscriberAnalytics/index.tsx',
         })}: ${d3Sum(Object.values(values))}
@@ -92,11 +93,13 @@ const Content = () => {
         const keyName = {
           [DatumKey.subscriber]: intl.formatMessage({
             defaultMessage: 'Pay',
+            id: 'y0b6Kp',
             description:
               'src/views/Circle/Analytics/SubscriberAnalytics/index.tsx',
           }),
           [DatumKey.invitee]: intl.formatMessage({
             defaultMessage: 'Free',
+            id: 'L0J61B',
             description:
               'src/views/Circle/Analytics/SubscriberAnalytics/index.tsx',
           }),
@@ -118,6 +121,7 @@ const Content = () => {
             title={
               <FormattedMessage
                 defaultMessage="subscribers_empty"
+                id="6OBAOi"
                 description="src/views/Circle/Analytics/SubscriberAnalytics/index.tsx"
               />
             }
@@ -126,6 +130,7 @@ const Content = () => {
               // <Translate zh_hant="人" zh_hans="人" en="subscribers" />
               <FormattedMessage
                 defaultMessage={`{subscriber, plural, =1 {subscriber} other {subscribers}}`}
+                id="zxy15q"
                 description="src/views/Circle/Analytics/SubscriberAnalytics/index.tsx"
                 values={{
                   subscriber:
@@ -140,6 +145,7 @@ const Content = () => {
             title={
               <FormattedMessage
                 defaultMessage="Subscribers"
+                id="TSDiqB"
                 description="src/views/Circle/Analytics/SubscriberAnalytics/index.tsx"
               />
             }
@@ -147,6 +153,7 @@ const Content = () => {
             unit={
               <FormattedMessage
                 defaultMessage="subscribers"
+                id="XHMco9"
                 description="src/views/Circle/Analytics/SubscriberAnalytics/index.tsx"
               />
             }
@@ -156,6 +163,7 @@ const Content = () => {
             title={
               <FormattedMessage
                 defaultMessage="Invitees"
+                id="1qQzV0"
                 description="src/views/Circle/Analytics/SubscriberAnalytics/index.tsx"
               />
             }
@@ -163,6 +171,7 @@ const Content = () => {
             unit={
               <FormattedMessage
                 defaultMessage="subscribers"
+                id="XHMco9"
                 description="src/views/Circle/Analytics/SubscriberAnalytics/index.tsx"
               />
             }
@@ -199,6 +208,7 @@ const SubscriberAnalytics = () => {
         title={
           <FormattedMessage
             defaultMessage="Subscribe"
+            id="WpvsPu"
             description="src/views/Circle/Analytics/SubscriberAnalytics/index.tsx"
           />
         }
@@ -215,6 +225,7 @@ const SubscriberAnalytics = () => {
               <TextIcon color="greyDarker" size="xs">
                 <FormattedMessage
                   defaultMessage="View Members"
+                  id="SNh1n0"
                   description="src/views/Circle/Analytics/SubscriberAnalytics/index.tsx"
                 />
               </TextIcon>

--- a/src/views/Circle/Broadcast/Broadcast.tsx
+++ b/src/views/Circle/Broadcast/Broadcast.tsx
@@ -203,6 +203,7 @@ const CricleBroadcast = () => {
       message: (
         <FormattedMessage
           defaultMessage="Broadcast sent"
+          id="TjWWxF"
           description="src/views/Circle/Broadcast/Broadcast.tsx"
         />
       ),
@@ -222,6 +223,7 @@ const CricleBroadcast = () => {
               type="circleBroadcast"
               placeholder={intl.formatMessage({
                 defaultMessage: 'Announcement, reminder, chattering...',
+                id: 'zb8Kx1',
               })}
               submitCallback={submitCallback}
             />
@@ -234,6 +236,7 @@ const CricleBroadcast = () => {
               description={
                 <FormattedMessage
                   defaultMessage="No broadcast yet."
+                  id="mWjpk9"
                   description="src/views/Circle/Broadcast/Broadcast.tsx"
                 />
               }

--- a/src/views/Circle/CircleDetailTabs/index.tsx
+++ b/src/views/Circle/CircleDetailTabs/index.tsx
@@ -26,21 +26,21 @@ const CircleDetailTabs = () => {
         {...circleDetailPath}
         selected={isInPath('CIRCLE_DETAIL')}
       >
-        <FormattedMessage defaultMessage="Articles" />
+        <FormattedMessage defaultMessage="Articles" id="3KNMbJ" />
       </SegmentedTabs.Tab>
 
       <SegmentedTabs.Tab
         {...circleDiscussionPath}
         selected={isInPath('CIRCLE_DISCUSSION')}
       >
-        <FormattedMessage defaultMessage="Discussion" />
+        <FormattedMessage defaultMessage="Discussion" id="20bImY" />
       </SegmentedTabs.Tab>
 
       <SegmentedTabs.Tab
         {...circleBroadcastPath}
         selected={isInPath('CIRCLE_BROADCAST')}
       >
-        <FormattedMessage defaultMessage="Broadcast" />
+        <FormattedMessage defaultMessage="Broadcast" id="beLe/F" />
       </SegmentedTabs.Tab>
     </SegmentedTabs>
   )

--- a/src/views/Circle/Discussion/Discussion.tsx
+++ b/src/views/Circle/Discussion/Discussion.tsx
@@ -151,6 +151,7 @@ const CricleDiscussion = () => {
       message: (
         <FormattedMessage
           defaultMessage="Discussion sent"
+          id="9nNpKP"
           description="src/views/Circle/Discussion/Discussion.tsx"
         />
       ),
@@ -252,6 +253,7 @@ const CricleDiscussion = () => {
               type="circleDiscussion"
               placeholder={intl.formatMessage({
                 defaultMessage: 'Request an update, ask, share and discuss',
+                id: 'EW5R4p',
                 description: 'src/views/Circle/Discussion/Discussion.tsx',
               })}
               submitCallback={submitCallback}
@@ -265,6 +267,7 @@ const CricleDiscussion = () => {
               description={
                 <FormattedMessage
                   defaultMessage="No discussion yet"
+                  id="50cquj"
                   description="src/views/Circle/Discussion/Discussion.tsx"
                 />
               }

--- a/src/views/Circle/Profile/AddCircleArticle/Button.tsx
+++ b/src/views/Circle/Profile/AddCircleArticle/Button.tsx
@@ -24,7 +24,7 @@ const AddArticlesButton = ({ circle }: AddArticlesButtonProps) => {
           aria-haspopup="dialog"
         >
           <TextIcon icon={<IconPen16 />} weight="md" size="mdS">
-            <FormattedMessage defaultMessage="Add Articles" />
+            <FormattedMessage defaultMessage="Add Articles" id="k97/u7" />
           </TextIcon>
         </Button>
       )}

--- a/src/views/Circle/Profile/AddCircleArticle/Dialog/ConfirmContent.tsx
+++ b/src/views/Circle/Profile/AddCircleArticle/Dialog/ConfirmContent.tsx
@@ -23,7 +23,7 @@ const ConfirmContent: React.FC<ContentProps> = ({
   const ConfirmButton = () => (
     <Dialog.TextButton
       onClick={() => onConfirm(license === ArticleLicenseType.Arr, license)}
-      text={<FormattedMessage defaultMessage="Confirm" />}
+      text={<FormattedMessage defaultMessage="Confirm" id="N2IrpM" />}
       loading={loading}
     />
   )
@@ -34,7 +34,7 @@ const ConfirmContent: React.FC<ContentProps> = ({
         title="addArticles"
         leftBtn={
           <Dialog.TextButton
-            text={<FormattedMessage defaultMessage="Back" />}
+            text={<FormattedMessage defaultMessage="Back" id="cyR7Kh" />}
             onClick={onBack}
           />
         }
@@ -54,7 +54,7 @@ const ConfirmContent: React.FC<ContentProps> = ({
           <>
             <Dialog.TextButton
               color="greyDarker"
-              text={<FormattedMessage defaultMessage="Back" />}
+              text={<FormattedMessage defaultMessage="Back" id="cyR7Kh" />}
               onClick={onBack}
             />
             <ConfirmButton />

--- a/src/views/Circle/Profile/AddCircleArticle/Dialog/index.tsx
+++ b/src/views/Circle/Profile/AddCircleArticle/Dialog/index.tsx
@@ -114,7 +114,7 @@ const AddCircleArticleDialog = ({
             nodes={articles}
             saving={loading}
             headerRightButtonText={
-              <FormattedMessage defaultMessage="Next Step" />
+              <FormattedMessage defaultMessage="Next Step" id="8cv9D4" />
             }
             closeDialog={closeDialog}
           />

--- a/src/views/Circle/Profile/DropdownActions/index.tsx
+++ b/src/views/Circle/Profile/DropdownActions/index.tsx
@@ -57,6 +57,7 @@ const BaseDropdownActions = ({
           text={
             <FormattedMessage
               defaultMessage="Manage Circle"
+              id="q+N5Wd"
               description="src/views/Circle/Profile/DropdownActions/index.tsx"
             />
           }
@@ -68,7 +69,7 @@ const BaseDropdownActions = ({
 
       {isCircleOwner && (
         <Menu.Item
-          text={<FormattedMessage defaultMessage="Analytics" />}
+          text={<FormattedMessage defaultMessage="Analytics" id="GZJpDf" />}
           icon={<IconAnalytics24 size="mdS" />}
           {...toPath({ page: 'circleAnalytics', circle })}
           is="link"
@@ -80,6 +81,7 @@ const BaseDropdownActions = ({
           text={
             <FormattedMessage
               defaultMessage="Unsubscribe Circle"
+              id="8xPi0N"
               description="src/views/Circle/Profile/DropdownActions/index.tsx"
             />
           }
@@ -99,6 +101,7 @@ const BaseDropdownActions = ({
           bgColor="halfBlack"
           aria-label={intl.formatMessage({
             defaultMessage: 'More Actions',
+            id: 'A7ugfn',
           })}
           aria-haspopup="listbox"
           ref={ref}

--- a/src/views/Circle/Profile/FollowButton/Follow.tsx
+++ b/src/views/Circle/Profile/FollowButton/Follow.tsx
@@ -76,7 +76,7 @@ const Follow = ({ circle }: FollowProps) => {
       onClick={onClick}
     >
       <TextIcon weight="md" size="mdS">
-        <FormattedMessage defaultMessage="Follow" />
+        <FormattedMessage defaultMessage="Follow" id="ieGrWo" />
       </TextIcon>
     </Button>
   )

--- a/src/views/Circle/Profile/FollowButton/Unfollow.tsx
+++ b/src/views/Circle/Profile/FollowButton/Unfollow.tsx
@@ -62,9 +62,9 @@ const Unfollow = ({ circle }: UnfollowCircleProps) => {
     >
       <TextIcon weight="md" size="mdS">
         {hover ? (
-          <FormattedMessage defaultMessage="Unfollow" />
+          <FormattedMessage defaultMessage="Unfollow" id="izWS4J" />
         ) : (
-          <FormattedMessage defaultMessage="Followed" />
+          <FormattedMessage defaultMessage="Followed" id="LGox1K" />
         )}
       </TextIcon>
     </Button>

--- a/src/views/Circle/Profile/FollowersDialog/Content.tsx
+++ b/src/views/Circle/Profile/FollowersDialog/Content.tsx
@@ -90,7 +90,9 @@ const FollowersDialogContent = () => {
   if (!data || !circle || !edges || edges.length <= 0 || !pageInfo) {
     return (
       <EmptyWarning
-        description={<FormattedMessage defaultMessage="No followers yet" />}
+        description={
+          <FormattedMessage defaultMessage="No followers yet" id="XVYrS/" />
+        }
       />
     )
   }

--- a/src/views/Circle/Profile/FollowersDialog/index.tsx
+++ b/src/views/Circle/Profile/FollowersDialog/index.tsx
@@ -23,6 +23,7 @@ const BaseFollowersDialog = ({ circle, children }: FollowersDialogProps) => {
           title={
             <FormattedMessage
               defaultMessage="Followers of {circleName}"
+              id="WuvE8X"
               description="src/views/Circle/Profile/FollowersDialog/index.tsx"
               values={{
                 circleName: circle.displayName,
@@ -30,7 +31,7 @@ const BaseFollowersDialog = ({ circle, children }: FollowersDialogProps) => {
             />
           }
           closeDialog={closeDialog}
-          closeText={<FormattedMessage defaultMessage="Close" />}
+          closeText={<FormattedMessage defaultMessage="Close" id="rbrahO" />}
         />
 
         <DynamicContent />
@@ -38,7 +39,7 @@ const BaseFollowersDialog = ({ circle, children }: FollowersDialogProps) => {
         <Dialog.Footer
           smUpBtns={
             <Dialog.TextButton
-              text={<FormattedMessage defaultMessage="Close" />}
+              text={<FormattedMessage defaultMessage="Close" id="rbrahO" />}
               color="greyDarker"
               onClick={closeDialog}
             />

--- a/src/views/Circle/Profile/MembersDialog/Content.tsx
+++ b/src/views/Circle/Profile/MembersDialog/Content.tsx
@@ -94,6 +94,7 @@ const MembersDialogContent = () => {
         description={
           <FormattedMessage
             defaultMessage="No members yet"
+            id="FOOymB"
             description="src/views/Circle/Profile/MembersDialog/Content.tsx"
           />
         }

--- a/src/views/Circle/Profile/MembersDialog/index.tsx
+++ b/src/views/Circle/Profile/MembersDialog/index.tsx
@@ -21,9 +21,9 @@ const BaseMembersDialog = ({ children }: MembersDialogProps) => {
 
       <Dialog isOpen={show} onDismiss={closeDialog}>
         <Dialog.Header
-          title={<FormattedMessage defaultMessage="Members" />}
+          title={<FormattedMessage defaultMessage="Members" id="+a+2ug" />}
           closeDialog={closeDialog}
-          closeText={<FormattedMessage defaultMessage="Close" />}
+          closeText={<FormattedMessage defaultMessage="Close" id="rbrahO" />}
         />
 
         <DynamicContent />
@@ -31,7 +31,7 @@ const BaseMembersDialog = ({ children }: MembersDialogProps) => {
         <Dialog.Footer
           smUpBtns={
             <Dialog.TextButton
-              text={<FormattedMessage defaultMessage="Close" />}
+              text={<FormattedMessage defaultMessage="Close" id="rbrahO" />}
               color="greyDarker"
               onClick={closeDialog}
             />

--- a/src/views/Circle/Profile/index.tsx
+++ b/src/views/Circle/Profile/index.tsx
@@ -183,7 +183,8 @@ const CircleProfile = () => {
             <section className={styles.price}>
               <span className={styles.amount}>{price.amount}</span>
               <br />
-              {price.currency} / <FormattedMessage defaultMessage="month" />
+              {price.currency} /{' '}
+              <FormattedMessage defaultMessage="month" id="Cu3Cty" />
             </section>
           )}
         </header>
@@ -216,7 +217,7 @@ const CircleProfile = () => {
                     {numAbbr(circle.members.totalCount)}
                   </span>
                   {/* <Translate id="members" /> */}
-                  <FormattedMessage defaultMessage="Members" />
+                  <FormattedMessage defaultMessage="Members" id="+a+2ug" />
                 </button>
               )}
             </MembersDialog>
@@ -233,7 +234,7 @@ const CircleProfile = () => {
                   </span>
                   {/* <Translate id="follower" />  */}
 
-                  <FormattedMessage defaultMessage="Followers" />
+                  <FormattedMessage defaultMessage="Followers" id="pzTOmv" />
                 </button>
               )}
             </FollowersDialog>

--- a/src/views/Circle/Settings/ManageInvitation/AddButton/index.tsx
+++ b/src/views/Circle/Settings/ManageInvitation/AddButton/index.tsx
@@ -26,6 +26,7 @@ const CircleInvitationAddButton = () => {
           <TextIcon color="white" size="mdS" weight="md">
             <FormattedMessage
               defaultMessage="Add Invitation"
+              id="b8ogKp"
               description="src/views/Circle/Settings/ManageInvitation/AddButton/index.tsx"
             />
           </TextIcon>

--- a/src/views/Circle/Settings/ManageInvitation/AddInvitationDialog/PreSend.tsx
+++ b/src/views/Circle/Settings/ManageInvitation/AddInvitationDialog/PreSend.tsx
@@ -99,7 +99,7 @@ const InviteePreSend = ({ closeDialog, confirm, invitees }: Props) => {
 
   const SubmitButton = (
     <Dialog.TextButton
-      text={<FormattedMessage defaultMessage="Confirm and Send" />}
+      text={<FormattedMessage defaultMessage="Confirm and Send" id="rXnmeE" />}
       onClick={send}
       loading={inviteLoading}
     />
@@ -111,6 +111,7 @@ const InviteePreSend = ({ closeDialog, confirm, invitees }: Props) => {
         title={
           <FormattedMessage
             defaultMessage="Send"
+            id="tzq2+W"
             description="src/views/Circle/Settings/ManageInvitation/AddInvitationDialog/PreSend.tsx"
           />
         }
@@ -122,6 +123,7 @@ const InviteePreSend = ({ closeDialog, confirm, invitees }: Props) => {
         <p>
           <FormattedMessage
             defaultMessage="Friends will receive free trial invitations to Circle. Set up your invitations now!"
+            id="O0QB1v"
             description="src/views/Circle/Settings/ManageInvitation/AddInvitationDialog/PreSend.tsx"
           />
         </p>
@@ -155,7 +157,7 @@ const InviteePreSend = ({ closeDialog, confirm, invitees }: Props) => {
         smUpBtns={
           <>
             <Dialog.TextButton
-              text={<FormattedMessage defaultMessage="Cancel" />}
+              text={<FormattedMessage defaultMessage="Cancel" id="47FYwb" />}
               color="greyDarker"
               onClick={closeDialog}
             />

--- a/src/views/Circle/Settings/ManageInvitation/AddInvitationDialog/Search.tsx
+++ b/src/views/Circle/Settings/ManageInvitation/AddInvitationDialog/Search.tsx
@@ -49,7 +49,7 @@ const InviteeSearchEditor = ({ closeDialog, save }: Props) => {
     <Dialog.TextButton
       disabled={disabled}
       onClick={() => save({ nodes: selectedNodes })}
-      text={<FormattedMessage defaultMessage="Confirm" />}
+      text={<FormattedMessage defaultMessage="Confirm" id="N2IrpM" />}
     />
   )
 
@@ -83,7 +83,7 @@ const InviteeSearchEditor = ({ closeDialog, save }: Props) => {
         smUpBtns={
           <>
             <Dialog.TextButton
-              text={<FormattedMessage defaultMessage="Cancel" />}
+              text={<FormattedMessage defaultMessage="Cancel" id="47FYwb" />}
               color="greyDarker"
               onClick={closeDialog}
             />

--- a/src/views/Circle/Settings/ManageInvitation/AddInvitationDialog/SelectPeriod/index.tsx
+++ b/src/views/Circle/Settings/ManageInvitation/AddInvitationDialog/SelectPeriod/index.tsx
@@ -13,13 +13,15 @@ const SelectPeriod = ({ period, onChange }: Props) => {
   return (
     <Form.Select
       name="select-period"
-      label={<FormattedMessage defaultMessage="Free trial period" />}
+      label={
+        <FormattedMessage defaultMessage="Free trial period" id="FmWYRt" />
+      }
       onChange={(option) => onChange(option.value)}
       options={options.map((value) => ({
         name: (
           <>
             {value}
-            <FormattedMessage defaultMessage="days" />
+            <FormattedMessage defaultMessage="days" id="Bc20la" />
           </>
         ),
         value,

--- a/src/views/Circle/Settings/ManageInvitation/AddInvitationDialog/Sent.tsx
+++ b/src/views/Circle/Settings/ManageInvitation/AddInvitationDialog/Sent.tsx
@@ -9,6 +9,7 @@ interface Props {
 const InvitationSentTitle = (
   <FormattedMessage
     defaultMessage="Invitation Sent"
+    id="OIj8pQ"
     description="src/views/Circle/Settings/ManageInvitation/AddInvitationDialog/Sent.tsx"
   />
 )
@@ -31,6 +32,7 @@ const InvitationSent = ({ closeDialog }: Props) => (
       <p>
         <FormattedMessage
           defaultMessage="Invitations have been sent. You can check invitation status on the invitation management page."
+          id="SdXoXI"
           description="src/views/Circle/Settings/ManageInvitation/AddInvitationDialog/Sent.tsx"
         />
       </p>
@@ -39,13 +41,13 @@ const InvitationSent = ({ closeDialog }: Props) => (
     <Dialog.Footer
       btns={
         <Dialog.RoundedButton
-          text={<FormattedMessage defaultMessage="I see" />}
+          text={<FormattedMessage defaultMessage="I see" id="lIir/P" />}
           onClick={closeDialog}
         />
       }
       smUpBtns={
         <Dialog.TextButton
-          text={<FormattedMessage defaultMessage="I see" />}
+          text={<FormattedMessage defaultMessage="I see" id="lIir/P" />}
           onClick={closeDialog}
         />
       }

--- a/src/views/Circle/Settings/ManageInvitation/Invites/Accepted/index.tsx
+++ b/src/views/Circle/Settings/ManageInvitation/Invites/Accepted/index.tsx
@@ -79,6 +79,7 @@ const AcceptedInvites = () => {
         description={
           <FormattedMessage
             defaultMessage="friends have not accepted your invitations."
+            id="RxiHr/"
             description="src/views/Circle/Settings/ManageInvitation/Invites/Accepted/index.tsx"
           />
         }

--- a/src/views/Circle/Settings/ManageInvitation/Invites/Pending/index.tsx
+++ b/src/views/Circle/Settings/ManageInvitation/Invites/Pending/index.tsx
@@ -83,6 +83,7 @@ const PendingInvites = () => {
         description={
           <FormattedMessage
             defaultMessage="You have not invited anyone yet! Invite friends to join your circle by clicking 'invite friends'."
+            id="lNjDPr"
             description="src/views/Circle/Settings/ManageInvitation/Invites/Pending/index.tsx"
           />
         }

--- a/src/views/Circle/Settings/ManageInvitation/Invites/index.tsx
+++ b/src/views/Circle/Settings/ManageInvitation/Invites/index.tsx
@@ -23,6 +23,7 @@ const InvitesFeed: React.FC = () => {
         >
           <FormattedMessage
             defaultMessage="Pending"
+            id="fWDtpq"
             description="src/views/Circle/Settings/ManageInvitation/Invites/index.tsx"
           />
         </SegmentedTabs.Tab>
@@ -33,6 +34,7 @@ const InvitesFeed: React.FC = () => {
         >
           <FormattedMessage
             defaultMessage="Accepted"
+            id="JpS59y"
             description="src/views/Circle/Settings/ManageInvitation/Invites/index.tsx"
           />
         </SegmentedTabs.Tab>

--- a/src/views/Circle/Settings/index.tsx
+++ b/src/views/Circle/Settings/index.tsx
@@ -13,6 +13,7 @@ const BaseSettings = () => {
         title={
           <FormattedMessage
             defaultMessage="Profile"
+            id="ZAs170"
             description="src/views/Circle/Settings/index.tsx"
           />
         }
@@ -24,6 +25,7 @@ const BaseSettings = () => {
         title={
           <FormattedMessage
             defaultMessage="Manage Invitation"
+            id="EQeKnO"
             description="src/views/Circle/Settings/index.tsx"
           />
         }

--- a/src/views/Home/Feed/Authors/index.tsx
+++ b/src/views/Home/Feed/Authors/index.tsx
@@ -147,7 +147,7 @@ const Authors = () => {
             }}
             textAlign="center"
           >
-            <FormattedMessage defaultMessage="View All" />
+            <FormattedMessage defaultMessage="View All" id="wbcwKd" />
           </ViewMoreCard>
         </section>
       </Media>

--- a/src/views/Home/Feed/SortBy/index.tsx
+++ b/src/views/Home/Feed/SortBy/index.tsx
@@ -20,21 +20,21 @@ const SortBy: React.FC<SortByProps> = ({ feedType, setFeedType }) => {
         onClick={() => setFeedType('hottest')}
         selected={isHottest}
       >
-        <FormattedMessage defaultMessage="Trending" />
+        <FormattedMessage defaultMessage="Trending" id="ll/ufR" />
       </SegmentedTabs.Tab>
 
       <SegmentedTabs.Tab
         onClick={() => setFeedType('newest')}
         selected={isNewset}
       >
-        <FormattedMessage defaultMessage="Latest" />
+        <FormattedMessage defaultMessage="Latest" id="adThp5" />
       </SegmentedTabs.Tab>
 
       <SegmentedTabs.Tab
         onClick={() => setFeedType('icymi')}
         selected={isICYMI}
       >
-        <FormattedMessage defaultMessage="Featured" />
+        <FormattedMessage defaultMessage="Featured" id="CnPG8j" />
       </SegmentedTabs.Tab>
     </SegmentedTabs>
   )

--- a/src/views/Home/Feed/Tags/index.tsx
+++ b/src/views/Home/Feed/Tags/index.tsx
@@ -151,7 +151,7 @@ const TagsFeed = () => {
             }}
             textAlign="center"
           >
-            <FormattedMessage defaultMessage="View All" />
+            <FormattedMessage defaultMessage="View All" id="wbcwKd" />
           </ViewMoreCard>
         </section>
       </Media>

--- a/src/views/Home/SectionHeader/index.tsx
+++ b/src/views/Home/SectionHeader/index.tsx
@@ -21,8 +21,8 @@ const FeedHeader = ({
     tags: PATHS.TAGS,
   }
   const titleMap = {
-    authors: <FormattedMessage defaultMessage="Authors" />,
-    tags: <FormattedMessage defaultMessage="Topics" />,
+    authors: <FormattedMessage defaultMessage="Authors" id="XgdZSb" />,
+    tags: <FormattedMessage defaultMessage="Topics" id="kc79d3" />,
   }
   const path = pathMap[type]
 

--- a/src/views/Me/Analytics/EmptyAnalytics/index.tsx
+++ b/src/views/Me/Analytics/EmptyAnalytics/index.tsx
@@ -16,6 +16,7 @@ const EmptyAnalytics = () => {
       <p>
         <FormattedMessage
           defaultMessage="You haven‘t published any articles yet, so there is no data available. Create one now to introduce yourself!"
+          id="cmtHjM"
           description="src/views/Me/Analytics/EmptyAnalytics/index.tsx"
         />
       </p>
@@ -30,7 +31,7 @@ const EmptyAnalytics = () => {
         onClick={() => analytics.trackEvent('click_button', { type: 'write' })}
       >
         <TextIcon color="white" weight="md">
-          <FormattedMessage defaultMessage="Start Creating" />
+          <FormattedMessage defaultMessage="Start Creating" id="69+D96" />
         </TextIcon>
       </Button>
 
@@ -38,6 +39,7 @@ const EmptyAnalytics = () => {
         <p>
           <FormattedMessage
             defaultMessage="Want to know more? Check the "
+            id="l/f7bu"
             description="src/views/Me/Analytics/EmptyAnalytics/index.tsx"
           />
           <a
@@ -46,7 +48,7 @@ const EmptyAnalytics = () => {
             target="_blank"
             rel="noreferrer"
           >
-            <FormattedMessage defaultMessage="tutorial" />
+            <FormattedMessage defaultMessage="tutorial" id="uw32VR" />
           </a>
         </p>
       </section>

--- a/src/views/Me/Analytics/SelectPeriod/index.tsx
+++ b/src/views/Me/Analytics/SelectPeriod/index.tsx
@@ -16,6 +16,7 @@ const SelectPeriod: React.FC<SelectProps> = ({ period, onChange }) => {
         <>
           <FormattedMessage
             defaultMessage="Last 7 days"
+            id="0iyH+q"
             description="src/views/Me/Analytics/SelectPeriod/index.tsx"
           />
         </>
@@ -27,6 +28,7 @@ const SelectPeriod: React.FC<SelectProps> = ({ period, onChange }) => {
         <>
           <FormattedMessage
             defaultMessage="Last 1 month"
+            id="/BQWEh"
             description="src/views/Me/Analytics/SelectPeriod/index.tsx"
           />
         </>
@@ -38,6 +40,7 @@ const SelectPeriod: React.FC<SelectProps> = ({ period, onChange }) => {
         <>
           <FormattedMessage
             defaultMessage="Last 3 months"
+            id="W0sZaX"
             description="src/views/Me/Analytics/SelectPeriod/index.tsx"
           />
         </>
@@ -47,7 +50,7 @@ const SelectPeriod: React.FC<SelectProps> = ({ period, onChange }) => {
     {
       label: (
         <>
-          <FormattedMessage defaultMessage="All" />
+          <FormattedMessage defaultMessage="All" id="zQvVDJ" />
         </>
       ),
       value: 0,

--- a/src/views/Me/Analytics/index.tsx
+++ b/src/views/Me/Analytics/index.tsx
@@ -65,7 +65,7 @@ const MyAnalytics = () => {
       <Layout.Header
         left={
           <Layout.Header.Title id="myAnalytics">
-            <FormattedMessage defaultMessage="Top Supporters" />
+            <FormattedMessage defaultMessage="Top Supporters" id="/IMR+8" />
           </Layout.Header.Title>
         }
         right={
@@ -126,7 +126,7 @@ const MyAnalytics = () => {
               <AnalyticsNoSupporter />
             </section>
             <p>
-              <FormattedMessage defaultMessage="No data yet." />
+              <FormattedMessage defaultMessage="No data yet." id="eTpiYa" />
             </p>
           </section>
         )}

--- a/src/views/Me/DraftDetail/SettingsButton/ConfirmPublishDialogContent/index.tsx
+++ b/src/views/Me/DraftDetail/SettingsButton/ConfirmPublishDialogContent/index.tsx
@@ -64,7 +64,7 @@ const ConfirmPublishDialogContent: React.FC<
         title={<Translate zh_hant="發布須知" zh_hans="發布须知" en="Notice" />}
         leftBtn={
           <Dialog.TextButton
-            text={<FormattedMessage defaultMessage="Back" />}
+            text={<FormattedMessage defaultMessage="Back" id="cyR7Kh" />}
             onClick={onBack}
           />
         }
@@ -123,7 +123,7 @@ const ConfirmPublishDialogContent: React.FC<
           <>
             <Dialog.TextButton
               color="greyDarker"
-              text={<FormattedMessage defaultMessage="Back" />}
+              text={<FormattedMessage defaultMessage="Back" id="cyR7Kh" />}
               onClick={onBack}
             />
             {SubmitButton}

--- a/src/views/Me/DraftDetail/index.tsx
+++ b/src/views/Me/DraftDetail/index.tsx
@@ -246,6 +246,7 @@ const DraftDetail = () => {
           message: (
             <FormattedMessage
               defaultMessage={`Content length exceeds limit ({length}/{limit})`}
+              id="VefaFQ"
               values={{
                 length: contentCount,
                 limit: MAX_ARTICLE_CONTENT_LENGTH,

--- a/src/views/Me/History/Comments/index.tsx
+++ b/src/views/Me/History/Comments/index.tsx
@@ -176,6 +176,7 @@ const HistoryComments = () => {
   const intl = useIntl()
   const title = intl.formatMessage({
     defaultMessage: 'History',
+    id: 'djJp6c',
   })
 
   return (

--- a/src/views/Me/History/HistoryTabs.tsx
+++ b/src/views/Me/History/HistoryTabs.tsx
@@ -14,19 +14,20 @@ const HistoryTabs: React.FC = () => {
       <Tabs.Tab href={PATHS.ME_HISTORY} selected={isInPath('ME_HISTORY')}>
         <FormattedMessage
           defaultMessage="Articles"
+          id="xMaFCO"
           description="src/views/Me/History/HistoryTabs.tsx"
         />
       </Tabs.Tab>
 
       <Tabs.Tab href={PATHS.ME_HISTORY_LIKES_SENT} selected={isLike}>
-        <FormattedMessage defaultMessage="Likes" />
+        <FormattedMessage defaultMessage="Likes" id="2slIPX" />
       </Tabs.Tab>
 
       <Tabs.Tab
         href={PATHS.ME_HISTORY_COMMENTS}
         selected={isInPath('ME_HISTORY_COMMENTS')}
       >
-        <FormattedMessage defaultMessage="Comments" />
+        <FormattedMessage defaultMessage="Comments" id="wCgTu5" />
       </Tabs.Tab>
     </Tabs>
   )

--- a/src/views/Me/History/LikesReceived/index.tsx
+++ b/src/views/Me/History/LikesReceived/index.tsx
@@ -112,6 +112,7 @@ const LikesReceived = () => {
   const intl = useIntl()
   const title = intl.formatMessage({
     defaultMessage: 'History',
+    id: 'djJp6c',
   })
 
   return (

--- a/src/views/Me/History/LikesSent/index.tsx
+++ b/src/views/Me/History/LikesSent/index.tsx
@@ -107,6 +107,7 @@ const LikesSent = () => {
   const intl = useIntl()
   const title = intl.formatMessage({
     defaultMessage: 'History',
+    id: 'djJp6c',
   })
 
   return (

--- a/src/views/Me/History/index.tsx
+++ b/src/views/Me/History/index.tsx
@@ -101,6 +101,7 @@ const BaseMeHistory = () => {
       <EmptyArticle
         description={intl.formatMessage({
           defaultMessage: 'No data yet',
+          id: '1Z1M77',
           description: 'src/views/Me/History/index.tsx',
         })}
       />
@@ -181,6 +182,7 @@ const MeHistory = () => {
   const intl = useIntl()
   const title = intl.formatMessage({
     defaultMessage: 'History',
+    id: 'djJp6c',
   })
 
   return (

--- a/src/views/Me/Settings/Account/Email/index.tsx
+++ b/src/views/Me/Settings/Account/Email/index.tsx
@@ -33,6 +33,7 @@ const Email = () => {
             title={
               <FormattedMessage
                 defaultMessage="Email"
+                id="aacIz8"
                 description="src/views/Me/Settings/Settings/Email/index.tsx"
               />
             }
@@ -41,7 +42,7 @@ const Email = () => {
             right={
               hasEmail ? undefined : (
                 <SettingsButton onClick={openDialog}>
-                  <FormattedMessage defaultMessage="Connect" />
+                  <FormattedMessage defaultMessage="Connect" id="+vVZ/G" />
                 </SettingsButton>
               )
             }

--- a/src/views/Me/Settings/Account/MyProfile/index.tsx
+++ b/src/views/Me/Settings/Account/MyProfile/index.tsx
@@ -22,6 +22,7 @@ const MyProfile = () => {
           title={
             <FormattedMessage
               defaultMessage="My profile"
+              id="n2Sc6g"
               description="src/views/Me/Settings/Settings/MyProfile/index.tsx"
             />
           }

--- a/src/views/Me/Settings/Account/Password/index.tsx
+++ b/src/views/Me/Settings/Account/Password/index.tsx
@@ -19,6 +19,7 @@ const Password = () => {
             title={
               <FormattedMessage
                 defaultMessage="Password"
+                id="PLBmDT"
                 description="src/views/Me/Settings/Settings/Password/index.tsx"
               />
             }
@@ -27,14 +28,16 @@ const Password = () => {
                 !isEmailVerified ? (
                   <FormattedMessage
                     defaultMessage="Please verify email first"
+                    id="+51DoZ"
                     description="src/views/Me/Settings/Settings/Password/index.tsx"
                   />
                 ) : hasPassword ? (
-                  <FormattedMessage defaultMessage="Change" />
+                  <FormattedMessage defaultMessage="Change" id="BY343C" />
                 ) : undefined
               ) : (
                 <FormattedMessage
                   defaultMessage="Please add email first"
+                  id="O0MQs/"
                   description="src/views/Me/Settings/Settings/Password/index.tsx"
                 />
               )
@@ -50,7 +53,7 @@ const Password = () => {
             right={
               hasEmail && isEmailVerified && !hasPassword ? (
                 <SettingsButton onClick={openDialog}>
-                  <FormattedMessage defaultMessage="Set" />
+                  <FormattedMessage defaultMessage="Set" id="HnxG15" />
                 </SettingsButton>
               ) : undefined
             }

--- a/src/views/Me/Settings/Account/Socials/index.tsx
+++ b/src/views/Me/Settings/Account/Socials/index.tsx
@@ -81,6 +81,7 @@ const Socials = () => {
           message: (
             <FormattedMessage
               defaultMessage="Connected to {type}"
+              id="C3NKBg"
               description="src/views/Me/Settings/Settings/Socials/index.tsx"
               values={{
                 type: bindResult.type,
@@ -98,6 +99,7 @@ const Socials = () => {
           message: (
             <FormattedMessage
               defaultMessage="This {type} account is connected to a Matters account. Sign in to that account to disconnect it then try again"
+              id="D+N1Q6"
               description="src/views/Me/Settings/Settings/Socials/index.tsx"
               values={{
                 type: bindResult.type,
@@ -115,6 +117,7 @@ const Socials = () => {
           message: (
             <FormattedMessage
               defaultMessage="Unavailable"
+              id="rADhX5"
               description="FORBIDDEN_BY_STATE"
             />
           ),
@@ -148,7 +151,10 @@ const Socials = () => {
                   <>
                     {!isGoogleLoading && (
                       <SettingsButton onClick={gotoGoogle}>
-                        <FormattedMessage defaultMessage="Connect" />
+                        <FormattedMessage
+                          defaultMessage="Connect"
+                          id="+vVZ/G"
+                        />
                       </SettingsButton>
                     )}
                     {isGoogleLoading && (
@@ -184,7 +190,10 @@ const Socials = () => {
                   <>
                     {!isTwitterLoading && (
                       <SettingsButton onClick={gotoTwitter}>
-                        <FormattedMessage defaultMessage="Connect" />
+                        <FormattedMessage
+                          defaultMessage="Connect"
+                          id="+vVZ/G"
+                        />
                       </SettingsButton>
                     )}
                     {isTwitterLoading && (
@@ -220,7 +229,10 @@ const Socials = () => {
                   <>
                     {!isFacebookLoading && (
                       <SettingsButton onClick={gotoFacebook}>
-                        <FormattedMessage defaultMessage="Connect" />
+                        <FormattedMessage
+                          defaultMessage="Connect"
+                          id="+vVZ/G"
+                        />
                       </SettingsButton>
                     )}
                     {isFacebookLoading && (

--- a/src/views/Me/Settings/Account/Wallet/index.tsx
+++ b/src/views/Me/Settings/Account/Wallet/index.tsx
@@ -28,6 +28,7 @@ const Wallet = () => {
                   title={
                     <FormattedMessage
                       defaultMessage="Wallet address"
+                      id="Gt7K6r"
                       description="src/views/Me/Settings/Settings/Wallet/index.tsx"
                     />
                   }
@@ -45,7 +46,10 @@ const Wallet = () => {
                   right={
                     ethAddress ? undefined : (
                       <SettingsButton onClick={openAddWalletLoginDialog}>
-                        <FormattedMessage defaultMessage="Connect" />
+                        <FormattedMessage
+                          defaultMessage="Connect"
+                          id="+vVZ/G"
+                        />
                       </SettingsButton>
                     )
                   }

--- a/src/views/Me/Settings/Account/index.tsx
+++ b/src/views/Me/Settings/Account/index.tsx
@@ -34,6 +34,7 @@ const Settings = () => {
           groupName={
             <FormattedMessage
               defaultMessage="Wallet"
+              id="HPVOw/"
               description="src/views/Me/Settings/Settings/index.tsx"
             />
           }
@@ -46,6 +47,7 @@ const Settings = () => {
           groupName={
             <FormattedMessage
               defaultMessage="Social Login"
+              id="ohbnFU"
               description="src/views/Me/Settings/Settings/index.tsx"
             />
           }

--- a/src/views/Me/Settings/Blocked/SettingsBlocked.tsx
+++ b/src/views/Me/Settings/Blocked/SettingsBlocked.tsx
@@ -61,6 +61,7 @@ const SettingsBlocked = () => {
         description={
           <FormattedMessage
             defaultMessage="No blocked users yet"
+            id="dAvP6d"
             description="src/views/Me/Settings/Blocked/SettingsBlocked.tsx"
           />
         }

--- a/src/views/Me/Settings/Blocked/ToggleBlockButton.tsx
+++ b/src/views/Me/Settings/Blocked/ToggleBlockButton.tsx
@@ -51,11 +51,13 @@ export const ToggleBlockUserButton = ({ user }: ToggleBlockUserButtonProps) => {
         {isBlocked ? (
           <FormattedMessage
             defaultMessage="Unblock"
+            id="DqQvtL"
             description="src/views/Me/Settings/Blocked/ToggleBlockButton.tsx"
           />
         ) : (
           <FormattedMessage
             defaultMessage="Block"
+            id="2ef/Xl"
             description="src/views/Me/Settings/Blocked/ToggleBlockButton.tsx"
           />
         )}

--- a/src/views/Me/Settings/Blocked/index.tsx
+++ b/src/views/Me/Settings/Blocked/index.tsx
@@ -8,6 +8,7 @@ const SettingsBlocked = () => {
   const intl = useIntl()
   const title = intl.formatMessage({
     defaultMessage: 'Settings - Blocked Users',
+    id: 'KxVlDj',
     description: 'src/views/Me/Settings/Blocked/index.tsx',
   })
 
@@ -18,6 +19,7 @@ const SettingsBlocked = () => {
           <Layout.Header.Title>
             <FormattedMessage
               defaultMessage="Blocked Users"
+              id="YUXRsM"
               description="src/views/Me/Settings/Blocked/index.tsx"
             />
           </Layout.Header.Title>

--- a/src/views/Me/Settings/Misc/BlockedUsers.tsx
+++ b/src/views/Me/Settings/Misc/BlockedUsers.tsx
@@ -19,6 +19,7 @@ const BlockedUsers = () => {
       title={
         <FormattedMessage
           defaultMessage="Blocked Users"
+          id="hASeng"
           description="src/views/Me/Settings/Misc/BlockedUsers.tsx"
         />
       }

--- a/src/views/Me/Settings/Misc/Currency.tsx
+++ b/src/views/Me/Settings/Misc/Currency.tsx
@@ -88,6 +88,7 @@ const Currency = () => {
           title={
             <FormattedMessage
               defaultMessage="Currency"
+              id="cQYXjl"
               description="src/views/Me/Settings/Misc/Currency/index.tsx"
             />
           }

--- a/src/views/Me/Settings/Misc/Language.tsx
+++ b/src/views/Me/Settings/Misc/Language.tsx
@@ -19,6 +19,7 @@ const Language = () => {
           title={
             <FormattedMessage
               defaultMessage="Language"
+              id="BnMru1"
               description="src/views/Me/Settings/Misc/Language.tsx"
             />
           }

--- a/src/views/Me/Settings/Misc/LikerID.tsx
+++ b/src/views/Me/Settings/Misc/LikerID.tsx
@@ -13,6 +13,7 @@ const LikerID = () => {
       title={
         <FormattedMessage
           defaultMessage="Liker ID"
+          id="kS3vTS"
           description="src/views/Me/Settings/Misc/LikerID.tsx"
         />
       }
@@ -29,7 +30,7 @@ const LikerID = () => {
               window.dispatchEvent(new CustomEvent(OPEN_LIKE_COIN_DIALOG, {}))
             }
           >
-            <FormattedMessage defaultMessage="Connect" />
+            <FormattedMessage defaultMessage="Connect" id="+vVZ/G" />
           </Button>
         )
       }

--- a/src/views/Me/Settings/Misc/index.tsx
+++ b/src/views/Me/Settings/Misc/index.tsx
@@ -13,6 +13,7 @@ const SettingsMisc = () => {
   const intl = useIntl()
   const title = intl.formatMessage({
     defaultMessage: 'Settings - Misc',
+    id: 'Lp6CiR',
     description: 'src/views/Me/Settings/Misc/index.tsx',
   })
 
@@ -23,6 +24,7 @@ const SettingsMisc = () => {
           <Layout.Header.Title>
             <FormattedMessage
               defaultMessage="Settings"
+              id="8qGjpr"
               description="src/views/Me/Settings/Misc/index.tsx"
             />
           </Layout.Header.Title>

--- a/src/views/Me/Settings/Notifications/CircleSettings/index.tsx
+++ b/src/views/Me/Settings/Notifications/CircleSettings/index.tsx
@@ -113,6 +113,7 @@ const BaseNotificationSettings = () => {
         groupName={
           <FormattedMessage
             defaultMessage="My circle"
+            id="u+cgOo"
             description="src/views/Me/Settings/Notifications/Circle/index.tsx"
           />
         }
@@ -123,6 +124,7 @@ const BaseNotificationSettings = () => {
           title={
             <FormattedMessage
               defaultMessage="New subscribers"
+              id="m4KtjK"
               description="src/views/Me/Settings/Notifications/Circle/index.tsx"
             />
           }
@@ -132,6 +134,7 @@ const BaseNotificationSettings = () => {
               label={
                 <FormattedMessage
                   defaultMessage="New subscribers"
+                  id="m4KtjK"
                   description="src/views/Me/Settings/Notifications/Circle/index.tsx"
                 />
               }
@@ -146,6 +149,7 @@ const BaseNotificationSettings = () => {
           title={
             <FormattedMessage
               defaultMessage="New followers"
+              id="h7sMQs"
               description="src/views/Me/Settings/Notifications/Circle/index.tsx"
             />
           }
@@ -155,6 +159,7 @@ const BaseNotificationSettings = () => {
               label={
                 <FormattedMessage
                   defaultMessage="New followers"
+                  id="h7sMQs"
                   description="src/views/Me/Settings/Notifications/Circle/index.tsx"
                 />
               }
@@ -169,6 +174,7 @@ const BaseNotificationSettings = () => {
           title={
             <FormattedMessage
               defaultMessage="Subscription cancellations"
+              id="GhogWq"
               description="src/views/Me/Settings/Notifications/Circle/index.tsx"
             />
           }
@@ -178,6 +184,7 @@ const BaseNotificationSettings = () => {
               label={
                 <FormattedMessage
                   defaultMessage="Subscription cancellations"
+                  id="GhogWq"
                   description="src/views/Me/Settings/Notifications/Circle/index.tsx"
                 />
               }
@@ -192,6 +199,7 @@ const BaseNotificationSettings = () => {
           title={
             <FormattedMessage
               defaultMessage="New replies to broadcast"
+              id="A0KB7s"
               description="src/views/Me/Settings/Notifications/Circle/index.tsx"
             />
           }
@@ -201,6 +209,7 @@ const BaseNotificationSettings = () => {
               label={
                 <FormattedMessage
                   defaultMessage="New replies to broadcast"
+                  id="A0KB7s"
                   description="src/views/Me/Settings/Notifications/Circle/index.tsx"
                 />
               }
@@ -215,6 +224,7 @@ const BaseNotificationSettings = () => {
           title={
             <FormattedMessage
               defaultMessage="New discussions"
+              id="xafreT"
               description="src/views/Me/Settings/Notifications/Circle/index.tsx"
             />
           }
@@ -224,6 +234,7 @@ const BaseNotificationSettings = () => {
               label={
                 <FormattedMessage
                   defaultMessage="New discussions"
+                  id="xafreT"
                   description="src/views/Me/Settings/Notifications/Circle/index.tsx"
                 />
               }
@@ -238,6 +249,7 @@ const BaseNotificationSettings = () => {
           title={
             <FormattedMessage
               defaultMessage="New replies to discussions"
+              id="2vpUYs"
               description="src/views/Me/Settings/Notifications/Circle/index.tsx"
             />
           }
@@ -247,6 +259,7 @@ const BaseNotificationSettings = () => {
               label={
                 <FormattedMessage
                   defaultMessage="New replies to discussions"
+                  id="2vpUYs"
                   description="src/views/Me/Settings/Notifications/Circle/index.tsx"
                 />
               }
@@ -262,6 +275,7 @@ const BaseNotificationSettings = () => {
         groupName={
           <FormattedMessage
             defaultMessage="Following circles"
+            id="d1mBsg"
             description="src/views/Me/Settings/Notifications/Circle/index.tsx"
           />
         }
@@ -272,6 +286,7 @@ const BaseNotificationSettings = () => {
           title={
             <FormattedMessage
               defaultMessage="New articles"
+              id="ctl5tq"
               description="src/views/Me/Settings/Notifications/Circle/index.tsx"
             />
           }
@@ -281,6 +296,7 @@ const BaseNotificationSettings = () => {
               label={
                 <FormattedMessage
                   defaultMessage="New articles"
+                  id="ctl5tq"
                   description="src/views/Me/Settings/Notifications/Circle/index.tsx"
                 />
               }
@@ -295,6 +311,7 @@ const BaseNotificationSettings = () => {
           title={
             <FormattedMessage
               defaultMessage="New broadcasts"
+              id="viMrzF"
               description="src/views/Me/Settings/Notifications/Circle/index.tsx"
             />
           }
@@ -304,6 +321,7 @@ const BaseNotificationSettings = () => {
               label={
                 <FormattedMessage
                   defaultMessage="New broadcasts"
+                  id="viMrzF"
                   description="src/views/Me/Settings/Notifications/Circle/index.tsx"
                 />
               }
@@ -318,6 +336,7 @@ const BaseNotificationSettings = () => {
           title={
             <FormattedMessage
               defaultMessage="New replies to broadcast"
+              id="A0KB7s"
               description="src/views/Me/Settings/Notifications/Circle/index.tsx"
             />
           }
@@ -327,6 +346,7 @@ const BaseNotificationSettings = () => {
               label={
                 <FormattedMessage
                   defaultMessage="New replies to broadcast"
+                  id="A0KB7s"
                   description="src/views/Me/Settings/Notifications/Circle/index.tsx"
                 />
               }
@@ -341,6 +361,7 @@ const BaseNotificationSettings = () => {
           title={
             <FormattedMessage
               defaultMessage="New discussions"
+              id="xafreT"
               description="src/views/Me/Settings/Notifications/Circle/index.tsx"
             />
           }
@@ -350,6 +371,7 @@ const BaseNotificationSettings = () => {
               label={
                 <FormattedMessage
                   defaultMessage="New discussions"
+                  id="xafreT"
                   description="src/views/Me/Settings/Notifications/Circle/index.tsx"
                 />
               }
@@ -364,6 +386,7 @@ const BaseNotificationSettings = () => {
           title={
             <FormattedMessage
               defaultMessage="New replies to discussions"
+              id="2vpUYs"
               description="src/views/Me/Settings/Notifications/Circle/index.tsx"
             />
           }
@@ -373,6 +396,7 @@ const BaseNotificationSettings = () => {
               label={
                 <FormattedMessage
                   defaultMessage="New replies to discussions"
+                  id="2vpUYs"
                   description="src/views/Me/Settings/Notifications/Circle/index.tsx"
                 />
               }
@@ -390,6 +414,7 @@ const NotificationsCircleSettings = () => {
   const intl = useIntl()
   const title = intl.formatMessage({
     defaultMessage: 'Settings - Circle notifications',
+    id: 'MoyOR+',
     description: 'src/views/Me/Settings/Notifications/Circle/index.tsx',
   })
 
@@ -400,6 +425,7 @@ const NotificationsCircleSettings = () => {
           <Layout.Header.Title>
             <FormattedMessage
               defaultMessage="Circle notifications"
+              id="mp9SBo"
               description="src/views/Me/Settings/Notifications/index.tsx"
             />
           </Layout.Header.Title>

--- a/src/views/Me/Settings/Notifications/GeneralSettings/Email.tsx
+++ b/src/views/Me/Settings/Notifications/GeneralSettings/Email.tsx
@@ -19,6 +19,7 @@ const Email = ({ settings, toggle }: EmailProps) => {
   const intl = useIntl()
   const label = intl.formatMessage({
     defaultMessage: 'Matters Daily Report',
+    id: '8t6Cs8',
     description: 'src/views/Me/Settings/Notifications/Email.tsx',
   })
 
@@ -29,6 +30,7 @@ const Email = ({ settings, toggle }: EmailProps) => {
     <TableView
       groupName={intl.formatMessage({
         defaultMessage: 'Email',
+        id: 'NEKHMm',
         description: 'src/views/Me/Settings/Notifications/Email.tsx',
       })}
       spacingX={0}
@@ -38,6 +40,7 @@ const Email = ({ settings, toggle }: EmailProps) => {
         subtitle={
           <FormattedMessage
             defaultMessage="Selected activities related to you in the past 24 hours"
+            id="Mn7GEf"
             description="src/views/Me/Settings/Notifications/Email.tsx"
           />
         }
@@ -55,6 +58,7 @@ const Email = ({ settings, toggle }: EmailProps) => {
           !hasEmail && (
             <FormattedMessage
               defaultMessage="Please add email first"
+              id="ROPCC0"
               description="src/views/Me/Settings/Notifications/GeneralSettings/Email.tsx"
             />
           )

--- a/src/views/Me/Settings/Notifications/GeneralSettings/index.tsx
+++ b/src/views/Me/Settings/Notifications/GeneralSettings/index.tsx
@@ -101,6 +101,7 @@ const NotificationsGeneralSettings = () => {
           title={
             <FormattedMessage
               defaultMessage="New followers"
+              id="JkWLg6"
               description="src/views/Me/Settings/Notifications/GeneralSettings/index.tsx"
             />
           }
@@ -110,6 +111,7 @@ const NotificationsGeneralSettings = () => {
               label={
                 <FormattedMessage
                   defaultMessage="New followers"
+                  id="JkWLg6"
                   description="src/views/Me/Settings/Notifications/GeneralSettings/index.tsx"
                 />
               }
@@ -124,6 +126,7 @@ const NotificationsGeneralSettings = () => {
           title={
             <FormattedMessage
               defaultMessage="New likes"
+              id="Opaa0R"
               description="src/views/Me/Settings/Notifications/GeneralSettings/index.tsx"
             />
           }
@@ -133,6 +136,7 @@ const NotificationsGeneralSettings = () => {
               label={
                 <FormattedMessage
                   defaultMessage="New likes"
+                  id="Opaa0R"
                   description="src/views/Me/Settings/Notifications/GeneralSettings/index.tsx"
                 />
               }
@@ -147,6 +151,7 @@ const NotificationsGeneralSettings = () => {
           title={
             <FormattedMessage
               defaultMessage="Comments and replies"
+              id="dVbKzB"
               description="src/views/Me/Settings/Notifications/GeneralSettings/index.tsx"
             />
           }
@@ -156,6 +161,7 @@ const NotificationsGeneralSettings = () => {
               label={
                 <FormattedMessage
                   defaultMessage="Comments and replies"
+                  id="dVbKzB"
                   description="src/views/Me/Settings/Notifications/GeneralSettings/index.tsx"
                 />
               }
@@ -170,6 +176,7 @@ const NotificationsGeneralSettings = () => {
           title={
             <FormattedMessage
               defaultMessage="Mention me"
+              id="BMGZE2"
               description="src/views/Me/Settings/Notifications/GeneralSettings/index.tsx"
             />
           }
@@ -179,6 +186,7 @@ const NotificationsGeneralSettings = () => {
               label={
                 <FormattedMessage
                   defaultMessage="Mention me"
+                  id="BMGZE2"
                   description="src/views/Me/Settings/Notifications/GeneralSettings/index.tsx"
                 />
               }
@@ -193,6 +201,7 @@ const NotificationsGeneralSettings = () => {
           title={
             <FormattedMessage
               defaultMessage="Articles has been bookmarked"
+              id="Wg0ZvI"
               description="src/views/Me/Settings/Notifications/GeneralSettings/index.tsx"
             />
           }
@@ -202,6 +211,7 @@ const NotificationsGeneralSettings = () => {
               label={
                 <FormattedMessage
                   defaultMessage="Articles has been bookmarked"
+                  id="Wg0ZvI"
                   description="src/views/Me/Settings/Notifications/GeneralSettings/index.tsx"
                 />
               }
@@ -216,6 +226,7 @@ const NotificationsGeneralSettings = () => {
           title={
             <FormattedMessage
               defaultMessage="Articles has been collected"
+              id="l02bPO"
               description="src/views/Me/Settings/Notifications/GeneralSettings/index.tsx"
             />
           }
@@ -225,6 +236,7 @@ const NotificationsGeneralSettings = () => {
               label={
                 <FormattedMessage
                   defaultMessage="Articles has been collected"
+                  id="l02bPO"
                   description="src/views/Me/Settings/Notifications/GeneralSettings/index.tsx"
                 />
               }
@@ -239,6 +251,7 @@ const NotificationsGeneralSettings = () => {
           title={
             <FormattedMessage
               defaultMessage="Comments has been pinned"
+              id="gW/KWu"
               description="src/views/Me/Settings/Notifications/GeneralSettings/index.tsx"
             />
           }
@@ -248,6 +261,7 @@ const NotificationsGeneralSettings = () => {
               label={
                 <FormattedMessage
                   defaultMessage="Comments has been pinned"
+                  id="gW/KWu"
                   description="src/views/Me/Settings/Notifications/GeneralSettings/index.tsx"
                 />
               }
@@ -265,6 +279,7 @@ const NotificationsGeneralSettings = () => {
         groupName={
           <FormattedMessage
             defaultMessage="Circle"
+            id="kPylKK"
             description="src/views/Me/Settings/Notifications/index.tsx"
           />
         }
@@ -275,6 +290,7 @@ const NotificationsGeneralSettings = () => {
           title={
             <FormattedMessage
               defaultMessage="Circle notifications"
+              id="mp9SBo"
               description="src/views/Me/Settings/Notifications/index.tsx"
             />
           }

--- a/src/views/Me/Settings/Notifications/index.tsx
+++ b/src/views/Me/Settings/Notifications/index.tsx
@@ -10,6 +10,7 @@ const NotificationSettings = () => {
   const intl = useIntl()
   const title = intl.formatMessage({
     defaultMessage: 'Settings - Notifications',
+    id: '2DkkhD',
     description: 'src/views/Me/Settings/Notifications/index.tsx',
   })
 
@@ -20,6 +21,7 @@ const NotificationSettings = () => {
           <Layout.Header.Title>
             <FormattedMessage
               defaultMessage="Settings"
+              id="z+a1SW"
               description="src/views/Me/Settings/Notifications/index.tsx"
             />
           </Layout.Header.Title>

--- a/src/views/Me/Settings/SettingsTabs/index.tsx
+++ b/src/views/Me/Settings/SettingsTabs/index.tsx
@@ -17,6 +17,7 @@ const SettingsTabs: React.FC = () => {
       <Tabs.Tab href={PATHS.ME_SETTINGS} selected={isAccount}>
         <FormattedMessage
           defaultMessage="Account"
+          id="At8Qd2"
           description="src/views/Me/Settings/Settings/SettingsTabs/index.tsx"
         />
       </Tabs.Tab>
@@ -27,6 +28,7 @@ const SettingsTabs: React.FC = () => {
       >
         <FormattedMessage
           defaultMessage="Notifications"
+          id="6e8teX"
           description="src/views/Me/Settings/Settings/SettingsTabs/index.tsx"
         />
       </Tabs.Tab>
@@ -34,6 +36,7 @@ const SettingsTabs: React.FC = () => {
       <Tabs.Tab href={PATHS.ME_SETTINGS_MISC} selected={isOthers}>
         <FormattedMessage
           defaultMessage="Misc"
+          id="6lwWCu"
           description="src/views/Me/Settings/Settings/SettingsTabs/index.tsx"
         />
       </Tabs.Tab>

--- a/src/views/Me/Transactions/index.tsx
+++ b/src/views/Me/Transactions/index.tsx
@@ -152,6 +152,7 @@ const Transactions = () => {
   const intl = useIntl()
   const title = intl.formatMessage({
     defaultMessage: 'Transactions',
+    id: '/jJLYy',
   })
 
   return (
@@ -179,6 +180,7 @@ const Transactions = () => {
         >
           <FormattedMessage
             defaultMessage="All"
+            id="6aE6hr"
             description="src/views/Me/Transactions/index.tsx"
           />
         </SegmentedTabs.Tab>
@@ -189,6 +191,7 @@ const Transactions = () => {
         >
           <FormattedMessage
             defaultMessage="Supports"
+            id="NCBtyI"
             description="src/views/Me/Transactions/index.tsx"
           />
         </SegmentedTabs.Tab>
@@ -199,6 +202,7 @@ const Transactions = () => {
         >
           <FormattedMessage
             defaultMessage="Subscriptions"
+            id="T73SwS"
             description="src/views/Me/Transactions/index.tsx"
           />
         </SegmentedTabs.Tab>

--- a/src/views/Search/AggregateResults/Articles.tsx
+++ b/src/views/Search/AggregateResults/Articles.tsx
@@ -107,6 +107,7 @@ const AggregateArticleResults = () => {
         title={intl.formatMessage(
           {
             defaultMessage: '{q} - Matters Search',
+            id: 'l9LpDx',
             description: 'src/views/Search/AggregateResults/Articles.tsx',
           },
           { q: stripSpaces(q) }
@@ -120,7 +121,9 @@ const AggregateArticleResults = () => {
           pageInfo.hasNextPage && edges.length < MAX_SEARCH_RESULTS_LENGTH
         }
         loadMore={loadMore}
-        eof={<FormattedMessage defaultMessage="End of the results" />}
+        eof={
+          <FormattedMessage defaultMessage="End of the results" id="ui1+QC" />
+        }
       >
         <List>
           {edges.map(

--- a/src/views/Search/AggregateResults/Tags.tsx
+++ b/src/views/Search/AggregateResults/Tags.tsx
@@ -100,7 +100,9 @@ const AggregateTagResults = () => {
           pageInfo.hasNextPage && edges.length < MAX_SEARCH_RESULTS_LENGTH
         }
         loadMore={loadMore}
-        eof={<FormattedMessage defaultMessage="End of the results" />}
+        eof={
+          <FormattedMessage defaultMessage="End of the results" id="ui1+QC" />
+        }
       >
         <Menu>
           {edges.map(

--- a/src/views/Search/AggregateResults/Users.tsx
+++ b/src/views/Search/AggregateResults/Users.tsx
@@ -100,7 +100,9 @@ const AggregateUserResults = () => {
           pageInfo.hasNextPage && edges.length < MAX_SEARCH_RESULTS_LENGTH
         }
         loadMore={loadMore}
-        eof={<FormattedMessage defaultMessage="End of the results" />}
+        eof={
+          <FormattedMessage defaultMessage="End of the results" id="ui1+QC" />
+        }
       >
         <Menu>
           {edges.map(

--- a/src/views/TagDetail/ArticlesCount/index.tsx
+++ b/src/views/TagDetail/ArticlesCount/index.tsx
@@ -20,6 +20,7 @@ const ArticlesCount = ({ tag }: ArticlesCountProps) => {
         &nbsp;
         <FormattedMessage
           defaultMessage={`{totalCount, plural, =1 {article} other {articles}}`}
+          id="cd/II9"
           values={{
             totalCount: numAbbr(totalCount),
           }}

--- a/src/views/TagDetail/Buttons/FollowButton/Follow.tsx
+++ b/src/views/TagDetail/Buttons/FollowButton/Follow.tsx
@@ -71,7 +71,7 @@ const Follow = ({ tag }: FollowProps) => {
       onClick={onClick}
     >
       <TextIcon icon={<IconAdd16 />} weight="md" size="mdS">
-        <FormattedMessage defaultMessage="Follow" />
+        <FormattedMessage defaultMessage="Follow" id="ieGrWo" />
       </TextIcon>
     </Button>
   )

--- a/src/views/TagDetail/Buttons/FollowButton/Unfollow.tsx
+++ b/src/views/TagDetail/Buttons/FollowButton/Unfollow.tsx
@@ -51,9 +51,9 @@ const Unfollow = ({ tag }: UnfollowTagProps) => {
     >
       <TextIcon weight="md" size="mdS">
         {hover ? (
-          <FormattedMessage defaultMessage="Unfollow" />
+          <FormattedMessage defaultMessage="Unfollow" id="izWS4J" />
         ) : (
-          <FormattedMessage defaultMessage="Followed" />
+          <FormattedMessage defaultMessage="Followed" id="LGox1K" />
         )}
       </TextIcon>
     </Button>

--- a/src/views/TagDetail/Community/Maintainers/index.tsx
+++ b/src/views/TagDetail/Community/Maintainers/index.tsx
@@ -34,7 +34,7 @@ const ManageButton = ({ id }: Props) => {
           aria-haspopup="dialog"
         >
           <TextIcon icon={<IconSettings24 />} weight="md" size={'xs'}>
-            <FormattedMessage defaultMessage="Manage" />
+            <FormattedMessage defaultMessage="Manage" id="0Azlrb" />
           </TextIcon>
         </Button>
       )}
@@ -74,7 +74,7 @@ const Maintainers = ({ id, isOwner }: Props) => {
         <>
           <section className={styles.category}>
             <section>
-              <FormattedMessage defaultMessage="Maintainer" />
+              <FormattedMessage defaultMessage="Maintainer" id="eXDZGQ" />
             </section>
             {isOwner && (
               <section>
@@ -96,7 +96,7 @@ const Maintainers = ({ id, isOwner }: Props) => {
         <>
           <section className={styles.category}>
             <section>
-              <FormattedMessage defaultMessage="collaborators" />
+              <FormattedMessage defaultMessage="collaborators" id="dg3JCQ" />
               <span className={styles.count}>({editors.length})</span>
             </section>
           </section>

--- a/src/views/TagDetail/Community/Participants/index.tsx
+++ b/src/views/TagDetail/Community/Participants/index.tsx
@@ -77,7 +77,7 @@ const Participants = ({ id }: Props) => {
     <>
       <section className={styles.category}>
         <section>
-          <FormattedMessage defaultMessage="Creators" />
+          <FormattedMessage defaultMessage="Creators" id="TzhzIH" />
           <span className={styles.count}>({count})</span>
         </section>
       </section>

--- a/src/views/TagDetail/DropdownActions/index.tsx
+++ b/src/views/TagDetail/DropdownActions/index.tsx
@@ -65,7 +65,7 @@ const BaseDropdownActions = ({
     <Menu>
       {hasEditTag && (
         <Menu.Item
-          text={<FormattedMessage defaultMessage="Edit" />}
+          text={<FormattedMessage defaultMessage="Edit" id="wEQDC6" />}
           icon={<IconEdit16 size="mdS" />}
           onClick={openEditTagDialog}
           ariaHasPopup="dialog"
@@ -76,6 +76,7 @@ const BaseDropdownActions = ({
           text={
             <FormattedMessage
               defaultMessage="Add Articles into Featured"
+              id="ySGgTo"
               description="src/views/TagDetail/DropdownActions/index.tsx"
             />
           }
@@ -89,6 +90,7 @@ const BaseDropdownActions = ({
           text={
             <FormattedMessage
               defaultMessage="Manage Community"
+              id="L7Si5/"
               description="src/views/TagDetail/DropdownActions/index.tsx"
             />
           }
@@ -102,6 +104,7 @@ const BaseDropdownActions = ({
           text={
             <FormattedMessage
               defaultMessage="Resign From Maintainer"
+              id="GRtGnZ"
               description="src/views/TagDetail/DropdownActions/index.tsx"
             />
           }
@@ -121,6 +124,7 @@ const BaseDropdownActions = ({
           bgColor="halfBlack"
           aria-label={intl.formatMessage({
             defaultMessage: 'More Actions',
+            id: 'A7ugfn',
           })}
           aria-haspopup="listbox"
           ref={ref}
@@ -165,6 +169,7 @@ const DropdownActions = (props: DropdownActionsProps) => {
       toast.success({
         message: intl.formatMessage({
           defaultMessage: 'Tags added',
+          id: 'UjKkhq',
           description: 'src/views/TagDetail/DropdownActions/index.tsx',
         }),
       })
@@ -182,7 +187,10 @@ const DropdownActions = (props: DropdownActionsProps) => {
   const forbid = () => {
     toast.error({
       message: (
-        <FormattedMessage defaultMessage="You do not have permission to perform this operation" />
+        <FormattedMessage
+          defaultMessage="You do not have permission to perform this operation"
+          id="5FO4vn"
+        />
       ),
     })
     return
@@ -206,6 +214,7 @@ const DropdownActions = (props: DropdownActionsProps) => {
           title={
             <FormattedMessage
               defaultMessage="Add Articles into Featured"
+              id="ySGgTo"
               description="src/views/TagDetail/DropdownActions/index.tsx"
             />
           }

--- a/src/views/TagDetail/Followers/index.tsx
+++ b/src/views/TagDetail/Followers/index.tsx
@@ -24,6 +24,7 @@ const Followers = ({ tag }: FollowersProps) => {
           &nbsp;
           <FormattedMessage
             defaultMessage="are following"
+            id="hYG5fb"
             description="src/views/TagDetail/Followers/index.tsx"
           />
         </span>

--- a/src/views/TagDetail/Owner/index.tsx
+++ b/src/views/TagDetail/Owner/index.tsx
@@ -20,7 +20,10 @@ const Owner = ({ tag }: { tag: TagFragmentFragment }) => {
   const forbid = () => {
     toast.error({
       message: (
-        <FormattedMessage defaultMessage="You do not have permission to perform this operation" />
+        <FormattedMessage
+          defaultMessage="You do not have permission to perform this operation"
+          id="5FO4vn"
+        />
       ),
     })
   }
@@ -41,6 +44,7 @@ const Owner = ({ tag }: { tag: TagFragmentFragment }) => {
           >
             <FormattedMessage
               defaultMessage="This tag has no manager currently"
+              id="63HuBz"
               description="src/views/TagDetail/Owner/index.tsx"
             />
           </TextIcon>
@@ -60,6 +64,7 @@ const Owner = ({ tag }: { tag: TagFragmentFragment }) => {
                 <TextIcon weight="md" size="xs">
                   <FormattedMessage
                     defaultMessage="Maintain Tag"
+                    id="KMcrz8"
                     description="src/views/TagDetail/Owner/index.tsx"
                   />
                 </TextIcon>
@@ -84,6 +89,7 @@ const Owner = ({ tag }: { tag: TagFragmentFragment }) => {
         <TextIcon size="sm" color="greyDark">
           <FormattedMessage
             defaultMessage="Maintain"
+            id="ANA7sk"
             description="src/views/TagDetail/Owner/index.tsx"
           />
         </TextIcon>

--- a/src/views/TagDetail/RelatedTags/index.tsx
+++ b/src/views/TagDetail/RelatedTags/index.tsx
@@ -42,6 +42,7 @@ const RelatedTagsHeader = ({
       title={
         <FormattedMessage
           defaultMessage="Related Tags"
+          id="HFVDeB"
           description="src/views/TagDetail/RelatedTags/index.tsx"
         />
       }
@@ -133,7 +134,7 @@ const RelatedTags: React.FC<RelatedTagsProps> = ({ tagId, inSidebar }) => {
             textIconProps={{ size: 'sm', weight: 'md', spacing: 'xxtight' }}
             textAlign="center"
           >
-            <FormattedMessage defaultMessage="Back to All" />
+            <FormattedMessage defaultMessage="Back to All" id="o2Na0B" />
           </ViewMoreCard>
         </section>
       </section>

--- a/src/views/TagDetail/index.tsx
+++ b/src/views/TagDetail/index.tsx
@@ -199,14 +199,14 @@ const TagDetail = ({ tag }: { tag: TagFragmentFragment }) => {
           selected={isHottest}
           onClick={() => changeFeed('hottest')}
         >
-          <FormattedMessage defaultMessage="Trending" />
+          <FormattedMessage defaultMessage="Trending" id="ll/ufR" />
         </SegmentedTabs.Tab>
 
         <SegmentedTabs.Tab
           selected={isLatest}
           onClick={() => changeFeed('latest')}
         >
-          <FormattedMessage defaultMessage="Latest" />
+          <FormattedMessage defaultMessage="Latest" id="adThp5" />
         </SegmentedTabs.Tab>
 
         {hasSelectedFeed && (
@@ -214,7 +214,7 @@ const TagDetail = ({ tag }: { tag: TagFragmentFragment }) => {
             selected={isSelected}
             onClick={() => changeFeed('selected')}
           >
-            <FormattedMessage defaultMessage="Featured" />
+            <FormattedMessage defaultMessage="Featured" id="CnPG8j" />
           </SegmentedTabs.Tab>
         )}
 
@@ -222,7 +222,7 @@ const TagDetail = ({ tag }: { tag: TagFragmentFragment }) => {
           selected={isCreators}
           onClick={() => changeFeed('creators')}
         >
-          <FormattedMessage defaultMessage="Creators" />
+          <FormattedMessage defaultMessage="Creators" id="TzhzIH" />
         </SegmentedTabs.Tab>
       </SegmentedTabs>
 

--- a/src/views/User/Articles/PinBoard/UnPinButton/index.tsx
+++ b/src/views/User/Articles/PinBoard/UnPinButton/index.tsx
@@ -78,6 +78,7 @@ const UnPinButton = ({
       content={
         <FormattedMessage
           defaultMessage="Unpin from profile"
+          id="84VOdX"
           description="src/views/User/Articles/PinBoard/UnPinButton/index.tsx"
         />
       }

--- a/src/views/User/Articles/StartWirting.tsx
+++ b/src/views/User/Articles/StartWirting.tsx
@@ -32,6 +32,7 @@ const StartWriting = () => {
       >
         <FormattedMessage
           defaultMessage="Start writing"
+          id="4sl6yu"
           description="src/views/User/Articles/UserArticles.tsx"
         />
       </Button>

--- a/src/views/User/CollectionDetail/CollectionArticles/ViewerArticles.tsx
+++ b/src/views/User/CollectionDetail/CollectionArticles/ViewerArticles.tsx
@@ -82,6 +82,7 @@ const ViewerArticles = ({ collection }: ViewerArticlesProps) => {
         <section className={styles.updatedDate}>
           <FormattedMessage
             defaultMessage="Updated {date}"
+            id="h+punE"
             description="src/views/User/CollectionDetail/Content.tsx"
             values={{
               date: <DateTime date={updatedAt} color="grey" size="sm" />,
@@ -98,6 +99,7 @@ const ViewerArticles = ({ collection }: ViewerArticlesProps) => {
           content={
             <FormattedMessage
               defaultMessage="Collections allow up to 100 articles currently"
+              id="yJsERg"
               description="src/views/User/CollectionDetail/CollectionArticles/ViewerArticles.tsx"
             />
           }
@@ -105,7 +107,7 @@ const ViewerArticles = ({ collection }: ViewerArticlesProps) => {
         >
           <section className={styles.disableAddArticles}>
             <TextIcon icon={<IconAdd20 size="mdS" />}>
-              <FormattedMessage defaultMessage="Add Articles" />
+              <FormattedMessage defaultMessage="Add Articles" id="k97/u7" />
             </TextIcon>
           </section>
         </Tooltip>
@@ -121,7 +123,7 @@ const ViewerArticles = ({ collection }: ViewerArticlesProps) => {
               onClick={openAddArticlesCollection}
             >
               <TextIcon icon={<IconAdd20 size="mdS" />}>
-                <FormattedMessage defaultMessage="Add Articles" />
+                <FormattedMessage defaultMessage="Add Articles" id="k97/u7" />
               </TextIcon>
             </section>
           )}

--- a/src/views/User/CollectionDetail/CollectionArticles/index.tsx
+++ b/src/views/User/CollectionDetail/CollectionArticles/index.tsx
@@ -98,6 +98,7 @@ const CollectionArticles = ({ collection }: CollectionArticlesProps) => {
         <section className={styles.updatedDate}>
           <FormattedMessage
             defaultMessage="Updated {date}"
+            id="h+punE"
             description="src/views/User/CollectionDetail/Content.tsx"
             values={{
               date: <DateTime date={updatedAt} color="grey" size="sm" />,
@@ -123,12 +124,12 @@ const CollectionArticles = ({ collection }: CollectionArticlesProps) => {
         >
           {isSequenceNormal && (
             <TextIcon icon={<IconArrowDown20 size="mdS" />}>
-              <FormattedMessage defaultMessage="Sort" />
+              <FormattedMessage defaultMessage="Sort" id="25oM9Q" />
             </TextIcon>
           )}
           {isSequenceReverse && (
             <TextIcon icon={<IconArrowUp20 size="mdS" />}>
-              <FormattedMessage defaultMessage="Sort" />
+              <FormattedMessage defaultMessage="Sort" id="25oM9Q" />
             </TextIcon>
           )}
         </button>

--- a/src/views/User/CollectionDetail/CollectionProfile/index.tsx
+++ b/src/views/User/CollectionDetail/CollectionProfile/index.tsx
@@ -57,6 +57,7 @@ const CollectionProfile = ({ collection }: CollectionProfileProps) => {
                   <p className={styles.articleCount}>
                     <FormattedMessage
                       defaultMessage="{articleCount} Articles"
+                      id="LQxY1o"
                       description="src/views/User/CollectionDetail/CollectionProfile/index.tsx"
                       values={{
                         articleCount: articles.totalCount,
@@ -86,6 +87,7 @@ const CollectionProfile = ({ collection }: CollectionProfileProps) => {
                     >
                       <FormattedMessage
                         defaultMessage="Add description"
+                        id="JTWayV"
                         description="src/views/User/CollectionDetail/Content.tsx"
                       />
                     </Button>
@@ -127,6 +129,7 @@ const CollectionProfile = ({ collection }: CollectionProfileProps) => {
                     >
                       <FormattedMessage
                         defaultMessage="Add description"
+                        id="JTWayV"
                         description="src/views/User/CollectionDetail/Content.tsx"
                       />
                     </Button>

--- a/src/views/User/Collections/CreateCollection.tsx
+++ b/src/views/User/Collections/CreateCollection.tsx
@@ -21,6 +21,7 @@ const CreateCollection = () => {
             >
               <FormattedMessage
                 defaultMessage="Create collection"
+                id="0ThOw1"
                 description="src/views/User/Collections/UserCollections.tsx"
               />
             </Button>

--- a/src/views/User/Collections/UserCollections.tsx
+++ b/src/views/User/Collections/UserCollections.tsx
@@ -151,7 +151,10 @@ const UserCollections = () => {
             return (
               <section className={styles.addCollection} onClick={openDialog}>
                 <TextIcon icon={<IconAdd20 size="mdS" />}>
-                  <FormattedMessage defaultMessage="New Collection" />
+                  <FormattedMessage
+                    defaultMessage="New Collection"
+                    id="L4Fcr8"
+                  />
                 </TextIcon>
               </section>
             )

--- a/src/views/User/UserProfile/AsideUserProfile/index.tsx
+++ b/src/views/User/UserProfile/AsideUserProfile/index.tsx
@@ -110,7 +110,7 @@ export const AsideUserProfile = () => {
           <section className={styles.displayName}>
             <h1 className={styles.name}>
               {isUserArchived && (
-                <FormattedMessage defaultMessage="Deleted user" />
+                <FormattedMessage defaultMessage="Deleted user" id="9J0iCw" />
               )}
             </h1>
           </section>
@@ -240,7 +240,7 @@ export const AsideUserProfile = () => {
                   {numAbbr(user.followers.totalCount)}
                 </span>
                 &nbsp;
-                <FormattedMessage defaultMessage="Followers" />
+                <FormattedMessage defaultMessage="Followers" id="pzTOmv" />
               </button>
             )}
           </FollowersDialog>
@@ -254,6 +254,7 @@ export const AsideUserProfile = () => {
                 &nbsp;
                 <FormattedMessage
                   defaultMessage="Following"
+                  id="ohgTH4"
                   description="src/components/UserProfile/index.tsx"
                 />
               </button>
@@ -285,7 +286,7 @@ export const AsideUserProfile = () => {
                   textActiveColor="green"
                   onClick={openEditProfileDialog}
                 >
-                  <FormattedMessage defaultMessage="Edit profile" />
+                  <FormattedMessage defaultMessage="Edit profile" id="nYrKWp" />
                 </Button>
               )}
             </EditProfileDialog>

--- a/src/views/User/UserProfile/BadgesDialog/index.tsx
+++ b/src/views/User/UserProfile/BadgesDialog/index.tsx
@@ -19,6 +19,7 @@ const BaseBadgesDialog = ({ content, children }: BadgesDialogProps) => {
           title={
             <FormattedMessage
               defaultMessage="Badges"
+              id="DYrDcG"
               description="src/components/UserProfile/index.tsx"
             />
           }

--- a/src/views/User/UserProfile/DropdownActions/index.tsx
+++ b/src/views/User/UserProfile/DropdownActions/index.tsx
@@ -89,7 +89,7 @@ const BaseDropdownActions = ({
         textColor="greyDarker"
         textActiveColor="black"
         spacing={['xtight', 'base']}
-        text={<FormattedMessage defaultMessage="Share" />}
+        text={<FormattedMessage defaultMessage="Share" id="OKhRC6" />}
         icon={<IconShare20 size="mdS" />}
       />
       {hasRssFeed && (
@@ -121,6 +121,7 @@ const BaseDropdownActions = ({
                 textActiveColor="green"
                 aria-label={intl.formatMessage({
                   defaultMessage: 'More Actions',
+                  id: 'A7ugfn',
                 })}
                 onClick={openDropdown}
                 ref={ref}
@@ -138,6 +139,7 @@ const BaseDropdownActions = ({
                 borderActiveColor="black"
                 aria-label={intl.formatMessage({
                   defaultMessage: 'More Actions',
+                  id: 'A7ugfn',
                 })}
                 onClick={openDropdown}
                 ref={ref}
@@ -155,6 +157,7 @@ const BaseDropdownActions = ({
                 borderActiveColor="black"
                 aria-label={intl.formatMessage({
                   defaultMessage: 'More Actions',
+                  id: 'A7ugfn',
                 })}
                 onClick={openDropdown}
                 ref={ref}

--- a/src/views/User/UserProfile/FollowersDialog/index.tsx
+++ b/src/views/User/UserProfile/FollowersDialog/index.tsx
@@ -28,7 +28,7 @@ const BaseFollowersDialog = ({ user, children }: FollowersDialogProps) => {
             />
           }
           closeDialog={closeDialog}
-          closeText={<FormattedMessage defaultMessage="Close" />}
+          closeText={<FormattedMessage defaultMessage="Close" id="rbrahO" />}
         />
 
         <DynamicContent />
@@ -36,7 +36,7 @@ const BaseFollowersDialog = ({ user, children }: FollowersDialogProps) => {
         <Dialog.Footer
           smUpBtns={
             <Dialog.TextButton
-              text={<FormattedMessage defaultMessage="Close" />}
+              text={<FormattedMessage defaultMessage="Close" id="rbrahO" />}
               color="greyDarker"
               onClick={closeDialog}
             />

--- a/src/views/User/UserProfile/FollowingDialog/index.tsx
+++ b/src/views/User/UserProfile/FollowingDialog/index.tsx
@@ -24,7 +24,7 @@ const BaseFollowingDialog = ({ user, children }: FollowingDialogProps) => {
             <Translate zh_hant="追蹤內容" zh_hans="追踪内容" en={`Following`} />
           }
           closeDialog={closeDialog}
-          closeText={<FormattedMessage defaultMessage="Close" />}
+          closeText={<FormattedMessage defaultMessage="Close" id="rbrahO" />}
         />
 
         <DynamicContent />
@@ -32,7 +32,7 @@ const BaseFollowingDialog = ({ user, children }: FollowingDialogProps) => {
         <Dialog.Footer
           smUpBtns={
             <Dialog.TextButton
-              text={<FormattedMessage defaultMessage="Close" />}
+              text={<FormattedMessage defaultMessage="Close" id="rbrahO" />}
               color="greyDarker"
               onClick={closeDialog}
             />

--- a/src/views/User/UserProfile/Inactive.tsx
+++ b/src/views/User/UserProfile/Inactive.tsx
@@ -20,7 +20,7 @@ const Inactive = () => {
         <section className={styles.info}>
           <section className={styles.displayName}>
             <h1 className={styles.name}>
-              <FormattedMessage defaultMessage="Deleted user" />
+              <FormattedMessage defaultMessage="Deleted user" id="9J0iCw" />
             </h1>
           </section>
         </section>

--- a/src/views/User/UserProfile/TraveloggersAvatar/LogbookDialog/index.tsx
+++ b/src/views/User/UserProfile/TraveloggersAvatar/LogbookDialog/index.tsx
@@ -41,7 +41,7 @@ const LogbookDialog: React.FC<LogbookDialogProps> = ({
         <Dialog.Header
           title={title}
           closeDialog={closeDialog}
-          closeText={<FormattedMessage defaultMessage="Close" />}
+          closeText={<FormattedMessage defaultMessage="Close" id="rbrahO" />}
         />
 
         <Dialog.Message>
@@ -107,7 +107,7 @@ const LogbookDialog: React.FC<LogbookDialogProps> = ({
         <Dialog.Footer
           smUpBtns={
             <Dialog.TextButton
-              text={<FormattedMessage defaultMessage="Close" />}
+              text={<FormattedMessage defaultMessage="Close" id="rbrahO" />}
               color="greyDarker"
               onClick={closeDialog}
             />

--- a/src/views/User/UserProfile/WalletLabel/WalletAddress/index.tsx
+++ b/src/views/User/UserProfile/WalletLabel/WalletAddress/index.tsx
@@ -53,11 +53,16 @@ const WalletAddress: React.FC<WalletAddressProps> = ({
   return (
     <CopyToClipboard
       text={ensName || address}
-      successMessage={<FormattedMessage defaultMessage="Address copied" />}
+      successMessage={
+        <FormattedMessage defaultMessage="Address copied" id="+aMAeT" />
+      }
     >
       <Button
         {...buttonProps}
-        aria-label={intl.formatMessage({ defaultMessage: 'Copy' })}
+        aria-label={intl.formatMessage({
+          defaultMessage: 'Copy',
+          id: '4l6vz1',
+        })}
       >
         <TextIcon {...textIconProps} icon={<IconCopy16 size="sm" />}>
           {ensName || maskAddress(getAddress(address))}

--- a/src/views/User/UserProfile/WalletLabel/index.tsx
+++ b/src/views/User/UserProfile/WalletLabel/index.tsx
@@ -76,6 +76,7 @@ const WalletLabel: React.FC<WalletLabelProps> = ({
           content={
             <FormattedMessage
               defaultMessage="Wallet linked"
+              id="AVpR3Q"
               description="src/components/UserProfile/WalletLabel/index.tsx"
             />
           }
@@ -92,6 +93,7 @@ const WalletLabel: React.FC<WalletLabelProps> = ({
           title={
             <FormattedMessage
               defaultMessage="Wallet address"
+              id="9mfw9c"
               description="src/components/UserProfile/WalletLabel/WalletDialog/index.tsx"
             />
           }
@@ -123,11 +125,19 @@ const WalletLabel: React.FC<WalletLabelProps> = ({
               <CopyToClipboard
                 text={ensName || address}
                 successMessage={
-                  <FormattedMessage defaultMessage="Address copied" />
+                  <FormattedMessage
+                    defaultMessage="Address copied"
+                    id="+aMAeT"
+                  />
                 }
               >
                 <Dialog.RoundedButton
-                  text={<FormattedMessage defaultMessage="Copy Address" />}
+                  text={
+                    <FormattedMessage
+                      defaultMessage="Copy Address"
+                      id="me1nR+"
+                    />
+                  }
                   color="green"
                 />
               </CopyToClipboard>
@@ -137,6 +147,7 @@ const WalletLabel: React.FC<WalletLabelProps> = ({
                   text={
                     <FormattedMessage
                       defaultMessage="Open IPNS page"
+                      id="jkrM1r"
                       description="src/components/UserProfile/WalletLabel/index.tsx"
                     />
                   }
@@ -164,7 +175,7 @@ const WalletLabel: React.FC<WalletLabelProps> = ({
               )}
 
               <Dialog.RoundedButton
-                text={<FormattedMessage defaultMessage="Close" />}
+                text={<FormattedMessage defaultMessage="Close" id="rbrahO" />}
                 color="greyDarker"
                 onClick={closeDialog}
               />
@@ -173,19 +184,27 @@ const WalletLabel: React.FC<WalletLabelProps> = ({
           smUpBtns={
             <>
               <Dialog.TextButton
-                text={<FormattedMessage defaultMessage="Close" />}
+                text={<FormattedMessage defaultMessage="Close" id="rbrahO" />}
                 color="greyDarker"
                 onClick={closeDialog}
               />
               <CopyToClipboard
                 text={ensName || address}
                 successMessage={
-                  <FormattedMessage defaultMessage="Address copied" />
+                  <FormattedMessage
+                    defaultMessage="Address copied"
+                    id="+aMAeT"
+                  />
                 }
               >
                 <Dialog.TextButton
                   color="green"
-                  text={<FormattedMessage defaultMessage="Copy Address" />}
+                  text={
+                    <FormattedMessage
+                      defaultMessage="Copy Address"
+                      id="me1nR+"
+                    />
+                  }
                 />
               </CopyToClipboard>
               {ensName && hasLinkedIPNS && (
@@ -194,6 +213,7 @@ const WalletLabel: React.FC<WalletLabelProps> = ({
                   text={
                     <FormattedMessage
                       defaultMessage="Open IPNS page"
+                      id="jkrM1r"
                       description="src/components/UserProfile/WalletLabel/index.tsx"
                     />
                   }

--- a/src/views/User/UserProfile/index.tsx
+++ b/src/views/User/UserProfile/index.tsx
@@ -221,7 +221,7 @@ export const UserProfile = () => {
                     {numAbbr(user.followers.totalCount)}
                   </span>
                   &nbsp;
-                  <FormattedMessage defaultMessage="Followers" />
+                  <FormattedMessage defaultMessage="Followers" id="pzTOmv" />
                 </button>
               )}
             </FollowersDialog>
@@ -235,6 +235,7 @@ export const UserProfile = () => {
                   &nbsp;
                   <FormattedMessage
                     defaultMessage="Following"
+                    id="ohgTH4"
                     description="src/components/UserProfile/index.tsx"
                   />
                 </button>

--- a/src/views/User/UserTabs/index.tsx
+++ b/src/views/User/UserTabs/index.tsx
@@ -43,7 +43,7 @@ const UserTabs = ({
         selected={isInPath('USER_ARTICLES')}
         count={articleCount > 0 ? articleCount : undefined}
       >
-        <FormattedMessage defaultMessage="Articles" />
+        <FormattedMessage defaultMessage="Articles" id="3KNMbJ" />
       </Tabs.Tab>
 
       {showCollectionTab && (
@@ -52,7 +52,7 @@ const UserTabs = ({
           selected={isInPath('USER_COLLECTIONS')}
           count={collectionCount > 0 ? collectionCount : undefined}
         >
-          <FormattedMessage defaultMessage="Collections" />
+          <FormattedMessage defaultMessage="Collections" id="ulh3kf" />
         </Tabs.Tab>
       )}
     </Tabs>


### PR DESCRIPTION
* enable ESLint `formatjs/enforce-id` rule [0][1];
* remove `babel-plugin-formatjs` and related `.babelrc` config [2]; 

**Note:**
[0] [Unit tests with vitest](https://github.com/thematters/matters-web/pull/3897 ) cannot use custom transformers as [jest](https://formatjs.io/docs/tooling/ts-transformer#via-ts-jest-in-jestconfigjs) does;
[1] `id` will be added automatically on save file with VS Code, or run `npm run lint:ts:fix && npm run format` instead;
[2] Next.js 13 with [swc plugin](https://github.com/formatjs/formatjs/tree/main/packages/swc-plugin-experimental) is not stable yet and we are planning to [remove babel](https://github.com/thematters/matters-web/issues/3431);