### PR TITLE
feat(inputstep): enable paste in matters id input

### DIFF
--- a/src/components/Dialogs/SetUserNameDialog/InputStep.tsx
+++ b/src/components/Dialogs/SetUserNameDialog/InputStep.tsx
@@ -124,10 +124,6 @@ const InputStep: React.FC<Props> = ({ userName, gotoConfirm }) => {
             e.stopPropagation()
           }
         }}
-        onPaste={(e) => {
-          e.preventDefault()
-          return false
-        }}
         onKeyUp={() => {
           const v = normalizeUserName(values.mattersID)
           setFieldValue('mattersID', v.slice(0, maxUsername))


### PR DESCRIPTION
In the previous state, pasting Matters ID during registration was disabled to alert user the importance of this UUID. However, this presents UX drawbacks to users for unexpected behavior. Reverting to default behavior.

re #4251