### PR TITLE
Fix Community Watch comment query complexity

### DIFF
--- a/src/common/enums/article.ts
+++ b/src/common/enums/article.ts
@@ -1,4 +1,4 @@
-export const COMMENTS_COUNT = 40
+export const COMMENTS_COUNT = 39
 export const TOOLBAR_FIXEDTOOLBAR_ID = 'toolbar/fixedToolbar/id'
 export const COMMENT_FEED_ID_PREFIX = 'comment-feed-'
 export const SUPPORT_TAB_PREFERENCE_KEY = 'support-tab-preference-key'


### PR DESCRIPTION
## Summary
- Reduce article comment initial page size from 40 to 39 so the Community Watch comment fragment stays under the staging GraphQL complexity limit.
- Keeps the existing comment UI and Community Watch audit link data unchanged.

## Verification
- npm run lint:ts
- Commit hook ran i18n and full lint successfully.

## Staging context
Opening the article comment drawer on matters.icu currently returns: Query is too complex. Requested complexity 25007 is greater than maximum allowed 25000. This patch lowers the comment query multiplier while preserving the Community Watch comment fields.