### PR TITLE
fix(auth): reset Apollo client store on wallet login completion

### DIFF
--- a/src/components/Forms/WalletAuthForm/Connect.tsx
+++ b/src/components/Forms/WalletAuthForm/Connect.tsx
@@ -106,9 +106,13 @@ const Connect: React.FC<FormProps> = ({
     undefined,
     { showToast: false }
   )
-  const [walletLogin] = useMutation<WalletLoginMutation>(
+  const [walletLogin, { client }] = useMutation<WalletLoginMutation>(
     WALLET_LOGIN,
-    undefined,
+    {
+      onCompleted: () => {
+        client?.resetStore()
+      },
+    },
     {
       showToast: false,
     }
@@ -235,6 +239,8 @@ const Connect: React.FC<FormProps> = ({
             redirectToTarget({
               fallback: isInPage ? 'homepage' : 'current',
             })
+
+            closeDialog?.()
           } else if (submitCallback) {
             submitCallback(loginData?.walletLogin.type)
           }


### PR DESCRIPTION
- Added client reset to the wallet login mutation to ensure fresh data after login.
- Closed dialog after successful login to improve user experience.

ref: PD-2503-2-1