### PR TITLE
feat(dialog): make close dialog on click outside as default

### DIFF
--- a/src/components/Dialog/Inner/index.tsx
+++ b/src/components/Dialog/Inner/index.tsx
@@ -19,6 +19,7 @@ export type DialogInnerProps = {
 
   dismissOnClickOutside?: boolean
   dismissOnHandle?: boolean
+  dismissOnESC?: boolean
 
   testId?: string
 }
@@ -36,8 +37,9 @@ const Inner: React.FC<
   smBgColor,
   smUpBgColor,
 
-  dismissOnClickOutside = false,
+  dismissOnClickOutside = true,
   dismissOnHandle = true,
+  dismissOnESC = true,
 
   style,
   initialFocusRef,
@@ -82,7 +84,6 @@ const Inner: React.FC<
     if (!dismissOnClickOutside) {
       return
     }
-
     closeTopDialog()
   }
 
@@ -98,7 +99,7 @@ const Inner: React.FC<
         if (event.code.toLowerCase() !== KEYVALUE.escape) {
           return
         }
-        if (!dismissOnHandle) {
+        if (!dismissOnESC) {
           return
         }
         closeTopDialog()

--- a/src/components/Dialogs/AddCollectionDialog/index.tsx
+++ b/src/components/Dialogs/AddCollectionDialog/index.tsx
@@ -21,7 +21,12 @@ const BaseAddCollectionDialog = ({
     <>
       {children({ openDialog })}
 
-      <Dialog isOpen={show} onDismiss={closeDialog}>
+      <Dialog
+        isOpen={show}
+        onDismiss={closeDialog}
+        dismissOnClickOutside={false}
+        dismissOnESC={false}
+      >
         <DynamicContent
           closeDialog={closeDialog}
           gotoDetailPage={gotoDetailPage}

--- a/src/components/Dialogs/EditProfileDialog/Content.tsx
+++ b/src/components/Dialogs/EditProfileDialog/Content.tsx
@@ -13,7 +13,11 @@ import {
   MAX_USER_DESCRIPTION_LENGTH,
   MAX_USER_DISPLAY_NAME_LENGTH,
 } from '~/common/enums'
-import { parseFormSubmitErrors, validateDisplayName } from '~/common/utils'
+import {
+  formStorage,
+  parseFormSubmitErrors,
+  validateDisplayName,
+} from '~/common/utils'
 import {
   AvatarUploader,
   CoverUploader,
@@ -43,6 +47,11 @@ interface FormValues {
   description: string
 }
 
+type FormDraft = FormValues & {
+  avatarPath?: string | null
+  profileCoverPath?: string | null
+}
+
 const UPDATE_USER_INFO = gql`
   mutation UpdateUserInfoProfile($input: UpdateUserInfoInput!) {
     updateUserInfo(input: $input) {
@@ -66,14 +75,19 @@ const EditProfileDialogContent: React.FC<FormProps> = ({
   user,
   closeDialog,
 }) => {
+  const intl = useIntl()
+  const viewer = useContext(ViewerContext)
+
+  const formId = 'edit-profile-form'
+  const formStorageKey = formStorage.genKey({ authorId: viewer.id, formId })
+  const formDraft = formStorage.get<FormDraft>(formStorageKey, 'session')
+
   const [update] = useMutation<UpdateUserInfoProfileMutation>(
     UPDATE_USER_INFO,
     undefined,
     { showToast: false }
   )
-  const viewer = useContext(ViewerContext)
-  const formId = 'edit-profile-form'
-  const intl = useIntl()
+
   const validateDescription = (value: string) => {
     if (value.length > MAX_USER_DESCRIPTION_LENGTH) {
       return intl.formatMessage(
@@ -100,10 +114,10 @@ const EditProfileDialogContent: React.FC<FormProps> = ({
     setFieldValue,
   } = useFormik<FormValues>({
     initialValues: {
-      avatar: UNCHANGED_FIELD,
-      profileCover: UNCHANGED_FIELD,
-      displayName: user.displayName || '',
-      description: user.info.description || '',
+      avatar: formDraft?.avatar || UNCHANGED_FIELD,
+      profileCover: formDraft?.profileCover || UNCHANGED_FIELD,
+      displayName: formDraft?.displayName || user.displayName || '',
+      description: formDraft?.description || user.info.description || '',
     },
     validateOnBlur: false,
     validateOnChange: false,
@@ -131,6 +145,9 @@ const EditProfileDialogContent: React.FC<FormProps> = ({
         toast.success({
           message: <FormattedMessage defaultMessage="Saved" id="fsB/4p" />,
         })
+
+        // clear draft
+        formStorage.remove(formStorageKey, 'session')
 
         setSubmitting(false)
         closeDialog()
@@ -163,21 +180,43 @@ const EditProfileDialogContent: React.FC<FormProps> = ({
       <section className={styles.coverField}>
         <CoverUploader
           assetType={ASSET_TYPE.profileCover}
-          cover={user.info.profileCover}
+          cover={formDraft?.profileCoverPath || user.info.profileCover}
           fallbackCover={IMAGE_COVER.src}
           entityType={ENTITY_TYPE.user}
           type="userProfile"
           inEditor
-          onUploaded={(assetId) => setFieldValue('profileCover', assetId)}
+          onUploaded={(assetId, path) => {
+            setFieldValue('profileCover', assetId)
+            formStorage.set<FormDraft>(
+              formStorageKey,
+              { ...values, profileCover: assetId, profileCoverPath: path },
+              'session'
+            )
+          }}
           onUploadStart={() => setCoverLoading(true)}
           onUploadEnd={() => setCoverLoading(false)}
+          onReset={() => {
+            setFieldValue('profileCover', null)
+            formStorage.set<FormDraft>(
+              formStorageKey,
+              { ...values, profileCover: null, profileCoverPath: null },
+              'session'
+            )
+          }}
         />
       </section>
 
       <section className={styles.avatarField}>
         <AvatarUploader
-          user={user}
-          onUploaded={(assetId) => setFieldValue('avatar', assetId)}
+          src={formDraft?.avatarPath || user.avatar}
+          onUploaded={(assetId, path) => {
+            setFieldValue('avatar', assetId)
+            formStorage.set<FormDraft>(
+              formStorageKey,
+              { ...values, avatar: assetId, avatarPath: path },
+              'session'
+            )
+          }}
           onUploadStart={() => setAvatarLoading(true)}
           onUploadEnd={() => setAvatarLoading(false)}
           hasBorder
@@ -197,7 +236,14 @@ const EditProfileDialogContent: React.FC<FormProps> = ({
         error={touched.displayName && errors.displayName}
         hintAlign={touched.displayName && errors.displayName ? 'left' : 'right'}
         onBlur={handleBlur}
-        onChange={handleChange}
+        onChange={(e) => {
+          handleChange(e)
+          formStorage.set<FormDraft>(
+            formStorageKey,
+            { ...values, displayName: e.target.value },
+            'session'
+          )
+        }}
         maxLength={MAX_USER_DISPLAY_NAME_LENGTH}
         spacingTop="base"
         spacingBottom="base"
@@ -215,7 +261,14 @@ const EditProfileDialogContent: React.FC<FormProps> = ({
         error={touched.description && errors.description}
         hintAlign={touched.description && errors.description ? 'left' : 'right'}
         onBlur={handleBlur}
-        onChange={handleChange}
+        onChange={(e) => {
+          handleChange(e)
+          formStorage.set<FormDraft>(
+            formStorageKey,
+            { ...values, description: e.target.value },
+            'session'
+          )
+        }}
       />
     </Form>
   )

--- a/src/components/Dialogs/EditTagDialog/Content.tsx
+++ b/src/components/Dialogs/EditTagDialog/Content.tsx
@@ -132,6 +132,7 @@ const EditTagDialogContent: React.FC<BaseEditTagDialogContentProps> = ({
           onUploaded={(assetId) => setFieldValue('newCover', assetId)}
           onUploadStart={() => setCoverLoading(true)}
           onUploadEnd={() => setCoverLoading(false)}
+          onReset={() => setFieldValue('newCover', null)}
         />
       </section>
 

--- a/src/components/Dialogs/EditorSearchSelectDialog/index.tsx
+++ b/src/components/Dialogs/EditorSearchSelectDialog/index.tsx
@@ -9,6 +9,8 @@ type EditorSearchSelectDialogProps = Omit<
   'closeDialog'
 > & {
   children: ({ openDialog }: { openDialog: () => void }) => React.ReactNode
+  dismissOnClickOutside?: boolean
+  dismissOnESC?: boolean
 }
 
 const DynamicEditorSearchSelectForm = dynamic(
@@ -18,6 +20,8 @@ const DynamicEditorSearchSelectForm = dynamic(
 
 const BaseSearchSelectDialog = ({
   children,
+  dismissOnClickOutside,
+  dismissOnESC,
   ...props
 }: EditorSearchSelectDialogProps) => {
   const { show, openDialog, closeDialog } = useDialogSwitch(true)
@@ -26,7 +30,12 @@ const BaseSearchSelectDialog = ({
     <>
       {children({ openDialog })}
 
-      <Dialog isOpen={show} onDismiss={closeDialog}>
+      <Dialog
+        isOpen={show}
+        onDismiss={closeDialog}
+        dismissOnClickOutside={dismissOnClickOutside}
+        dismissOnESC={dismissOnESC}
+      >
         <DynamicEditorSearchSelectForm
           {...props}
           onSave={async (nodes: SelectNode[]) => {

--- a/src/components/Dialogs/SetUserNameDialog/index.tsx
+++ b/src/components/Dialogs/SetUserNameDialog/index.tsx
@@ -23,7 +23,13 @@ const BaseSetUserNameDialog = ({ children }: SetUserNameDialogProps) => {
     <>
       {children && children({ openDialog })}
 
-      <Dialog isOpen={show} onDismiss={closeDialog} dismissOnHandle={false}>
+      <Dialog
+        isOpen={show}
+        onDismiss={closeDialog}
+        dismissOnHandle={false}
+        dismissOnClickOutside={false}
+        dismissOnESC={false}
+      >
         <DynamicContent closeDialog={closeDialog} />
       </Dialog>
     </>

--- a/src/components/Editor/BottomBar/index.tsx
+++ b/src/components/Editor/BottomBar/index.tsx
@@ -176,6 +176,8 @@ const BottomBar: React.FC<BottomBarProps> = ({
               saving={tagsSaving}
               createTag
               CustomStagingArea={TagCustomStagingArea}
+              dismissOnClickOutside={false}
+              dismissOnESC={false}
             >
               {({ openDialog }) => (
                 <button
@@ -218,6 +220,8 @@ const BottomBar: React.FC<BottomBarProps> = ({
               nodes={collection}
               saving={collectionSaving}
               CustomStagingArea={ArticleCustomStagingArea}
+              dismissOnClickOutside={false}
+              dismissOnESC={false}
             >
               {({ openDialog }) => (
                 <button

--- a/src/components/Editor/SetCover/Dialog.tsx
+++ b/src/components/Editor/SetCover/Dialog.tsx
@@ -19,7 +19,12 @@ const BaseSetCoverDialog = ({ children, ...props }: SetCoverDialogProps) => {
     <>
       {children({ openDialog })}
 
-      <Dialog isOpen={show} onDismiss={closeDialog}>
+      <Dialog
+        isOpen={show}
+        onDismiss={closeDialog}
+        dismissOnClickOutside={false}
+        dismissOnESC={false}
+      >
         <DynamicSetCover {...props} closeDialog={closeDialog} />
       </Dialog>
     </>

--- a/src/components/Editor/SetVersionDescription/index.tsx
+++ b/src/components/Editor/SetVersionDescription/index.tsx
@@ -24,7 +24,12 @@ const BaseSetVersionDescriptionDialog = ({
     <>
       {children({ openDialog })}
 
-      <Dialog isOpen={show} onDismiss={closeDialog}>
+      <Dialog
+        isOpen={show}
+        onDismiss={closeDialog}
+        dismissOnClickOutside={false}
+        dismissOnESC={false}
+      >
         <DynamicContent
           closeDialog={closeDialog}
           description={description}

--- a/src/components/Editor/SettingsDialog/index.tsx
+++ b/src/components/Editor/SettingsDialog/index.tsx
@@ -186,7 +186,12 @@ const BaseEditorSettingsDialog = ({
     <>
       {children({ openDialog })}
 
-      <Dialog isOpen={show} onDismiss={closeDialog}>
+      <Dialog
+        isOpen={show}
+        onDismiss={closeDialog}
+        dismissOnClickOutside={false}
+        dismissOnESC={false}
+      >
         {isList && (
           <SettingsList
             saving={saving}

--- a/src/components/Editor/Sidebar/Collection/index.tsx
+++ b/src/components/Editor/Sidebar/Collection/index.tsx
@@ -46,6 +46,8 @@ const SidebarCollection = ({
       nodes={collection}
       saving={collectionSaving}
       CustomStagingArea={ArticleCustomStagingArea}
+      dismissOnClickOutside={false}
+      dismissOnESC={false}
     >
       {({ openDialog }) => (
         <Box

--- a/src/components/Editor/Sidebar/Tags/index.tsx
+++ b/src/components/Editor/Sidebar/Tags/index.tsx
@@ -45,6 +45,8 @@ const SidebarTags = ({
       saving={saving}
       createTag
       CustomStagingArea={TagCustomStagingArea}
+      dismissOnClickOutside={false}
+      dismissOnESC={false}
     >
       {({ openDialog }) => (
         <Box

--- a/src/components/Editor/ToggleAccess/SupportSettingDialog/index.tsx
+++ b/src/components/Editor/ToggleAccess/SupportSettingDialog/index.tsx
@@ -35,7 +35,12 @@ const BaseSupportSettingDialog = ({
     <>
       {children({ openDialog })}
 
-      <Dialog isOpen={show} onDismiss={closeDialog}>
+      <Dialog
+        isOpen={show}
+        onDismiss={closeDialog}
+        dismissOnClickOutside={false}
+        dismissOnESC={false}
+      >
         <DynamicContent
           closeDialog={closeDialog}
           draft={draft}

--- a/src/components/FileUploader/AvatarUploader/index.tsx
+++ b/src/components/FileUploader/AvatarUploader/index.tsx
@@ -34,7 +34,7 @@ import {
 import styles from './styles.module.css'
 
 export type AvatarUploaderProps = {
-  onUploaded: (assetId: string) => void
+  onUploaded: (assetId: string, path: string) => void
   onUploadStart: () => void
   onUploadEnd: () => void
   hasBorder?: boolean
@@ -138,7 +138,7 @@ export const AvatarUploader: React.FC<AvatarUploaderProps> = ({
         }).catch(console.error)
 
         setAvatar(path)
-        onUploaded(assetId)
+        onUploaded(assetId, path)
       } else {
         throw new Error()
       }

--- a/src/components/FileUploader/CoverUploader/index.tsx
+++ b/src/components/FileUploader/CoverUploader/index.tsx
@@ -64,13 +64,15 @@ export type CoverUploaderProps = {
     | ENTITY_TYPE.tag
     | ENTITY_TYPE.circle
     | ENTITY_TYPE.collection
-  onUploaded: (assetId: string | null) => void
+
+  onUploaded: (assetId: string, path: string) => void
   onUploadStart: () => void
   onUploadEnd: () => void
+  onReset: () => void
+
   type?: 'circle' | 'collection' | 'userProfile'
 
   bookTitle?: string
-  bookArticleCount?: number
 } & CoverProps
 
 export const CoverUploader = ({
@@ -80,12 +82,14 @@ export const CoverUploader = ({
   entityId,
   entityType,
   inEditor,
+
   onUploaded,
   onUploadStart,
   onUploadEnd,
+  onReset,
+
   type,
   bookTitle,
-  bookArticleCount,
 }: CoverUploaderProps) => {
   const intl = useIntl()
 
@@ -162,7 +166,7 @@ export const CoverUploader = ({
         }).catch(console.error)
 
         setCover(path)
-        onUploaded(assetId)
+        onUploaded(assetId, path)
       } else {
         throw new Error()
       }
@@ -186,7 +190,10 @@ export const CoverUploader = ({
     event.preventDefault()
     setCover(undefined)
     setLocalSrc(undefined)
-    onUploaded(null)
+
+    if (onReset) {
+      onReset()
+    }
   }
 
   const Mask = () => (

--- a/src/components/Forms/CreateCircleForm/Profile.tsx
+++ b/src/components/Forms/CreateCircleForm/Profile.tsx
@@ -150,6 +150,7 @@ const Init: React.FC<FormProps> = ({ circle, type, purpose, closeDialog }) => {
           onUploaded={(assetId) => setFieldValue('cover', assetId)}
           onUploadStart={() => setCoverLoading(true)}
           onUploadEnd={() => setCoverLoading(false)}
+          onReset={() => setFieldValue('cover', null)}
           entityType={ENTITY_TYPE.user}
           entityId={circle.id}
         />

--- a/src/stories/components/Uploader/Cover.stories.tsx
+++ b/src/stories/components/Uploader/Cover.stories.tsx
@@ -25,6 +25,7 @@ const Template: ComponentStory<typeof CoverUploader> = () => (
           onUploaded={(assetId) => alert({ assetId })}
           onUploadStart={() => null}
           onUploadEnd={() => null}
+          onReset={() => null}
           fallbackCover={IMAGE_COVER.src}
         />
       </li>
@@ -35,6 +36,7 @@ const Template: ComponentStory<typeof CoverUploader> = () => (
           onUploaded={(assetId) => alert({ assetId })}
           onUploadStart={() => null}
           onUploadEnd={() => null}
+          onReset={() => null}
           fallbackCover={IMAGE_COVER.src}
           cover="https://source.unsplash.com/512x512?cover"
         />
@@ -49,6 +51,7 @@ const Template: ComponentStory<typeof CoverUploader> = () => (
           onUploaded={(assetId) => alert({ assetId })}
           onUploadStart={() => null}
           onUploadEnd={() => null}
+          onReset={() => null}
           fallbackCover={CIRCLE_COVER}
         />
       </li>
@@ -60,6 +63,7 @@ const Template: ComponentStory<typeof CoverUploader> = () => (
           onUploaded={(assetId) => alert({ assetId })}
           onUploadStart={() => null}
           onUploadEnd={() => null}
+          onReset={() => null}
           fallbackCover={CIRCLE_COVER}
           cover="https://source.unsplash.com/512x512?circle-cover"
         />

--- a/src/views/User/UserProfile/BadgesDialog/index.tsx
+++ b/src/views/User/UserProfile/BadgesDialog/index.tsx
@@ -45,7 +45,7 @@ export const BaseBadgesDialog = ({
     <>
       {children({ openDialog: openStepDialog })}
 
-      <Dialog isOpen={show} onDismiss={closeDialog} dismissOnClickOutside>
+      <Dialog isOpen={show} onDismiss={closeDialog}>
         {isInBadgesStep && (
           <>
             <Dialog.Header


### PR DESCRIPTION
* make close dialog on click outside as default and disable it for some;
* use session storage to cache form data:
  * `<EditProfileDialog>` in user profile;
  * `<SupportSettingDialog>` in draft detail;
  * `<EditCollection>` dialog in collection detail;
* revise `<AvatarUploader>` and `<CoverUploader>` to return `path` on image uploaded;

Base branch: `feat/form-draft`