### PR TITLE
Fix docker build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.16
+FROM node:18
 
 # install os level packages
 RUN apt-get update && apt-get -y install \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && apt-get -y install \
 # install node dependencies
 WORKDIR /var/app
 COPY package*.json ./
+COPY .npmrc ./
 RUN npm i
 
 CMD ["npm", "run", "start"]


### PR DESCRIPTION
I discovered that the _Dockerfile_ was out of date while setting up the project. This pull request updates the _Node_ version from _12_ to _18_ to match the requirements defined in _package.json_.

Additionally, the inclusion of the _.npmrc_ file ensures that we have the same _npm_ behavior inside Docker as we would on the host system. I believe this is due to the `legacy-peer-deps` setting.