### PR TITLE
Fix Community Watch viewer flag query

### DIFF
--- a/src/components/Root/Root.test.ts
+++ b/src/components/Root/Root.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest'
+
+import { ROOT_QUERY_PRIVATE_VARIABLES } from './variables'
+
+describe('Root', () => {
+  it('requests viewer OSS feature flags for Community Watch permissions', () => {
+    expect(ROOT_QUERY_PRIVATE_VARIABLES.includeViewerOss).toBe(true)
+  })
+})

--- a/src/components/Root/index.tsx
+++ b/src/components/Root/index.tsx
@@ -29,12 +29,10 @@ import {
   ViewerProvider,
 } from '~/components'
 import { ChannelsProvider, FetchPolicyProvider } from '~/components/Context'
-import {
-  RootQueryPrivateQuery,
-  RootQueryPrivateQueryVariables,
-} from '~/gql/graphql'
+import { RootQueryPrivateQuery } from '~/gql/graphql'
 
 import { ROOT_QUERY_PRIVATE } from './gql'
+import { ROOT_QUERY_PRIVATE_VARIABLES } from './variables'
 
 const DynamicToaster = dynamic(
   () => import('~/components/Toast').then((mod) => mod.Toaster),
@@ -96,14 +94,12 @@ const Root = ({
 
   const referralCode = getQuery(REFERRAL_QUERY_REFERRAL_KEY)
 
-  const { loading, data, error } = useQuery<
-    RootQueryPrivateQuery,
-    RootQueryPrivateQueryVariables
-  >(ROOT_QUERY_PRIVATE, {
-    variables: {
-      includeViewerOss: false,
-    },
-  })
+  const { loading, data, error } = useQuery<RootQueryPrivateQuery>(
+    ROOT_QUERY_PRIVATE,
+    {
+      variables: ROOT_QUERY_PRIVATE_VARIABLES,
+    }
+  )
   const viewer = data?.viewer
   const official = data?.official
   const channels = data?.channels

--- a/src/components/Root/variables.ts
+++ b/src/components/Root/variables.ts
@@ -1,0 +1,3 @@
+export const ROOT_QUERY_PRIVATE_VARIABLES = {
+  includeViewerOss: true,
+}


### PR DESCRIPTION
## Summary
- request viewer OSS feature flags from the root private query again
- keep the variables in one exported constant so Community Watch permission loading stays explicit
- add a focused regression test for the root query variables

## Why
Community Watch comment actions depend on `viewer.isCommunityWatch`, which is computed from `viewer.oss.featureFlags`. The root query was sending `includeViewerOss: false`, so flagged users on staging could still see admin actions but not the Community Watch reasons (色情廣告 / 濫發廣告).

## Validation
- `npx vitest run src/components/Root/Root.test.ts`
- `npx prettier --check src/components/Root/index.tsx src/components/Root/variables.ts src/components/Root/Root.test.ts`

Note: the pre-commit full lint currently fails on existing generated GraphQL type drift in Fediverse / badge / admin Community Watch files, not on this patch.