### PR TITLE
fix: rename `.link` classname of <LinkWrapper>

### DIFF
--- a/src/components/Interaction/LinkWrapper/index.tsx
+++ b/src/components/Interaction/LinkWrapper/index.tsx
@@ -36,7 +36,7 @@ export const LinkWrapper: React.FC<
   }
 
   const linkClasses = classNames({
-    [styles.link]: true,
+    [styles.wrapper]: true,
     [textActiveColor
       ? styles[`textActive${capitalizeFirstLetter(textActiveColor)}`]
       : '']: !!textActiveColor,

--- a/src/components/Interaction/LinkWrapper/styles.module.css
+++ b/src/components/Interaction/LinkWrapper/styles.module.css
@@ -1,4 +1,4 @@
-.link {
+.wrapper {
   @mixin transition;
 
   display: flex;


### PR DESCRIPTION
https://feedback.matters.town/bug-reports/p/bd2dda