### PR TITLE
Add Community Watch admin toggle and badge UI

### DIFF
--- a/lang/default.json
+++ b/lang/default.json
@@ -726,6 +726,9 @@
     "defaultMessage": "Edit",
     "description": "src/components/CircleComment/DropdownActions/index.tsx"
   },
+  "90M7k0": {
+    "defaultMessage": "馬特市守望相助隊"
+  },
   "91AzwP": {
     "defaultMessage": "Only JPEG, PNG, and GIF and WebP images are supported."
   },

--- a/lang/en.json
+++ b/lang/en.json
@@ -726,6 +726,9 @@
     "defaultMessage": "Edit",
     "description": "src/components/CircleComment/DropdownActions/index.tsx"
   },
+  "90M7k0": {
+    "defaultMessage": "馬特市守望相助隊"
+  },
   "91AzwP": {
     "defaultMessage": "Only JPEG, PNG, and GIF and WebP images are supported."
   },

--- a/lang/zh-Hans.json
+++ b/lang/zh-Hans.json
@@ -726,6 +726,9 @@
     "defaultMessage": "编辑评论",
     "description": "src/components/CircleComment/DropdownActions/index.tsx"
   },
+  "90M7k0": {
+    "defaultMessage": "馬特市守望相助隊"
+  },
   "91AzwP": {
     "defaultMessage": "仅支持 JPEG、PNG、GIF 和 WebP 图片"
   },

--- a/lang/zh-Hant.json
+++ b/lang/zh-Hant.json
@@ -726,6 +726,9 @@
     "defaultMessage": "編輯",
     "description": "src/components/CircleComment/DropdownActions/index.tsx"
   },
+  "90M7k0": {
+    "defaultMessage": "馬特市守望相助隊"
+  },
   "91AzwP": {
     "defaultMessage": "僅支持 JPEG、PNG、GIF 和 WebP 圖片"
   },

--- a/public/static/icons/24px/badge-community-watch.svg
+++ b/public/static/icons/24px/badge-community-watch.svg
@@ -1,0 +1,12 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="12" cy="12" r="12" fill="white"/>
+<circle cx="12" cy="12" r="11" fill="#25685B"/>
+<path d="M6.4 15.8V18.1C6.4 18.52 6.74 18.86 7.16 18.86H16.84C17.26 18.86 17.6 18.52 17.6 18.1V15.8C17.6 15.38 17.26 15.04 16.84 15.04H7.16C6.74 15.04 6.4 15.38 6.4 15.8Z" fill="#F3D179"/>
+<path d="M8.1 15.04H15.9L14.98 8.18C14.78 6.68 13.5 5.56 12 5.56C10.5 5.56 9.22 6.68 9.02 8.18L8.1 15.04Z" fill="#F7E6A4"/>
+<path d="M9.78 8.28C9.93 7.17 10.88 6.34 12 6.34C13.12 6.34 14.07 7.17 14.22 8.28L15 14.18H9L9.78 8.28Z" fill="#FFEAB1"/>
+<path d="M10.4 10.3C10.4 9.42 11.12 8.7 12 8.7C12.88 8.7 13.6 9.42 13.6 10.3C13.6 11.18 12.88 11.9 12 11.9C11.12 11.9 10.4 11.18 10.4 10.3Z" fill="#2D2A24"/>
+<path d="M12 7.04V4.52" stroke="#F3D179" stroke-width="1.2" stroke-linecap="round"/>
+<path d="M8.15 18.86L6.92 20.66" stroke="#F3D179" stroke-width="1.1" stroke-linecap="round"/>
+<path d="M15.85 18.86L17.08 20.66" stroke="#F3D179" stroke-width="1.1" stroke-linecap="round"/>
+<path d="M7.12 15.04C7.12 12.13 9.26 9.68 12 9.68C14.74 9.68 16.88 12.13 16.88 15.04" stroke="#DCA642" stroke-width="0.8" stroke-linecap="round"/>
+</svg>

