### PR TITLE
Expose Fediverse setting in draft editor

### DIFF
--- a/lang/default.json
+++ b/lang/default.json
@@ -1026,6 +1026,9 @@
   "DjIpR6": {
     "defaultMessage": "Set Cover"
   },
+  "DnOjES": {
+    "defaultMessage": "關閉"
+  },
   "DoOt1q": {
     "defaultMessage": "Your channel suggestion has been accepted by the editor. Thank you for supporting Matters!",
     "description": "src/components/Notice/ArticleNotice/TopicChannelFeedbackAcceptedNotice.tsx"
@@ -1693,9 +1696,6 @@
     "defaultMessage": "Comment",
     "description": "src/views/ArticleDetail/index.tsx"
   },
-  "OvzONl": {
-    "defaultMessage": "Off"
-  },
   "OwMuXW": {
     "defaultMessage": "Cancel schedule"
   },
@@ -2294,6 +2294,9 @@
     "defaultMessage": "Archived for violation.",
     "description": "src/views/ArticleDetail/StickyTopBanner/index.tsx"
   },
+  "ZAoAcG": {
+    "defaultMessage": "Threads, Mastodon, Misskey 這些地方的粉絲也會看到"
+  },
   "ZAs170": {
     "defaultMessage": "Profile",
     "description": "src/views/Circle/Settings/index.tsx"
@@ -2433,9 +2436,6 @@
   },
   "beLe/F": {
     "defaultMessage": "Broadcast"
-  },
-  "bubFD6": {
-    "defaultMessage": "Only public articles can be exported. Private or paywalled articles stay blocked by the server."
   },
   "c/z318": {
     "defaultMessage": "Incorrect email or password",
@@ -3059,6 +3059,9 @@
     "defaultMessage": "Remove bookmark",
     "description": "src/components/Buttons/TagBookmark/Unbookmark.tsx"
   },
