### PR TITLE
fix: load viewer feature flags for Community Watch

### DIFF
--- a/src/components/Root/index.tsx
+++ b/src/components/Root/index.tsx
@@ -101,7 +101,7 @@ const Root = ({
     RootQueryPrivateQueryVariables
   >(ROOT_QUERY_PRIVATE, {
     variables: {
-      includeViewerOss: false,
+      includeViewerOss: true,
     },
   })
   const viewer = data?.viewer


### PR DESCRIPTION
## Summary
- Load `viewer.oss.featureFlags` in the root viewer query.
- This allows `ViewerContext.isCommunityWatch` to become true on article/moment comment menus.
- Fixes the staging issue where the logged-in admin/member saw only delete/admin actions, not `色情廣告` / `濫發廣告`.

## Verification
- `NODE_PATH=/Users/mashbean/Documents/AI-Agent/external/matters-web/node_modules /Users/mashbean/Documents/AI-Agent/external/matters-web/node_modules/.bin/eslint src/components/Root/index.tsx --quiet`
- `npx prettier --check src/components/Root/index.tsx`
- `git diff --check`

## Notes
- Server already returns `communityWatch` for `mashbeanmatters` on `server.matters.icu`; the missing UI option was caused by the web root query excluding OSS feature flags.
