### PR TITLE
fix(article-detail): adjust page up/down scroll height for floating toolbar

### DIFF
--- a/src/common/enums/keyValue.ts
+++ b/src/common/enums/keyValue.ts
@@ -6,4 +6,6 @@ export const KEYVALUE = {
   arrowUp: 'arrowup',
   arrowDown: 'arrowdown',
   space: 'space',
+  pageDown: 'pagedown',
+  pageUp: 'pageup',
 }

--- a/src/views/ArticleDetail/index.tsx
+++ b/src/views/ArticleDetail/index.tsx
@@ -32,6 +32,7 @@ import {
   useEventListener,
   useFeatures,
   useIntersectionObserver,
+  useNativeEventListener,
   usePublicQuery,
   useRoute,
   ViewerContext,
@@ -538,6 +539,27 @@ const ArticleDetail = ({
   useEffect(() => {
     loadPrivate()
   }, [article?.shortHash, viewer.id])
+
+  // floating toolbar is blocking some text when pressing page up and down
+  // offsetting it with the height of floating toolbar
+  useNativeEventListener('keydown', (event: KeyboardEvent) => {
+    if (
+      event.code.toLowerCase() === 'pagedown' ||
+      event.code.toLowerCase() === 'pageup'
+    ) {
+      event.preventDefault()
+      const remInPixels = parseFloat(
+        getComputedStyle(document.documentElement).fontSize
+      )
+      const scrollDirection = event.code.toLowerCase() === 'pagedown' ? 1 : -1
+      const scrollAmount = window.innerHeight - 5 * remInPixels // the height of floating toolbar
+
+      window.scrollBy({
+        top: scrollAmount * scrollDirection,
+        behavior: 'smooth',
+      })
+    }
+  })
 
   /**
    * Render:Loading

--- a/src/views/ArticleDetail/index.tsx
+++ b/src/views/ArticleDetail/index.tsx
@@ -545,7 +545,8 @@ const ArticleDetail = ({
   useNativeEventListener('keydown', (event: KeyboardEvent) => {
     if (
       event.code.toLowerCase() === 'pagedown' ||
-      event.code.toLowerCase() === 'pageup'
+      event.code.toLowerCase() === 'pageup' ||
+      event.code.toLowerCase() === 'space'
     ) {
       event.preventDefault()
       const remInPixels = parseFloat(

--- a/src/views/ArticleDetail/index.tsx
+++ b/src/views/ArticleDetail/index.tsx
@@ -5,6 +5,7 @@ import { useContext, useEffect, useState } from 'react'
 import { FormattedMessage } from 'react-intl'
 
 import {
+  KEYVALUE,
   OPEN_COMMENT_DETAIL_DIALOG,
   OPEN_COMMENT_LIST_DRAWER,
 } from '~/common/enums'
@@ -543,16 +544,18 @@ const ArticleDetail = ({
   // floating toolbar is blocking some text when pressing page up and down
   // offsetting it with the height of floating toolbar
   useNativeEventListener('keydown', (event: KeyboardEvent) => {
-    if (
-      event.code.toLowerCase() === 'pagedown' ||
-      event.code.toLowerCase() === 'pageup' ||
-      event.code.toLowerCase() === 'space'
-    ) {
+    const keyToScrollDirection = {
+      [KEYVALUE.pageDown]: 1,
+      [KEYVALUE.pageUp]: -1,
+      [KEYVALUE.space]: 1,
+    } // map the key to scroll direction
+    const key = event.code.toLowerCase()
+    if (key in keyToScrollDirection) {
       event.preventDefault()
       const remInPixels = parseFloat(
         getComputedStyle(document.documentElement).fontSize
       )
-      const scrollDirection = event.code.toLowerCase() === 'pagedown' ? 1 : -1
+      const scrollDirection = keyToScrollDirection[key]
       const scrollAmount = window.innerHeight - 5 * remInPixels // the height of floating toolbar
 
       window.scrollBy({


### PR DESCRIPTION
Since the presence of a floating toolbar, the normal scroll height for page up/down (fn + up/down key on OSX) hides some pixels. Now it will offset the height by the height of the toolbar

close: #4370