+  "mMji02": {
+    "defaultMessage": "開啟"
+  },
   "mPe6DK": {
     "defaultMessage": "subscribed your circle",
     "description": "src/components/Notice/CircleNotice/CircleNewUserNotice.tsx"
@@ -3453,6 +3456,9 @@
   "tZKvnZ": {
     "defaultMessage": "Unlike moment"
   },
+  "tsUFZX": {
+    "defaultMessage": "分享到聯邦宇宙"
+  },
   "tzq2+W": {
     "defaultMessage": "Send",
     "description": "src/views/Circle/Settings/ManageInvitation/AddInvitationDialog/PreSend.tsx"
@@ -3740,9 +3746,6 @@
     "defaultMessage": "Invalid display name",
     "description": "DISPLAYNAME_INVALID"
   },
-  "y/bmsG": {
-    "defaultMessage": "Allow"
-  },
   "y0b6Kp": {
     "defaultMessage": "Pay",
     "description": "src/views/Circle/Analytics/SubscriberAnalytics/index.tsx"
@@ -3783,9 +3786,6 @@
   "ydQPbv": {
     "defaultMessage": "Enter",
     "description": "src/components/CircleDigest/Price/index.tsx"
-  },
-  "yktxJN": {
-    "defaultMessage": "Follow author setting"
   },
   "yoRaUc": {
     "defaultMessage": "Refund",

--- a/lang/en.json
+++ b/lang/en.json
@@ -1026,6 +1026,9 @@
   "DjIpR6": {
     "defaultMessage": "Set Cover"
   },
+  "DnOjES": {
+    "defaultMessage": "關閉"
+  },
   "DoOt1q": {
     "defaultMessage": "Your channel suggestion has been accepted by the editor. Thank you for supporting Matters!",
     "description": "src/components/Notice/ArticleNotice/TopicChannelFeedbackAcceptedNotice.tsx"
@@ -1693,9 +1696,6 @@
     "defaultMessage": "Comment",
     "description": "src/views/ArticleDetail/index.tsx"
   },
-  "OvzONl": {
-    "defaultMessage": "Off"
-  },
   "OwMuXW": {
     "defaultMessage": "Cancel schedule"
   },
@@ -2294,6 +2294,9 @@
     "defaultMessage": "Archived for violation.",
     "description": "src/views/ArticleDetail/StickyTopBanner/index.tsx"
   },
+  "ZAoAcG": {
+    "defaultMessage": "Threads, Mastodon, Misskey 這些地方的粉絲也會看到"
+  },
   "ZAs170": {
     "defaultMessage": "Profile",
     "description": "src/views/Circle/Settings/index.tsx"
@@ -2433,9 +2436,6 @@
   },
   "beLe/F": {
     "defaultMessage": "Broadcast"
-  },
-  "bubFD6": {
-    "defaultMessage": "Only public articles can be exported. Private or paywalled articles stay blocked by the server."
   },
   "c/z318": {
     "defaultMessage": "Incorrect email or password",
@@ -3059,6 +3059,9 @@
     "defaultMessage": "Remove bookmark",
     "description": "src/components/Buttons/TagBookmark/Unbookmark.tsx"
   },
+  "mMji02": {
+    "defaultMessage": "開啟"
+  },
   "mPe6DK": {
     "defaultMessage": "subscribed your circle",
     "description": "src/components/Notice/CircleNotice/CircleNewUserNotice.tsx"
@@ -3453,6 +3456,9 @@
   "tZKvnZ": {
     "defaultMessage": "Unlike moment"
   },
+  "tsUFZX": {
+    "defaultMessage": "分享到聯邦宇宙"
+  },
   "tzq2+W": {
     "defaultMessage": "Send",
     "description": "src/views/Circle/Settings/ManageInvitation/AddInvitationDialog/PreSend.tsx"
@@ -3740,9 +3746,6 @@
     "defaultMessage": "Invalid display name",
     "description": "DISPLAYNAME_INVALID"
   },
-  "y/bmsG": {
-    "defaultMessage": "Allow"
-  },
   "y0b6Kp": {
     "defaultMessage": "Pay",
     "description": "src/views/Circle/Analytics/SubscriberAnalytics/index.tsx"
@@ -3783,9 +3786,6 @@
   "ydQPbv": {
     "defaultMessage": "Enter",
     "description": "src/components/CircleDigest/Price/index.tsx"
-  },
-  "yktxJN": {
-    "defaultMessage": "Follow author setting"
   },
   "yoRaUc": {
     "defaultMessage": "Refund",

--- a/lang/zh-Hans.json
+++ b/lang/zh-Hans.json
@@ -1026,6 +1026,9 @@
   "DjIpR6": {
     "defaultMessage": "选择封面"
   },
+  "DnOjES": {
+    "defaultMessage": "關閉"
+  },
   "DoOt1q": {
     "defaultMessage": "你的频道建议已被编辑采纳，感谢你对 Matters 的支持～",
     "description": "src/components/Notice/ArticleNotice/TopicChannelFeedbackAcceptedNotice.tsx"
@@ -1693,9 +1696,6 @@
     "defaultMessage": "评论",
     "description": "src/views/ArticleDetail/index.tsx"
   },
-  "OvzONl": {
-    "defaultMessage": "Off"
-  },
   "OwMuXW": {
     "defaultMessage": "取消定时发布"
   },
@@ -2294,6 +2294,9 @@
     "defaultMessage": "因违反用户协定而被封存，",
     "description": "src/views/ArticleDetail/StickyTopBanner/index.tsx"
   },
+  "ZAoAcG": {
+    "defaultMessage": "Threads, Mastodon, Misskey 這些地方的粉絲也會看到"
+  },
   "ZAs170": {
     "defaultMessage": "基本资料",
     "description": "src/views/Circle/Settings/index.tsx"
@@ -2433,9 +2436,6 @@
   },
   "beLe/F": {
     "defaultMessage": "广播"
-  },
-  "bubFD6": {
-    "defaultMessage": "Only public articles can be exported. Private or paywalled articles stay blocked by the server."
   },
   "c/z318": {
     "defaultMessage": "邮箱或密码错误",
@@ -3059,6 +3059,9 @@
     "defaultMessage": "取消收藏",
     "description": "src/components/Buttons/TagBookmark/Unbookmark.tsx"
   },
+  "mMji02": {
+    "defaultMessage": "開啟"
+  },
   "mPe6DK": {
     "defaultMessage": "订阅了你的围炉",
     "description": "src/components/Notice/CircleNotice/CircleNewUserNotice.tsx"
@@ -3453,6 +3456,9 @@
   "tZKvnZ": {
     "defaultMessage": "取消喜欢动态"
   },
+  "tsUFZX": {
+    "defaultMessage": "分享到聯邦宇宙"
+  },
   "tzq2+W": {
     "defaultMessage": "寄出邀请",
     "description": "src/views/Circle/Settings/ManageInvitation/AddInvitationDialog/PreSend.tsx"
@@ -3740,9 +3746,6 @@
     "defaultMessage": "名称不正确",
     "description": "DISPLAYNAME_INVALID"
   },
-  "y/bmsG": {
-    "defaultMessage": "Allow"
-  },
   "y0b6Kp": {
     "defaultMessage": "付费",
     "description": "src/views/Circle/Analytics/SubscriberAnalytics/index.tsx"
@@ -3783,9 +3786,6 @@
   "ydQPbv": {
     "defaultMessage": "进入围炉",
     "description": "src/components/CircleDigest/Price/index.tsx"
-  },
-  "yktxJN": {
-    "defaultMessage": "Follow author setting"
   },
   "yoRaUc": {
     "defaultMessage": "退款",

--- a/lang/zh-Hant.json
+++ b/lang/zh-Hant.json
@@ -1026,6 +1026,9 @@
   "DjIpR6": {
     "defaultMessage": "選擇封面"
   },
+  "DnOjES": {
+    "defaultMessage": "關閉"
+  },
   "DoOt1q": {
     "defaultMessage": "你的頻道建議已被編輯採納，感謝你對 Matters 的支持～",
     "description": "src/components/Notice/ArticleNotice/TopicChannelFeedbackAcceptedNotice.tsx"
@@ -1693,9 +1696,6 @@
     "defaultMessage": "評論",
     "description": "src/views/ArticleDetail/index.tsx"
   },
-  "OvzONl": {
-    "defaultMessage": "Off"
-  },
   "OwMuXW": {
     "defaultMessage": "取消排程"
   },
@@ -2294,6 +2294,9 @@
     "defaultMessage": "因違反用戶協定而被封存，",
     "description": "src/views/ArticleDetail/StickyTopBanner/index.tsx"
   },
+  "ZAoAcG": {
+    "defaultMessage": "Threads, Mastodon, Misskey 這些地方的粉絲也會看到"
+  },
   "ZAs170": {
     "defaultMessage": "基本資料",
     "description": "src/views/Circle/Settings/index.tsx"
@@ -2433,9 +2436,6 @@
   },
   "beLe/F": {
     "defaultMessage": "廣播"
-  },
-  "bubFD6": {
-    "defaultMessage": "Only public articles can be exported. Private or paywalled articles stay blocked by the server."
   },
   "c/z318": {
     "defaultMessage": "郵件地址或密碼錯誤",
@@ -3059,6 +3059,9 @@
     "defaultMessage": "取消收藏",
     "description": "src/components/Buttons/TagBookmark/Unbookmark.tsx"
   },
+  "mMji02": {
+    "defaultMessage": "開啟"
+  },
   "mPe6DK": {
     "defaultMessage": "訂閱了你的圍爐",
     "description": "src/components/Notice/CircleNotice/CircleNewUserNotice.tsx"
@@ -3453,6 +3456,9 @@
   "tZKvnZ": {
     "defaultMessage": "取消喜歡動態"
   },
+  "tsUFZX": {
+    "defaultMessage": "分享到聯邦宇宙"
+  },
   "tzq2+W": {
     "defaultMessage": "寄出邀請",
     "description": "src/views/Circle/Settings/ManageInvitation/AddInvitationDialog/PreSend.tsx"
@@ -3740,9 +3746,6 @@
     "defaultMessage": "名稱不正確",
     "description": "DISPLAYNAME_INVALID"
   },
-  "y/bmsG": {
-    "defaultMessage": "Allow"
-  },
   "y0b6Kp": {
     "defaultMessage": "付費",
     "description": "src/views/Circle/Analytics/SubscriberAnalytics/index.tsx"
@@ -3783,9 +3786,6 @@
   "ydQPbv": {
     "defaultMessage": "進入圍爐",
     "description": "src/components/CircleDigest/Price/index.tsx"
-  },
-  "yktxJN": {
-    "defaultMessage": "Follow author setting"
   },
   "yoRaUc": {
     "defaultMessage": "退款",

--- a/src/components/Editor/Sidebar/FederationSetting/index.tsx
+++ b/src/components/Editor/Sidebar/FederationSetting/index.tsx
@@ -1,3 +1,4 @@
+import { useQuery } from '@apollo/client'
 import gql from 'graphql-tag'
 import { FormattedMessage } from 'react-intl'
 
@@ -13,18 +14,33 @@ import {
 } from '~/components'
 import {
   FederationArticleSettingState,
+  FederationAuthorSettingState,
   SetArticleFederationSettingMutation,
   SetArticleFederationSettingMutationVariables,
+  SetViewerFederationSettingMutation,
+  SetViewerFederationSettingMutationVariables,
+  ViewerFederationSettingQuery,
 } from '~/gql/graphql'
 
 import Box from '../Box'
 
 export type SidebarFederationSettingProps = {
-  articleId: string
+  articleId?: string
   federationSetting?: FederationArticleSettingState | null
-  federationSettingSaving: boolean
-  editFederationSetting: (state: FederationArticleSettingState) => void
+  federationSettingSaving?: boolean
+  editFederationSetting?: (state: FederationArticleSettingState) => void
 }
+
+const VIEWER_FEDERATION_SETTING = gql`
+  query EditorViewerFederationSetting {
+    viewer {
+      id
+      federationSetting {
+        state
+      }
+    }
+  }
+`
 
 const SET_ARTICLE_FEDERATION_SETTING = gql`
   mutation SetArticleFederationSetting(
@@ -37,17 +53,35 @@ const SET_ARTICLE_FEDERATION_SETTING = gql`
   }
 `
 
+const SET_VIEWER_FEDERATION_SETTING = gql`
+  mutation SetViewerFederationSetting(
+    $input: SetViewerFederationSettingInput!
+  ) {
+    setViewerFederationSetting(input: $input) {
+      userId
+      state
+    }
+  }
+`
+
 const labels = {
-  [FederationArticleSettingState.Inherit]: (
-    <FormattedMessage defaultMessage="Follow author setting" id="yktxJN" />
-  ),
   [FederationArticleSettingState.Enabled]: (
-    <FormattedMessage defaultMessage="Allow" id="y/bmsG" />
+    <FormattedMessage defaultMessage="開啟" id="mMji02" />
   ),
   [FederationArticleSettingState.Disabled]: (
-    <FormattedMessage defaultMessage="Off" id="OvzONl" />
+    <FormattedMessage defaultMessage="關閉" id="DnOjES" />
   ),
 }
+
+const toArticleSetting = (state?: FederationAuthorSettingState | null) =>
+  state === FederationAuthorSettingState.Enabled
+    ? FederationArticleSettingState.Enabled
+    : FederationArticleSettingState.Disabled
+
+const toAuthorSetting = (state: FederationArticleSettingState) =>
+  state === FederationArticleSettingState.Enabled
+    ? FederationAuthorSettingState.Enabled
+    : FederationAuthorSettingState.Disabled
 
 const SidebarFederationSetting: React.FC<SidebarFederationSettingProps> = ({
   articleId,
@@ -55,32 +89,61 @@ const SidebarFederationSetting: React.FC<SidebarFederationSettingProps> = ({
   federationSettingSaving,
   editFederationSetting,
 }) => {
+  const { data, loading: viewerLoading } =
+    useQuery<ViewerFederationSettingQuery>(VIEWER_FEDERATION_SETTING, {
+      fetchPolicy: 'cache-and-network',
+    })
   const [setArticleFederationSetting, { loading }] = useMutation<
     SetArticleFederationSettingMutation,
     SetArticleFederationSettingMutationVariables
   >(SET_ARTICLE_FEDERATION_SETTING)
+  const [setViewerFederationSetting, { loading: viewerSaving }] = useMutation<
+    SetViewerFederationSettingMutation,
+    SetViewerFederationSettingMutationVariables
+  >(SET_VIEWER_FEDERATION_SETTING)
 
+  const authorDefaultState = toArticleSetting(
+    data?.viewer?.federationSetting?.state
+  )
   const currentState =
-    federationSetting || FederationArticleSettingState.Inherit
-  const saving = federationSettingSaving || loading
+    federationSetting &&
+    federationSetting !== FederationArticleSettingState.Inherit
+      ? federationSetting
+      : authorDefaultState
+  const saving = !!federationSettingSaving || loading || viewerSaving
+  const disabled = saving || viewerLoading || (!articleId && !data?.viewer?.id)
 
   const updateSetting = async (state: FederationArticleSettingState) => {
-    if (state === currentState || saving) {
+    if (state === currentState || disabled) {
       return
     }
 
     try {
-      await setArticleFederationSetting({
-        variables: { input: { id: articleId, state } },
-        optimisticResponse: {
-          setArticleFederationSetting: {
-            __typename: 'ArticleFederationSetting',
-            articleId,
-            state,
+      if (articleId) {
+        await setArticleFederationSetting({
+          variables: { input: { id: articleId, state } },
+          optimisticResponse: {
+            setArticleFederationSetting: {
+              __typename: 'ArticleFederationSetting',
+              articleId,
+              state,
+            },
           },
-        },
-      })
-      editFederationSetting(state)
+        })
+        editFederationSetting?.(state)
+      } else if (data?.viewer?.id) {
+        const authorState = toAuthorSetting(state)
+        await setViewerFederationSetting({
+          variables: { input: { state: authorState } },
+          optimisticResponse: {
+            setViewerFederationSetting: {
+              __typename: 'UserFederationSetting',
+              userId: data.viewer.id,
+              state: authorState,
+            },
+          },
+        })
+      }
     } catch {
       toast.error({
         message: (
@@ -92,15 +155,6 @@ const SidebarFederationSetting: React.FC<SidebarFederationSettingProps> = ({
 
   const Content = () => (
     <Menu>
-      <Menu.Item
-        text={labels[FederationArticleSettingState.Inherit]}
-        onClick={() => updateSetting(FederationArticleSettingState.Inherit)}
-        weight={
-          currentState === FederationArticleSettingState.Inherit
-            ? 'bold'
-            : 'normal'
-        }
-      />
       <Menu.Item
         text={labels[FederationArticleSettingState.Enabled]}
         onClick={() => updateSetting(FederationArticleSettingState.Enabled)}
@@ -124,11 +178,11 @@ const SidebarFederationSetting: React.FC<SidebarFederationSettingProps> = ({
 
   return (
     <Box
-      title={<FormattedMessage defaultMessage="Fediverse" id="R6sMIX" />}
+      title={<FormattedMessage defaultMessage="分享到聯邦宇宙" id="tsUFZX" />}
       subtitle={
         <FormattedMessage
-          defaultMessage="Only public articles can be exported. Private or paywalled articles stay blocked by the server."
-          id="bubFD6"
+          defaultMessage="Threads, Mastodon, Misskey 這些地方的粉絲也會看到"
+          id="ZAoAcG"
         />
       }
       rightButton={
@@ -139,7 +193,7 @@ const SidebarFederationSetting: React.FC<SidebarFederationSettingProps> = ({
               size={[null, '1.5rem']}
               spacing={[0, 8]}
               bgColor="white"
-              disabled={saving}
+              disabled={disabled}
               aria-haspopup="listbox"
               ref={ref}
             >

--- a/src/views/Me/DraftDetail/OptionContent/index.tsx
+++ b/src/views/Me/DraftDetail/OptionContent/index.tsx
@@ -11,6 +11,7 @@ import {
   DigestRichCirclePublicFragment,
   DraftDetailViewerQueryQuery,
   EditorSelectCampaignFragment,
+  UserFeatureFlagType,
 } from '~/gql/graphql'
 import { EditMetaDraftFragment } from '~/gql/graphql'
 
@@ -241,6 +242,9 @@ export const OptionContent = (
   const isPublished = props.draft.publishState === 'published'
   const disabled = isPending || isPublished
   const hasOwnCollections = (props.ownCollections?.length || 0) > 0
+  const isFediverseBeta = !!props.draftViewer?.viewer?.oss?.featureFlags.some(
+    ({ type }) => type === UserFeatureFlagType.FediverseBeta
+  )
 
   return (
     <section>
@@ -290,6 +294,7 @@ export const OptionContent = (
             <EditDraftLicense {...props} disabled={disabled} />
             <EditDraftCanComment {...props} disabled={disabled} />
             <EditDraftSupportSetting {...props} disabled={disabled} />
+            {isFediverseBeta && <Sidebar.FederationSetting />}
             <EditDraftSensitive {...props} disabled={disabled} />
             <EditDraftCircle {...props} disabled={disabled} />
           </>


### PR DESCRIPTION
## Summary
- add the Fediverse sharing control to draft article settings for beta users
- change the editor copy to Traditional Chinese product language
- replace the previous inherit/allow/off menu with a two-state open/closed control, using the author default as the visible default state

## Verification
- npx tsc --project tsconfig.json --noEmit
- npx eslint src/components/Editor/Sidebar/FederationSetting/index.tsx src/views/Me/DraftDetail/OptionContent/index.tsx
- pre-commit hook: format, i18n, lint

## Notes
- Drafts do not have an article federation row yet, so the draft control updates the author's Fediverse default setting. Published article edit pages still update the article-level override.