### PR TITLE
fix: use dvh as top priority instead of ivh

### DIFF
--- a/src/components/Buttons/Write/index.tsx
+++ b/src/components/Buttons/Write/index.tsx
@@ -27,7 +27,7 @@ interface Props {
 
 const BaseWriteButton = (props: ButtonProps) => {
   const intl = useIntl()
-  const isSmUp = useMediaQuery(`(min-width: ${BREAKPOINTS.MD}px)`)
+  const isMdUp = useMediaQuery(`(min-width: ${BREAKPOINTS.LG}px)`)
 
   return (
     <Tooltip
@@ -38,7 +38,7 @@ const BaseWriteButton = (props: ButtonProps) => {
       })}
       placement="left"
       delay={[1000, null]}
-      disabled={!isSmUp}
+      disabled={!isMdUp}
     >
       <Button
         bgActiveColor="greyLighter"

--- a/src/components/Dialog/Content/styles.module.css
+++ b/src/components/Dialog/Content/styles.module.css
@@ -4,6 +4,7 @@
   flex-shrink: 1;
   max-height: calc(70vh - 4.25rem); /* 4.25rem is the height of header */
   max-height: calc(var(--ivh) * 90 - 4.25rem);
+  max-height: calc(90dvh - 4.25rem);
   overflow-x: hidden;
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
@@ -11,20 +12,23 @@
   &.fixedHeight {
     height: calc(70vh - 4.25rem); /* 4.25rem is the height of header */
     height: calc(var(--ivh) * 90 - 4.25rem);
+    height: calc(90dvh - 4.25rem);
 
     @media (--sm-up) {
       height: min(34rem, 64vh);
       height: min(34rem, calc(var(--ivh) * 64));
+      height: min(34rem, 64dvh);
     }
   }
 
   @media (--sm-up) {
     max-height: min(34rem, 64vh);
     max-height: min(34rem, calc(var(--ivh) * 64));
+    max-height: min(34rem, 64dvh);
   }
 }
 
-/* FIXME: can be removed if editor is only used in single page instead of being used in dialog */
+/* FIXME: can be removed if editor is only used in single page instead of being used in dialog, use vvh to exclude visual keyboard */
 :global(body.editor-focused) {
   & .content {
     max-height: calc(var(--vvh) * 100 - 4.25rem);

--- a/src/components/Editor/Article/styles.module.css
+++ b/src/components/Editor/Article/styles.module.css
@@ -5,6 +5,7 @@
   ); /* 3rem for header, 4rem for bottom bar */
 
   height: calc(var(--ivh) * 100 - 3rem - 4rem - var(--sp16) * 2);
+  height: calc(100dvh - 3rem - 4rem - var(--sp16) * 2);
   overflow-x: hidden;
   overflow-y: auto;
 
@@ -19,6 +20,7 @@
   & :global(.tiptap) {
     min-height: 50vh;
     min-height: calc(var(--ivh) * 50);
+    min-height: 50dvh;
 
     /* outline */
     &:focus {

--- a/src/components/Form/Select/styles.module.css
+++ b/src/components/Form/Select/styles.module.css
@@ -10,6 +10,7 @@
   width: 100%;
   max-height: 50vh;
   max-height: calc(var(--ivh) * 50);
+  max-height: 50dvh;
   padding-top: var(--sp8);
   padding-bottom: var(--sp8);
   overflow: auto;
@@ -19,6 +20,7 @@
   @media (--sm-up) {
     max-height: 30vh;
     max-height: calc(var(--ivh) * 30);
+    max-height: 30dvh;
   }
 
   &.dropdown {

--- a/src/components/Layout/styles.module.css
+++ b/src/components/Layout/styles.module.css
@@ -59,6 +59,7 @@
     /* FIXME: page scrollbar is showed on open dialog */
     min-height: calc(100vh + 1px);
     min-height: calc(var(--ivh) * 100 + 1px);
+    min-height: calc(100dvh + 1px);
     padding-bottom: 0;
   }
 

--- a/src/views/Auth/Universal/styles.module.css
+++ b/src/views/Auth/Universal/styles.module.css
@@ -6,6 +6,7 @@
     width: 100vw;
     height: 100vh;
     height: calc(var(--ivh) * 100);
+    height: 100dvh;
 
     & .container {
       @mixin border-grey-light;

--- a/src/views/Callback/styles.module.css
+++ b/src/views/Callback/styles.module.css
@@ -2,8 +2,8 @@
   @mixin flex-center-all;
 
   height: 100vh;
-  height: 100dvh;
   height: calc(var(--ivh) * 100);
+  height: 100dvh;
 
   & .logo {
     & svg {


### PR DESCRIPTION
### Strategy for viewport heights
* For normal use cases: dvh > ivh > vh;
* For use cases want to exclude the visual keyboard: vvh > dvh > ivh > vh;


refs:
- 2024-05-prod-2#PR-59