### PR TITLE
Fix visitor root viewer OSS query

### DIFF
--- a/src/components/Context/Viewer/index.tsx
+++ b/src/components/Context/Viewer/index.tsx
@@ -30,7 +30,7 @@ const ViewerFragments = {
           id
           name
         }
-        oss {
+        oss @include(if: $includeViewerOss) {
           featureFlags {
             type
           }

--- a/src/components/Root/gql.ts
+++ b/src/components/Root/gql.ts
@@ -31,7 +31,7 @@ const fragments = {
 }
 
 export const ROOT_QUERY_PRIVATE = gql`
-  query RootQueryPrivate {
+  query RootQueryPrivate($includeViewerOss: Boolean!) {
     viewer {
       ...ViewerPublic
       ...ViewerPrivate

--- a/src/components/Root/index.tsx
+++ b/src/components/Root/index.tsx
@@ -29,7 +29,10 @@ import {
   ViewerProvider,
 } from '~/components'
 import { ChannelsProvider, FetchPolicyProvider } from '~/components/Context'
-import { RootQueryPrivateQuery } from '~/gql/graphql'
+import {
+  RootQueryPrivateQuery,
+  RootQueryPrivateQueryVariables,
+} from '~/gql/graphql'
 
 import { ROOT_QUERY_PRIVATE } from './gql'
 
@@ -93,8 +96,14 @@ const Root = ({
 
   const referralCode = getQuery(REFERRAL_QUERY_REFERRAL_KEY)
 
-  const { loading, data, error } =
-    useQuery<RootQueryPrivateQuery>(ROOT_QUERY_PRIVATE)
+  const { loading, data, error } = useQuery<
+    RootQueryPrivateQuery,
+    RootQueryPrivateQueryVariables
+  >(ROOT_QUERY_PRIVATE, {
+    variables: {
+      includeViewerOss: false,
+    },
+  })
   const viewer = data?.viewer
   const official = data?.official
   const channels = data?.channels


### PR DESCRIPTION
## Summary
- guard the root viewer OSS field behind an include variable
- keep the root query default visitor-safe so matters.icu does not request admin-only viewer.oss on initial load

## Verification
- npm run gen:type
- npm run lint:ts
- npx vitest run src/components/Comment/DropdownActions/DropdownActions.test.tsx
- curl staging GraphQL visitor query with includeViewerOss=false returned data without viewer.oss authorization errors