### PR TITLE
Add Fediverse export controls

### DIFF
--- a/lang/default.json
+++ b/lang/default.json
@@ -1693,6 +1693,9 @@
     "defaultMessage": "Comment",
     "description": "src/views/ArticleDetail/index.tsx"
   },
+  "OvzONl": {
+    "defaultMessage": "Off"
+  },
   "OwMuXW": {
     "defaultMessage": "Cancel schedule"
   },
@@ -1810,6 +1813,9 @@
   "R410ei": {
     "defaultMessage": "Incorrect verification code",
     "description": "CODE_INVALID"
+  },
+  "R6sMIX": {
+    "defaultMessage": "Fediverse"
   },
   "R7yHDl": {
     "defaultMessage": "Circle Revenue",
@@ -2427,6 +2433,9 @@
   },
   "beLe/F": {
     "defaultMessage": "Broadcast"
+  },
+  "bubFD6": {
+    "defaultMessage": "Only public articles can be exported. Private or paywalled articles stay blocked by the server."
   },
   "c/z318": {
     "defaultMessage": "Incorrect email or password",
@@ -3171,6 +3180,9 @@
   "ob+HDS": {
     "defaultMessage": "View Circle"
   },
+  "oh7tJ1": {
+    "defaultMessage": "Allow eligible public articles to be exported to Fediverse."
+  },
   "ohbnFU": {
     "defaultMessage": "Social Login",
     "description": "src/views/Me/Settings/Settings/index.tsx"
@@ -3728,6 +3740,9 @@
     "defaultMessage": "Invalid display name",
     "description": "DISPLAYNAME_INVALID"
   },
+  "y/bmsG": {
+    "defaultMessage": "Allow"
+  },
   "y0b6Kp": {
     "defaultMessage": "Pay",
     "description": "src/views/Circle/Analytics/SubscriberAnalytics/index.tsx"
@@ -3768,6 +3783,9 @@
   "ydQPbv": {
     "defaultMessage": "Enter",
     "description": "src/components/CircleDigest/Price/index.tsx"
+  },
+  "yktxJN": {
+    "defaultMessage": "Follow author setting"
   },
   "yoRaUc": {
     "defaultMessage": "Refund",

--- a/lang/en.json
+++ b/lang/en.json
@@ -1693,6 +1693,9 @@
     "defaultMessage": "Comment",
     "description": "src/views/ArticleDetail/index.tsx"
   },
+  "OvzONl": {
+    "defaultMessage": "Off"
+  },
   "OwMuXW": {
     "defaultMessage": "Cancel schedule"
   },
@@ -1810,6 +1813,9 @@
   "R410ei": {
     "defaultMessage": "Incorrect verification code",
     "description": "CODE_INVALID"
+  },
+  "R6sMIX": {
+    "defaultMessage": "Fediverse"
   },
   "R7yHDl": {
     "defaultMessage": "Circle Revenue",
@@ -2427,6 +2433,9 @@
   },
   "beLe/F": {
     "defaultMessage": "Broadcast"
+  },
+  "bubFD6": {
+    "defaultMessage": "Only public articles can be exported. Private or paywalled articles stay blocked by the server."
   },
   "c/z318": {
     "defaultMessage": "Incorrect email or password",
@@ -3171,6 +3180,9 @@
   "ob+HDS": {
     "defaultMessage": "View Circle"
   },
+  "oh7tJ1": {
+    "defaultMessage": "Allow eligible public articles to be exported to Fediverse."
+  },
   "ohbnFU": {
     "defaultMessage": "Social Login",
     "description": "src/views/Me/Settings/Settings/index.tsx"
@@ -3728,6 +3740,9 @@
     "defaultMessage": "Invalid display name",
     "description": "DISPLAYNAME_INVALID"
   },
+  "y/bmsG": {
+    "defaultMessage": "Allow"
+  },
   "y0b6Kp": {
     "defaultMessage": "Pay",
     "description": "src/views/Circle/Analytics/SubscriberAnalytics/index.tsx"
@@ -3768,6 +3783,9 @@
   "ydQPbv": {
     "defaultMessage": "Enter",
     "description": "src/components/CircleDigest/Price/index.tsx"
+  },
+  "yktxJN": {
+    "defaultMessage": "Follow author setting"
   },
   "yoRaUc": {
     "defaultMessage": "Refund",

--- a/lang/zh-Hans.json
+++ b/lang/zh-Hans.json
@@ -1693,6 +1693,9 @@
     "defaultMessage": "评论",
     "description": "src/views/ArticleDetail/index.tsx"
   },
+  "OvzONl": {
+    "defaultMessage": "Off"
+  },
   "OwMuXW": {
     "defaultMessage": "取消定时发布"
   },
@@ -1810,6 +1813,9 @@
   "R410ei": {
     "defaultMessage": "验证码错误",
     "description": "CODE_INVALID"
+  },
+  "R6sMIX": {
+    "defaultMessage": "Fediverse"
   },
   "R7yHDl": {
     "defaultMessage": "围炉营收",
@@ -2427,6 +2433,9 @@
   },
   "beLe/F": {
     "defaultMessage": "广播"
+  },
+  "bubFD6": {
+    "defaultMessage": "Only public articles can be exported. Private or paywalled articles stay blocked by the server."
   },
   "c/z318": {
     "defaultMessage": "邮箱或密码错误",
@@ -3171,6 +3180,9 @@
   "ob+HDS": {
     "defaultMessage": "马上逛逛"
   },
+  "oh7tJ1": {
+    "defaultMessage": "Allow eligible public articles to be exported to Fediverse."
+  },
   "ohbnFU": {
     "defaultMessage": "社交登录",
     "description": "src/views/Me/Settings/Settings/index.tsx"
@@ -3728,6 +3740,9 @@
     "defaultMessage": "名称不正确",
     "description": "DISPLAYNAME_INVALID"
   },
+  "y/bmsG": {
+    "defaultMessage": "Allow"
+  },
   "y0b6Kp": {
     "defaultMessage": "付费",
     "description": "src/views/Circle/Analytics/SubscriberAnalytics/index.tsx"
@@ -3768,6 +3783,9 @@
   "ydQPbv": {
     "defaultMessage": "进入围炉",
     "description": "src/components/CircleDigest/Price/index.tsx"
+  },
+  "yktxJN": {
+    "defaultMessage": "Follow author setting"
   },
   "yoRaUc": {
     "defaultMessage": "退款",

--- a/lang/zh-Hant.json
+++ b/lang/zh-Hant.json
@@ -1693,6 +1693,9 @@
     "defaultMessage": "評論",
     "description": "src/views/ArticleDetail/index.tsx"
   },
+  "OvzONl": {
+    "defaultMessage": "Off"
+  },
   "OwMuXW": {
     "defaultMessage": "取消排程"
   },
@@ -1810,6 +1813,9 @@
   "R410ei": {
     "defaultMessage": "驗證碼錯誤",
     "description": "CODE_INVALID"
+  },
+  "R6sMIX": {
+    "defaultMessage": "Fediverse"
   },
   "R7yHDl": {
     "defaultMessage": "圍爐營收",
@@ -2427,6 +2433,9 @@
   },
   "beLe/F": {
     "defaultMessage": "廣播"
+  },
+  "bubFD6": {
+    "defaultMessage": "Only public articles can be exported. Private or paywalled articles stay blocked by the server."
   },
   "c/z318": {
     "defaultMessage": "郵件地址或密碼錯誤",
@@ -3171,6 +3180,9 @@
   "ob+HDS": {
     "defaultMessage": "馬上逛逛"
   },
+  "oh7tJ1": {
+    "defaultMessage": "Allow eligible public articles to be exported to Fediverse."
+  },
   "ohbnFU": {
     "defaultMessage": "社交登入",
     "description": "src/views/Me/Settings/Settings/index.tsx"
@@ -3728,6 +3740,9 @@
     "defaultMessage": "名稱不正確",
     "description": "DISPLAYNAME_INVALID"
   },
+  "y/bmsG": {
+    "defaultMessage": "Allow"
+  },
   "y0b6Kp": {
     "defaultMessage": "付費",
     "description": "src/views/Circle/Analytics/SubscriberAnalytics/index.tsx"
@@ -3768,6 +3783,9 @@
   "ydQPbv": {
     "defaultMessage": "進入圍爐",
     "description": "src/components/CircleDigest/Price/index.tsx"
+  },
+  "yktxJN": {
+    "defaultMessage": "Follow author setting"
   },
   "yoRaUc": {
     "defaultMessage": "退款",

--- a/src/common/utils/types/index.ts
+++ b/src/common/utils/types/index.ts
@@ -47,6 +47,57 @@ export default gql`
   # block until the server schema exposing these fields is deployed there.
   extend enum UserFeatureFlagType {
     communityWatch
+    fediverseBeta
+  }
+
+  enum FederationAuthorSettingState {
+    enabled
+    disabled
+  }
+
+  enum FederationArticleSettingState {
+    inherit
+    enabled
+    disabled
+  }
+
+  type UserFederationSetting {
+    userId: ID!
+    state: FederationAuthorSettingState!
+    updatedBy: ID
+  }
+
+  type ArticleFederationSetting {
+    articleId: ID!
+    state: FederationArticleSettingState!
+    updatedBy: ID
+  }
+
+  extend type User {
+    federationSetting: UserFederationSetting
+  }
+
+  extend type Article {
+    federationSetting: ArticleFederationSetting
+  }
+
+  input SetViewerFederationSettingInput {
+    state: FederationAuthorSettingState!
+  }
+
+  input SetArticleFederationSettingInput {
+    id: ID!
+    state: FederationArticleSettingState!
+  }
+
+  extend type Mutation {
+    setViewerFederationSetting(
+      input: SetViewerFederationSettingInput!
+    ): UserFederationSetting!
+
+    setArticleFederationSetting(
+      input: SetArticleFederationSettingInput!
+    ): ArticleFederationSetting!
   }
 
   enum CommunityWatchRemoveCommentReason {

--- a/src/components/Editor/Sidebar/FederationSetting/index.tsx
+++ b/src/components/Editor/Sidebar/FederationSetting/index.tsx
@@ -1,0 +1,163 @@
+import gql from 'graphql-tag'
+import { FormattedMessage } from 'react-intl'
+
+import IconDown from '@/public/static/icons/24px/down.svg'
+import {
+  Button,
+  Dropdown,
+  Icon,
+  Menu,
+  TextIcon,
+  toast,
+  useMutation,
+} from '~/components'
+import {
+  FederationArticleSettingState,
+  SetArticleFederationSettingMutation,
+  SetArticleFederationSettingMutationVariables,
+} from '~/gql/graphql'
+
+import Box from '../Box'
+
+export type SidebarFederationSettingProps = {
+  articleId: string
+  federationSetting?: FederationArticleSettingState | null
+  federationSettingSaving: boolean
+  editFederationSetting: (state: FederationArticleSettingState) => void
+}
+
+const SET_ARTICLE_FEDERATION_SETTING = gql`
+  mutation SetArticleFederationSetting(
+    $input: SetArticleFederationSettingInput!
+  ) {
+    setArticleFederationSetting(input: $input) {
+      articleId
+      state
+    }
+  }
+`
+
+const labels = {
+  [FederationArticleSettingState.Inherit]: (
+    <FormattedMessage defaultMessage="Follow author setting" id="yktxJN" />
+  ),
+  [FederationArticleSettingState.Enabled]: (
+    <FormattedMessage defaultMessage="Allow" id="y/bmsG" />
+  ),
+  [FederationArticleSettingState.Disabled]: (
+    <FormattedMessage defaultMessage="Off" id="OvzONl" />
+  ),
+}
+
+const SidebarFederationSetting: React.FC<SidebarFederationSettingProps> = ({
+  articleId,
+  federationSetting,
+  federationSettingSaving,
+  editFederationSetting,
+}) => {
+  const [setArticleFederationSetting, { loading }] = useMutation<
+    SetArticleFederationSettingMutation,
+    SetArticleFederationSettingMutationVariables
+  >(SET_ARTICLE_FEDERATION_SETTING)
+
+  const currentState =
+    federationSetting || FederationArticleSettingState.Inherit
+  const saving = federationSettingSaving || loading
+
+  const updateSetting = async (state: FederationArticleSettingState) => {
+    if (state === currentState || saving) {
+      return
+    }
+
+    try {
+      await setArticleFederationSetting({
+        variables: { input: { id: articleId, state } },
+        optimisticResponse: {
+          setArticleFederationSetting: {
+            __typename: 'ArticleFederationSetting',
+            articleId,
+            state,
+          },
+        },
+      })
+      editFederationSetting(state)
+    } catch {
+      toast.error({
+        message: (
+          <FormattedMessage defaultMessage="Failed to save" id="+OtV6h" />
+        ),
+      })
+    }
+  }
+
+  const Content = () => (
+    <Menu>
+      <Menu.Item
+        text={labels[FederationArticleSettingState.Inherit]}
+        onClick={() => updateSetting(FederationArticleSettingState.Inherit)}
+        weight={
+          currentState === FederationArticleSettingState.Inherit
+            ? 'bold'
+            : 'normal'
+        }
+      />
+      <Menu.Item
+        text={labels[FederationArticleSettingState.Enabled]}
+        onClick={() => updateSetting(FederationArticleSettingState.Enabled)}
+        weight={
+          currentState === FederationArticleSettingState.Enabled
+            ? 'bold'
+            : 'normal'
+        }
+      />
+      <Menu.Item
+        text={labels[FederationArticleSettingState.Disabled]}
+        onClick={() => updateSetting(FederationArticleSettingState.Disabled)}
+        weight={
+          currentState === FederationArticleSettingState.Disabled
+            ? 'bold'
+            : 'normal'
+        }
+      />
+    </Menu>
+  )
+
+  return (
+    <Box
+      title={<FormattedMessage defaultMessage="Fediverse" id="R6sMIX" />}
+      subtitle={
+        <FormattedMessage
+          defaultMessage="Only public articles can be exported. Private or paywalled articles stay blocked by the server."
+          id="bubFD6"
+        />
+      }
+      rightButton={
+        <Dropdown content={<Content />}>
+          {({ openDropdown, ref }) => (
+            <Button
+              onClick={openDropdown}
+              size={[null, '1.5rem']}
+              spacing={[0, 8]}
+              bgColor="white"
+              disabled={saving}
+              aria-haspopup="listbox"
+              ref={ref}
+            >
+              <TextIcon
+                icon={<Icon icon={IconDown} size={12} />}
+                size={14}
+                color="grey"
+                spacing={4}
+                placement="left"
+              >
+                {labels[currentState]}
+              </TextIcon>
+            </Button>
+          )}
+        </Dropdown>
+      }
+    />
+  )
+}
+
+export default SidebarFederationSetting

--- a/src/components/Editor/Sidebar/index.tsx
+++ b/src/components/Editor/Sidebar/index.tsx
@@ -4,6 +4,7 @@ import Circle from './Circle'
 import Collections from './Collections'
 import Connections from './Connections'
 import Cover from './Cover'
+import FederationSetting from './FederationSetting'
 import Indent from './Indent'
 import ISCN from './ISCN'
 import License from './License'
@@ -15,6 +16,7 @@ import Tags from './Tags'
 const Sidebar = {
   CanComment,
   Cover,
+  FederationSetting,
   Tags,
   Connections,
   Management,

--- a/src/views/ArticleDetail/Edit/OptionContent/index.tsx
+++ b/src/views/ArticleDetail/Edit/OptionContent/index.tsx
@@ -17,6 +17,8 @@ import {
   DigestRichCirclePublicFragment,
   DraftDetailViewerQueryQuery,
   EditorSelectCampaignFragment,
+  FederationArticleSettingState,
+  UserFeatureFlagType,
 } from '~/gql/graphql'
 
 import { Article } from '..'
@@ -45,7 +47,11 @@ export type OptionContentProps = {
       replyToDonator: string | null
     ) => void
   } & SidebarSensitiveProps &
-  SidebarISCNProps
+  SidebarISCNProps & {
+    federationSetting?: FederationArticleSettingState | null
+    federationSettingSaving: boolean
+    editFederationSetting: (state: FederationArticleSettingState) => void
+  }
 
 type OptionItemProps = OptionContentProps & { disabled: boolean }
 
@@ -214,6 +220,22 @@ const EditSensitive = ({
   )
 }
 
+const EditFederationSetting = ({
+  article,
+  federationSetting,
+  federationSettingSaving,
+  editFederationSetting,
+}: OptionItemProps) => {
+  return (
+    <Sidebar.FederationSetting
+      articleId={article.id}
+      federationSetting={federationSetting}
+      federationSettingSaving={federationSettingSaving}
+      editFederationSetting={editFederationSetting}
+    />
+  )
+}
+
 const EditCircle = ({
   circle,
   editAccess,
@@ -245,6 +267,9 @@ export const OptionContent = (
   const isSettings = tab === 'settings'
   const hasOwnCollections = (props.ownCollections?.length || 0) > 0
   const hasOwnCircle = props.ownCircles && props.ownCircles.length >= 1
+  const isFediverseBeta = !!props.viewerData?.viewer?.oss?.featureFlags.some(
+    ({ type }) => type === UserFeatureFlagType.FediverseBeta
+  )
   const disabled = false
 
   return (
@@ -290,6 +315,9 @@ export const OptionContent = (
             <EditLicense {...props} disabled={disabled} />
             <EditCanComment {...props} disabled={disabled} />
             <EditSupportSetting {...props} disabled={disabled} />
+            {isFediverseBeta && (
+              <EditFederationSetting {...props} disabled={disabled} />
+            )}
             <EditSensitive {...props} disabled={disabled} />
             {hasOwnCircle && <EditCircle {...props} disabled={disabled} />}
           </>

--- a/src/views/ArticleDetail/Edit/gql.ts
+++ b/src/views/ArticleDetail/Edit/gql.ts
@@ -58,6 +58,9 @@ export const GET_EDIT_ARTICLE = gql`
       canComment
       indentFirstLine
       license
+      federationSetting {
+        state
+      }
       sensitiveByAuthor
       requestForDonation
       replyToDonator

--- a/src/views/ArticleDetail/Edit/index.tsx
+++ b/src/views/ArticleDetail/Edit/index.tsx
@@ -48,6 +48,7 @@ import {
   DigestTagFragment,
   DirectImageUploadDoneMutation,
   DirectImageUploadMutation,
+  FederationArticleSettingState,
   PublishState as PublishStateType,
   QueryEditArticleAssetsQuery,
   QueryEditArticleQuery,
@@ -217,6 +218,11 @@ const BaseEdit = ({ article }: { article: Article }) => {
 
   const [indented, setIndented] = useState<boolean>(article.indentFirstLine)
 
+  const [federationSetting, setFederationSetting] =
+    useState<FederationArticleSettingState>(
+      article.federationSetting?.state || FederationArticleSettingState.Inherit
+    )
+
   const revisionCountLeft =
     MAX_ARTICLE_REVISION_COUNT - (article?.revisionCount || 0)
   const isOverRevisionLimit = revisionCountLeft <= 0
@@ -291,6 +297,12 @@ const BaseEdit = ({ article }: { article: Article }) => {
     iscnPublish,
     toggleISCN: () => setIscnPublish(!iscnPublish),
     iscnPublishSaving: false,
+  }
+
+  const federationSettingProps = {
+    federationSetting,
+    federationSettingSaving: false,
+    editFederationSetting: setFederationSetting,
   }
 
   const [singleFileUpload] =
@@ -389,6 +401,7 @@ const BaseEdit = ({ article }: { article: Article }) => {
           tab={tab}
           setTab={setTab}
           article={article}
+          viewerData={viewerData}
           ownCircles={ownCircles}
           ownCollections={ownCollections}
           campaigns={selectableCampaigns || []}
@@ -405,6 +418,7 @@ const BaseEdit = ({ article }: { article: Article }) => {
           {...supportSettingProps}
           {...sensitiveProps}
           {...iscnProps}
+          {...federationSettingProps}
         />
       </OptionsPage>
     )
@@ -501,6 +515,7 @@ const BaseEdit = ({ article }: { article: Article }) => {
               isOpen={isOpenOptionDrawer}
               toggleDrawer={toggleOptionDrawer}
               article={article}
+              viewerData={viewerData}
               ownCircles={ownCircles}
               ownCollections={ownCollections}
               campaigns={selectableCampaigns || []}
@@ -517,6 +532,7 @@ const BaseEdit = ({ article }: { article: Article }) => {
               {...supportSettingProps}
               {...sensitiveProps}
               {...iscnProps}
+              {...federationSettingProps}
             />
           </Media>
         </Layout.Main>

--- a/src/views/Me/DraftDetail/gql.ts
+++ b/src/views/Me/DraftDetail/gql.ts
@@ -87,6 +87,11 @@ export const DRAFT_DETAIL_VIEWER = gql`
       }
       displayName
       avatar
+      oss {
+        featureFlags {
+          type
+        }
+      }
       collections(input: { first: 20, after: $collectionsAfter }) {
         pageInfo {
           hasNextPage

--- a/src/views/Me/Settings/Misc/FederationSetting.tsx
+++ b/src/views/Me/Settings/Misc/FederationSetting.tsx
@@ -1,0 +1,130 @@
+import { useQuery } from '@apollo/client'
+import gql from 'graphql-tag'
+import { useEffect, useState } from 'react'
+import { FormattedMessage, useIntl } from 'react-intl'
+
+import { Switch, TableView, toast, useMutation } from '~/components'
+import {
+  FederationAuthorSettingState,
+  SetViewerFederationSettingMutation,
+  SetViewerFederationSettingMutationVariables,
+  UserFeatureFlagType,
+  ViewerFederationSettingQuery,
+} from '~/gql/graphql'
+
+const VIEWER_FEDERATION_SETTING = gql`
+  query ViewerFederationSetting {
+    viewer {
+      id
+      federationSetting {
+        state
+      }
+      oss {
+        featureFlags {
+          type
+        }
+      }
+    }
+  }
+`
+
+const SET_VIEWER_FEDERATION_SETTING = gql`
+  mutation SetViewerFederationSetting(
+    $input: SetViewerFederationSettingInput!
+  ) {
+    setViewerFederationSetting(input: $input) {
+      userId
+      state
+    }
+  }
+`
+
+const FederationSetting = () => {
+  const intl = useIntl()
+  const [setting, setSetting] = useState(FederationAuthorSettingState.Disabled)
+  const { data, loading } = useQuery<ViewerFederationSettingQuery>(
+    VIEWER_FEDERATION_SETTING,
+    { fetchPolicy: 'cache-and-network' }
+  )
+  const [setViewerFederationSetting, { loading: saving }] = useMutation<
+    SetViewerFederationSettingMutation,
+    SetViewerFederationSettingMutationVariables
+  >(SET_VIEWER_FEDERATION_SETTING)
+
+  const viewer = data?.viewer
+  const isFediverseBeta = !!viewer?.oss?.featureFlags.some(
+    ({ type }) => type === UserFeatureFlagType.FediverseBeta
+  )
+
+  useEffect(() => {
+    if (viewer?.federationSetting?.state) {
+      setSetting(viewer.federationSetting.state)
+    }
+  }, [viewer?.federationSetting?.state])
+
+  if (!loading && !isFediverseBeta) {
+    return null
+  }
+
+  const enabled = setting === FederationAuthorSettingState.Enabled
+
+  const updateSetting = async () => {
+    if (!viewer?.id) {
+      return
+    }
+
+    const state = enabled
+      ? FederationAuthorSettingState.Disabled
+      : FederationAuthorSettingState.Enabled
+
+    try {
+      await setViewerFederationSetting({
+        variables: { input: { state } },
+        optimisticResponse: {
+          setViewerFederationSetting: {
+            __typename: 'UserFederationSetting',
+            userId: viewer.id,
+            state,
+          },
+        },
+      })
+      setSetting(state)
+    } catch {
+      toast.error({
+        message: (
+          <FormattedMessage
+            defaultMessage="Failed to edit, please try again."
+            id="USOHRK"
+          />
+        ),
+      })
+    }
+  }
+
+  return (
+    <TableView.Cell
+      title={<FormattedMessage defaultMessage="Fediverse" id="R6sMIX" />}
+      subtitle={
+        <FormattedMessage
+          defaultMessage="Allow eligible public articles to be exported to Fediverse."
+          id="oh7tJ1"
+        />
+      }
+      right={
+        <Switch
+          name="fediverse"
+          label={intl.formatMessage({
+            defaultMessage: 'Fediverse',
+            id: 'R6sMIX',
+          })}
+          checked={enabled}
+          onChange={updateSetting}
+          loading={loading || saving}
+          disabled={loading || saving || !viewer?.id}
+        />
+      }
+    />
+  )
+}
+
+export default FederationSetting

--- a/src/views/Me/Settings/Misc/index.tsx
+++ b/src/views/Me/Settings/Misc/index.tsx
@@ -6,6 +6,7 @@ import SettingsTabs from '../SettingsTabs'
 import styles from '../styles.module.css'
 import BlockedUsers from './BlockedUsers'
 import Currency from './Currency'
+import FederationSetting from './FederationSetting'
 import LikerID from './LikerID'
 
 const SettingsMisc = () => {
@@ -33,6 +34,7 @@ const SettingsMisc = () => {
       <section className={styles.container}>
         <TableView spacingX={0}>
           <Currency />
+          <FederationSetting />
           <BlockedUsers />
           <LikerID />
         </TableView>


### PR DESCRIPTION
## Summary
- add pilot-only Fediverse author setting under Misc settings
- add per-article Fediverse export override in article edit settings
- keep frontend schema extension temporary until matters-server PR #4773 is deployed to staging
- keep server public-only gate as the enforcement point; UI cannot export private or paywalled articles by itself

## Verification
- npm run gen:type
- npm run lint:ts
- npm run format:check
- commit hook: format, i18n, lint:ts, lint:css

## Depends on
- thematters/matters-server#4773 for the GraphQL fields and pilot mutations
