### PR TITLE
fix: stop querying viewer oss in root query

### DIFF
--- a/src/components/Root/index.tsx
+++ b/src/components/Root/index.tsx
@@ -101,7 +101,7 @@ const Root = ({
     RootQueryPrivateQueryVariables
   >(ROOT_QUERY_PRIVATE, {
     variables: {
-      includeViewerOss: true,
+      includeViewerOss: false,
     },
   })
   const viewer = data?.viewer


### PR DESCRIPTION
## Summary
- stop including admin-only viewer.oss in the global root query
- restores anonymous/general user access on matters.icu while Community Watch flag wiring is revisited

## Verification
- live GraphQL check: includeViewerOss=false returns viewer without FORBIDDEN
- CI on previous equivalent commit passed Test Build and Test Unit

## Context
The deployed bundle from PR #5889 still sends includeViewerOss=true, which causes visitors to hit "visitor isn't authorized for oss" from the admin-only User.oss field.