--- a/src/common/utils/types/index.ts
+++ b/src/common/utils/types/index.ts
@@ -50,6 +50,10 @@ export default gql`
     fediverseBeta
   }
 
+  extend enum BadgeType {
+    community_watch
+  }
+
   enum FederationAuthorSettingState {
     enabled
     disabled

--- a/src/views/User/UserProfile/AsideUserProfile/index.tsx
+++ b/src/views/User/UserProfile/AsideUserProfile/index.tsx
@@ -29,6 +29,7 @@ import { BadgeNomadDialog } from '../BadgeNomadDialog'
 import {
   ArchitectBadge,
   CivicLikerBadge,
+  CommunityWatchBadge,
   GoldenMotorBadge,
   GrandBadge,
   NomadBadge,
@@ -116,6 +117,9 @@ export const AsideUserProfile = () => {
   const hasSeedBadge = badges.some((b) => b.type === 'seed')
   const hasArchitectBadge = badges.some((b) => b.type === 'architect')
   const hasGoldenMotorBadge = badges.some((b) => b.type === 'golden_motor')
+  const hasCommunityWatchBadge = badges.some(
+    (b) => b.type === 'community_watch'
+  )
   const hasTraveloggersBadge = !!user.info.cryptoWallet?.hasNFTs
   const nomadBadgeType = badges.filter((b) =>
     ['nomad1', 'nomad2', 'nomad3', 'nomad4'].includes(b.type)
@@ -252,6 +256,7 @@ export const AsideUserProfile = () => {
           hasSeedBadge ||
           hasGoldenMotorBadge ||
           hasArchitectBadge ||
+          hasCommunityWatchBadge ||
           hasGrandBadge ||
           isCivicLiker ||
           user?.info.ethAddress) && (
@@ -278,6 +283,7 @@ export const AsideUserProfile = () => {
             {hasSeedBadge && <SeedBadge hasTooltip />}
             {hasGoldenMotorBadge && <GoldenMotorBadge hasTooltip />}
             {hasArchitectBadge && <ArchitectBadge hasTooltip />}
+            {hasCommunityWatchBadge && <CommunityWatchBadge hasTooltip />}
             {isCivicLiker && <CivicLikerBadge hasTooltip />}
 
             {user?.info.ethAddress && (

--- a/src/views/User/UserProfile/Badges/index.tsx
+++ b/src/views/User/UserProfile/Badges/index.tsx
@@ -1,6 +1,7 @@
 import classNames from 'classnames'
 import { FormattedMessage } from 'react-intl'
 
+import IconCommunityWatchBadge from '@/public/static/icons/24px/badge-community-watch.svg'
 import IconGrand from '@/public/static/icons/24px/badge-grand.svg'
 import IconNomad1Badge from '@/public/static/icons/24px/badge-nomad1-moon.svg'
 import IconNomad2Badge from '@/public/static/icons/24px/badge-nomad2-star.svg'
@@ -85,6 +86,11 @@ export const CivicLikerBadge = withBadge({
 export const TraveloggersBadge = withBadge({
   icon: IconTraveloggersBadge,
   name: 'Traveloggers',
+})
+
+export const CommunityWatchBadge = withBadge({
+  icon: IconCommunityWatchBadge,
+  name: <FormattedMessage defaultMessage="馬特市守望相助隊" id="90M7k0" />,
 })
 
 export const NomadBadge = ({
@@ -248,6 +254,7 @@ export interface BadgesOptions {
   hasSeedBadge?: boolean
   hasGoldenMotorBadge?: boolean
   hasArchitectBadge?: boolean
+  hasCommunityWatchBadge?: boolean
   isCivicLiker?: boolean
 }
 
@@ -262,6 +269,7 @@ export const Badges = ({
   hasSeedBadge,
   hasGoldenMotorBadge,
   hasArchitectBadge,
+  hasCommunityWatchBadge,
   isCivicLiker,
 }: BadgesOptions) =>
   isInDialog ? (
@@ -284,12 +292,14 @@ export const Badges = ({
         hasSeedBadge ||
         hasGoldenMotorBadge ||
         hasArchitectBadge ||
+        hasCommunityWatchBadge ||
         isCivicLiker) && (
         <section className={styles.badgesGroup}>
           {hasTraveloggersBadge && <TraveloggersBadge isInDialog />}
           {hasSeedBadge && <SeedBadge isInDialog />}
           {hasGoldenMotorBadge && <GoldenMotorBadge isInDialog />}
           {hasArchitectBadge && <ArchitectBadge isInDialog />}
+          {hasCommunityWatchBadge && <CommunityWatchBadge isInDialog />}
           {isCivicLiker && <CivicLikerBadge isInDialog />}
         </section>
       )}
@@ -302,6 +312,7 @@ export const Badges = ({
       {hasSeedBadge && <SeedBadge />}
       {hasGoldenMotorBadge && <GoldenMotorBadge />}
       {hasArchitectBadge && <ArchitectBadge />}
+      {hasCommunityWatchBadge && <CommunityWatchBadge />}
       {isCivicLiker && <CivicLikerBadge />}
     </span>
   )

--- a/src/views/User/UserProfile/BadgesDialog/index.tsx
+++ b/src/views/User/UserProfile/BadgesDialog/index.tsx
@@ -39,6 +39,7 @@ export const BaseBadgesDialog = ({
   hasSeedBadge,
   hasGoldenMotorBadge,
   hasArchitectBadge,
+  hasCommunityWatchBadge,
   isCivicLiker,
 }: BadgesDialogProps) => {
   const { show, openDialog, closeDialog } = useDialogSwitch(true)
@@ -93,6 +94,7 @@ export const BaseBadgesDialog = ({
                 hasSeedBadge={hasSeedBadge}
                 hasGoldenMotorBadge={hasGoldenMotorBadge}
                 hasArchitectBadge={hasArchitectBadge}
+                hasCommunityWatchBadge={hasCommunityWatchBadge}
                 isCivicLiker={isCivicLiker}
                 gotoNomadBadge={() => setStep('nomad')}
                 gotoGrandBadge={() => setStep('grand')}

--- a/src/views/User/UserProfile/DropdownActions/ToggleCommunityWatch/Button.tsx
+++ b/src/views/User/UserProfile/DropdownActions/ToggleCommunityWatch/Button.tsx
@@ -1,0 +1,75 @@
+import { useQuery } from '@apollo/client'
+import gql from 'graphql-tag'
+
+import IconCommunityWatchBadge from '@/public/static/icons/24px/badge-community-watch.svg'
+import { Icon, Menu, Spinner } from '~/components'
+import {
+  UserCommunityWatchAdminQuery,
+  UserFeatureFlagType,
+} from '~/gql/graphql'
+
+import { OpenToggleCommunityWatchDialogWithProps } from './Dialog'
+
+type ToggleCommunityWatchButtonProps = {
+  id: string
+  openDialog: (props: OpenToggleCommunityWatchDialogWithProps) => void
+}
+
+export const fragments = {
+  user: gql`
+    fragment ToggleCommunityWatchUser on User {
+      id
+      oss {
+        featureFlags {
+          type
+        }
+      }
+    }
+  `,
+}
+
+const USER_COMMUNITY_WATCH_ADMIN = gql`
+  query UserCommunityWatchAdmin($id: ID!) {
+    user: node(input: { id: $id }) {
+      ... on User {
+        id
+        ...ToggleCommunityWatchUser
+      }
+    }
+  }
+  ${fragments.user}
+`
+
+const ToggleCommunityWatchButton = ({
+  id,
+  openDialog,
+}: ToggleCommunityWatchButtonProps) => {
+  const { data, loading } = useQuery<UserCommunityWatchAdminQuery>(
+    USER_COMMUNITY_WATCH_ADMIN,
+    { variables: { id } }
+  )
+
+  if (loading) {
+    return <Menu.Item icon={<Spinner size={20} />} text="加載中…" />
+  }
+
+  if (data?.user?.__typename !== 'User') {
+    return null
+  }
+
+  const flags = data.user.oss.featureFlags.map(({ type }) => type)
+  const enabled = flags.includes(UserFeatureFlagType.CommunityWatch)
+
+  return (
+    <Menu.Item
+      text={enabled ? '取消守望相助隊' : '指定為守望相助隊'}
+      icon={<Icon icon={IconCommunityWatchBadge} size={20} />}
+      textColor={enabled ? 'greyDarker' : 'black'}
+      textActiveColor="black"
+      onClick={() => openDialog({ enabled, flags })}
+      ariaHasPopup="dialog"
+    />
+  )
+}
+
+export default ToggleCommunityWatchButton

--- a/src/views/User/UserProfile/DropdownActions/ToggleCommunityWatch/Dialog.tsx
+++ b/src/views/User/UserProfile/DropdownActions/ToggleCommunityWatch/Dialog.tsx
@@ -1,0 +1,124 @@
+import gql from 'graphql-tag'
+import { useState } from 'react'
+import { FormattedMessage } from 'react-intl'
+
+import { Dialog, toast, useDialogSwitch, useMutation } from '~/components'
+import {
+  ToggleCommunityWatchMutation,
+  UserFeatureFlagType,
+} from '~/gql/graphql'
+
+const TOGGLE_COMMUNITY_WATCH = gql`
+  mutation ToggleCommunityWatch($id: ID!, $flags: [UserFeatureFlagType!]!) {
+    putUserFeatureFlags(input: { ids: [$id], flags: $flags }) {
+      id
+      oss {
+        featureFlags {
+          type
+        }
+      }
+      info {
+        badges {
+          type
+        }
+      }
+    }
+  }
+`
+
+export type OpenToggleCommunityWatchDialogWithProps = {
+  enabled: boolean
+  flags: UserFeatureFlagType[]
+}
+
+export interface ToggleCommunityWatchDialogProps {
+  id: string
+  userName: string
+  children: ({
+    openDialog,
+  }: {
+    openDialog: (props: OpenToggleCommunityWatchDialogWithProps) => void
+  }) => React.ReactNode
+}
+
+const ToggleCommunityWatchDialog = ({
+  id,
+  userName,
+  children,
+}: ToggleCommunityWatchDialogProps) => {
+  const { show, openDialog, closeDialog } = useDialogSwitch(false)
+  const [enabled, setEnabled] = useState(false)
+  const [flags, setFlags] = useState<UserFeatureFlagType[]>([])
+  const [toggleCommunityWatch, { loading }] =
+    useMutation<ToggleCommunityWatchMutation>(TOGGLE_COMMUNITY_WATCH)
+
+  const openDialogWithProps = ({
+    enabled,
+    flags,
+  }: OpenToggleCommunityWatchDialogWithProps) => {
+    setEnabled(enabled)
+    setFlags(flags)
+    openDialog()
+  }
+
+  const onToggle = async () => {
+    const nextFlags = enabled
+      ? flags.filter((flag) => flag !== UserFeatureFlagType.CommunityWatch)
+      : Array.from(new Set([...flags, UserFeatureFlagType.CommunityWatch]))
+
+    await toggleCommunityWatch({
+      variables: {
+        id,
+        flags: nextFlags,
+      },
+    })
+    toast.info({ message: '設置成功' })
+    closeDialog()
+  }
+
+  return (
+    <>
+      {children({ openDialog: openDialogWithProps })}
+
+      <Dialog isOpen={show} onDismiss={closeDialog}>
+        <Dialog.Header
+          title={<span>{enabled ? '取消守望相助隊' : '指定為守望相助隊'}</span>}
+        />
+
+        <Dialog.Content>
+          <Dialog.Content.Message>
+            <p
+              dangerouslySetInnerHTML={{
+                __html: enabled
+                  ? `確認要取消「<span class="u-highlight">${userName}</span>」的守望相助隊權限嗎？`
+                  : `確認要指定「<span class="u-highlight">${userName}</span>」為守望相助隊員嗎？`,
+              }}
+            />
+          </Dialog.Content.Message>
+        </Dialog.Content>
+
+        <Dialog.Footer
+          closeDialog={closeDialog}
+          btns={
+            <Dialog.RoundedButton
+              text={<FormattedMessage defaultMessage="Confirm" id="N2IrpM" />}
+              color={enabled ? 'red' : 'green'}
+              onClick={onToggle}
+              loading={loading}
+            />
+          }
+          smUpBtns={
+            <Dialog.TextButton
+              text={<FormattedMessage defaultMessage="Confirm" id="N2IrpM" />}
+              color={enabled ? 'red' : 'green'}
+              onClick={onToggle}
+              loading={loading}
+            />
+          }
+        />
+      </Dialog>
+    </>
+  )
+}
+
+export default ToggleCommunityWatchDialog

--- a/src/views/User/UserProfile/DropdownActions/ToggleCommunityWatch/index.tsx
+++ b/src/views/User/UserProfile/DropdownActions/ToggleCommunityWatch/index.tsx
@@ -1,0 +1,10 @@
+import Button, { fragments } from './Button'
+import Dialog from './Dialog'
+
+const ToggleCommunityWatch = {
+  fragments,
+  Dialog,
+  Button,
+}
+
+export default ToggleCommunityWatch

--- a/src/views/User/UserProfile/DropdownActions/index.tsx
+++ b/src/views/User/UserProfile/DropdownActions/index.tsx
@@ -26,6 +26,10 @@ import {
 
 import type { ArchiveUserDialogProps } from './ArchiveUser/Dialog'
 import type {
+  OpenToggleCommunityWatchDialogWithProps,
+  ToggleCommunityWatchDialogProps,
+} from './ToggleCommunityWatch/Dialog'
+import type {
   OpenToggleFreezeUserDialogWithProps,
   ToggleFreezeUserDialogProps,
 } from './ToggleFreezeUser/Dialog'
@@ -58,6 +62,14 @@ const DynamicArchiveUserButton = dynamic(() => import('./ArchiveUser/Button'), {
 const DynamicArchiveUserDialog = dynamic(() => import('./ArchiveUser/Dialog'), {
   loading: () => <SpinnerBlock />,
 })
+const DynamicToggleCommunityWatchButton = dynamic(
+  () => import('./ToggleCommunityWatch/Button'),
+  { loading: () => <SpinnerBlock /> }
+)
+const DynamicToggleCommunityWatchDialog = dynamic(
+  () => import('./ToggleCommunityWatch/Dialog'),
+  { loading: () => <SpinnerBlock /> }
+)
 
 interface DropdownActionsProps {
   user: DropdownActionsUserPublicFragment &
@@ -77,6 +89,9 @@ interface Controls {
 }
 
 interface AdminProps {
+  openToggleCommunityWatchDialog: (
+    props: OpenToggleCommunityWatchDialogWithProps
+  ) => void
   openToggleFreezeDialog: (props: OpenToggleFreezeUserDialogWithProps) => void
   openToggleRestrictDialog: (
     props: OpenToggleRestrictUserDialogWithProps
@@ -121,6 +136,7 @@ const BaseDropdownActions = ({
   openShareDialog,
 
   // admin
+  openToggleCommunityWatchDialog,
   openToggleFreezeDialog,
   openToggleRestrictDialog,
   openArchiveDialog,
@@ -148,6 +164,10 @@ const BaseDropdownActions = ({
       {isAdminView && viewer.isAdmin && (
         <>
           <Menu.Divider />
+          <DynamicToggleCommunityWatchButton
+            id={user.id}
+            openDialog={openToggleCommunityWatchDialog}
+          />
           <DynamicToggleRestrictUserButton
             id={user.id}
             openDialog={openToggleRestrictDialog}
@@ -259,10 +279,22 @@ const DropdownActions = ({ user, isMe, isInAside }: DropdownActionsProps) => {
   /**
    * ADMIN ONLY
    */
+  const WithToggleCommunityWatch = withDialog<
+    Omit<ToggleCommunityWatchDialogProps, 'children'>
+  >(
+    WithBlockUser,
+    DynamicToggleCommunityWatchDialog as React.ComponentType<
+      Omit<ToggleCommunityWatchDialogProps, 'children'> & {
+        children: (props: { openDialog: () => void }) => React.ReactNode
+      }
+    >,
+    { id: user.id, userName: user.userName! },
+    ({ openDialog }) => ({ openToggleCommunityWatchDialog: openDialog })
+  )
   const WithToggleFreeze = withDialog<
     Omit<ToggleFreezeUserDialogProps, 'children'>
   >(
-    WithBlockUser,
+    WithToggleCommunityWatch,
     DynamicToggleFreezeUserDialog as React.ComponentType<
       Omit<ToggleFreezeUserDialogProps, 'children'> & {
         children: (props: { openDialog: () => void }) => React.ReactNode

--- a/src/views/User/UserProfile/index.tsx
+++ b/src/views/User/UserProfile/index.tsx
@@ -106,6 +106,9 @@ export const UserProfile = () => {
   const hasSeedBadge = badges.some((b) => b.type === 'seed')
   const hasArchitectBadge = badges.some((b) => b.type === 'architect')
   const hasGoldenMotorBadge = badges.some((b) => b.type === 'golden_motor')
+  const hasCommunityWatchBadge = badges.some(
+    (b) => b.type === 'community_watch'
+  )
   const hasTraveloggersBadge = !!user.info.cryptoWallet?.hasNFTs
   const nomadBadgeType = badges.filter((b) =>
     ['nomad1', 'nomad2', 'nomad3', 'nomad4'].includes(b.type)
@@ -214,6 +217,7 @@ export const UserProfile = () => {
                 hasSeedBadge={hasSeedBadge}
                 hasGoldenMotorBadge={hasGoldenMotorBadge}
                 hasArchitectBadge={hasArchitectBadge}
+                hasCommunityWatchBadge={hasCommunityWatchBadge}
                 isCivicLiker={isCivicLiker}
               >
                 {({ openDialog }) => (
@@ -230,6 +234,7 @@ export const UserProfile = () => {
                       hasSeedBadge={hasSeedBadge}
                       hasGoldenMotorBadge={hasGoldenMotorBadge}
                       hasArchitectBadge={hasArchitectBadge}
+                      hasCommunityWatchBadge={hasCommunityWatchBadge}
                       isCivicLiker={isCivicLiker}
                     />
                   </section>


### PR DESCRIPTION
## Summary
- add an admin-only profile menu action to assign or cancel the `communityWatch` feature flag
- render the Community Watch badge on user profiles and badge dialogs
- add a lantern-style badge icon and temporary local schema extension for `community_watch`

## Validation
- GRAPHQL_SCHEMA_URL=https://server.matters.icu/graphql npm run gen:type
- npm run lint:ts
- npm run build
