### PR TITLE
Add Community Watch record toast action

### DIFF
--- a/lang/default.json
+++ b/lang/default.json
@@ -2344,6 +2344,10 @@
     "defaultMessage": "Number of readers: unique registered users plus number of anonymous IP addresses visited the article (Data will be updated periodically and may be delayed)",
     "description": "src/views/Me/Works/Published/SortTabs.tsx"
   },
+  "a5ZQOK": {
+    "defaultMessage": "查看公開紀錄",
+    "description": "src/components/Comment/DropdownActions/CommunityWatchRemoveComment.tsx"
+  },
   "aCTmEO": {
     "defaultMessage": "I don't have a wallet yet",
     "description": "src/components/Forms/SelectAuthMethodForm/WalletFeed.tsx"

--- a/lang/en.json
+++ b/lang/en.json
@@ -2344,6 +2344,10 @@
     "defaultMessage": "Number of readers: unique registered users plus number of anonymous IP addresses visited the article (Data will be updated periodically and may be delayed)",
     "description": "src/views/Me/Works/Published/SortTabs.tsx"
   },
+  "a5ZQOK": {
+    "defaultMessage": "查看公開紀錄",
+    "description": "src/components/Comment/DropdownActions/CommunityWatchRemoveComment.tsx"
+  },
   "aCTmEO": {
     "defaultMessage": "I don't have a wallet yet",
     "description": "src/components/Forms/SelectAuthMethodForm/WalletFeed.tsx"

--- a/lang/zh-Hans.json
+++ b/lang/zh-Hans.json
@@ -2344,6 +2344,10 @@
     "defaultMessage": "读者数量：访问过作品页的不重复的登录用户数加匿名 IP 数（数据周期更新，可能存在延迟）",
     "description": "src/views/Me/Works/Published/SortTabs.tsx"
   },
+  "a5ZQOK": {
+    "defaultMessage": "查看公開紀錄",
+    "description": "src/components/Comment/DropdownActions/CommunityWatchRemoveComment.tsx"
+  },
   "aCTmEO": {
     "defaultMessage": "我还没有钱包",
     "description": "src/components/Forms/SelectAuthMethodForm/WalletFeed.tsx"

--- a/lang/zh-Hant.json
+++ b/lang/zh-Hant.json
@@ -2344,6 +2344,10 @@
     "defaultMessage": "讀者數量：訪問過作品頁的不重複的登入用戶數加匿名 IP 數（數據週期更新，可能存在延遲）",
     "description": "src/views/Me/Works/Published/SortTabs.tsx"
   },
+  "a5ZQOK": {
+    "defaultMessage": "查看公開紀錄",
+    "description": "src/components/Comment/DropdownActions/CommunityWatchRemoveComment.tsx"
+  },
   "aCTmEO": {
     "defaultMessage": "我還沒有錢包",
     "description": "src/components/Forms/SelectAuthMethodForm/WalletFeed.tsx"

--- a/src/components/Comment/DropdownActions/CommunityWatchRemoveComment.tsx
+++ b/src/components/Comment/DropdownActions/CommunityWatchRemoveComment.tsx
@@ -2,6 +2,7 @@ import gql from 'graphql-tag'
 import { FormattedMessage } from 'react-intl'
 
 import IconCircleMinus from '@/public/static/icons/24px/circle-minus.svg'
+import { toCommunityWatchRecordUrl } from '~/common/enums/communityWatch'
 import { Icon, Menu, toast, useMutation } from '~/components'
 import {
   CommentState,
@@ -33,7 +34,7 @@ const CommunityWatchRemoveComment = ({ id }: { id: string }) => {
 
   const submit = async (reason: CommunityWatchRemoveCommentReason) => {
     try {
-      await removeComment({
+      const result = await removeComment({
         variables: { id, reason },
         optimisticResponse: {
           communityWatchRemoveComment: {
@@ -49,6 +50,9 @@ const CommunityWatchRemoveComment = ({ id }: { id: string }) => {
           },
         },
       })
+      const recordUuid =
+        result.data?.communityWatchRemoveComment.communityWatchAction?.uuid
+
       toast.success({
         message: (
           <FormattedMessage
@@ -57,6 +61,27 @@ const CommunityWatchRemoveComment = ({ id }: { id: string }) => {
             description="src/components/Comment/DropdownActions/CommunityWatchRemoveComment.tsx"
           />
         ),
+        actions:
+          recordUuid && recordUuid !== 'pending'
+            ? [
+                {
+                  content: (
+                    <FormattedMessage
+                      defaultMessage="查看公開紀錄"
+                      id="a5ZQOK"
+                      description="src/components/Comment/DropdownActions/CommunityWatchRemoveComment.tsx"
+                    />
+                  ),
+                  onClick: () => {
+                    window.open(
+                      toCommunityWatchRecordUrl(recordUuid),
+                      '_blank',
+                      'noopener,noreferrer'
+                    )
+                  },
+                },
+              ]
+            : undefined,
       })
     } catch (error) {
       console.error(error)


### PR DESCRIPTION
## Summary\n- add a "查看公開紀錄" toast action after Community Watch comment removal\n- reuse the existing Community Watch record URL helper\n- include generated i18n files for the new label\n\n## Verification\n- npm run lint:ts -- --file src/components/Comment/DropdownActions/CommunityWatchRemoveComment.tsx\n- npm run test:unit -- --run src/components/Comment/DropdownActions/DropdownActions.test.tsx\n- commit hook ran format, i18n, lint