### PR TITLE
fix(editor): correct cursor position after image uploaded

### DIFF
--- a/src/components/Editor/Article/extensions/figureImageUploader/Uploader.tsx
+++ b/src/components/Editor/Article/extensions/figureImageUploader/Uploader.tsx
@@ -59,21 +59,16 @@ const Uploader: React.FC<NodeViewProps> = (props) => {
     if (!mime) return
 
     try {
-      // read from storage cache to prevent duplicate upload
-      // when redo and undo
+      // upload and update cache
+      const path = (await upload({ file, type: ASSET_TYPE.embed, mime })).path
+
+      // update cache
       const assets = editor.storage.figureImageUploader.assets as {
         [key: string]: string
       }
-      let path = assets[previewSrc]
-
-      // upload and update cache
-      if (!path) {
-        path = (await upload({ file, type: ASSET_TYPE.embed, mime })).path
-
-        editor.storage.figureImageUploader.assets = {
-          ...assets,
-          [previewSrc]: path,
-        }
+      editor.storage.figureImageUploader.assets = {
+        ...assets,
+        [previewSrc]: path,
       }
 
       // position to insert
@@ -97,7 +92,7 @@ const Uploader: React.FC<NodeViewProps> = (props) => {
             },
           },
         ])
-        .setTextSelection(currentPos)
+        .setTextSelection(currentPos + 1)
         .run()
     } catch (e) {
       deleteNode()
@@ -138,6 +133,9 @@ const Uploader: React.FC<NodeViewProps> = (props) => {
   return (
     <NodeViewWrapper>
       <img src={previewSrc} alt="Uploading..." />
+      <figcaption>
+        <br />
+      </figcaption>
       <span className={styles.progressIndicator}>{progress}%</span>
     </NodeViewWrapper>
   )

--- a/src/components/Editor/Article/extensions/figureImageUploader/styles.module.css
+++ b/src/components/Editor/Article/extensions/figureImageUploader/styles.module.css
@@ -1,7 +1,7 @@
 .progressIndicator {
   position: absolute;
   right: var(--sp12);
-  bottom: var(--sp12);
+  bottom: calc(var(--sp12) + 1.375rem); /* height of figcaption */
   padding: var(--sp2) var(--sp12);
   font-size: var(--text12);
   font-weight: var(--font-normal);

--- a/src/components/Editor/Article/styles.module.css
+++ b/src/components/Editor/Article/styles.module.css
@@ -101,6 +101,11 @@
       & + :global(figure) {
         margin-top: calc(var(--ar17-200) * 2);
       }
+
+      & figcaption {
+        margin-top: var(--sp12);
+        line-height: 1.375rem;
+      }
     }
 
     /* figure selected */


### PR DESCRIPTION
* correct cursor position after image uploaded
* add `<figcaption>` placeholder to prevent UI relayout after image uploaded
* remove unused;

ref:
- PR-2408-1-23