### PR TITLE
refactor(component): revert changes for conditional meta tag renders

### DIFF
--- a/src/components/Head/index.tsx
+++ b/src/components/Head/index.tsx
@@ -132,14 +132,6 @@ export const Head: React.FC<HeadProps> = (props) => {
           'minimum-scale=1, initial-scale=1, width=device-width, shrink-to-fit=no, user-scalable=no, viewport-fit=cover',
       },
       {
-        name: 'monetization',
-        content: props.paymentPointer || '',
-      },
-      {
-        name: 'googlebot',
-        content: !isProdServingCanonical ? 'noindex, nofollow' : '',
-      },
-      {
         name: 'application-name',
         content: 'Matters',
       },
@@ -231,6 +223,16 @@ export const Head: React.FC<HeadProps> = (props) => {
             }}
             key="ld-json-data"
           />
+        )}
+        {props.paymentPointer && (
+          <meta name="monetization" content={props.paymentPointer} />
+        )}
+        {/* noindex for non-production enviroment */}
+        {!isProdServingCanonical && (
+          <meta name="robots" content="noindex, nofollow" key="robots" />
+        )}
+        {!isProdServingCanonical && (
+          <meta name="googlebot" content="noindex, nofollow" key="googlebot" />
         )}
       </NextHead>
     </>


### PR DESCRIPTION
next-seo provides a nice static json config for seo tags, but for the previous conditionaly rendered dyanmic tags is not too friendly. resorting back to next/head

close #3838