### PR TITLE
Skip viewer OSS query for visitors

### DIFF
--- a/src/components/Root/Root.test.ts
+++ b/src/components/Root/Root.test.ts
@@ -1,9 +1,15 @@
 import { describe, expect, it } from 'vitest'
 
-import { ROOT_QUERY_PRIVATE_VARIABLES } from './variables'
+import { getRootQueryPrivateVariables } from './variables'
 
 describe('Root', () => {
-  it('requests viewer OSS feature flags for Community Watch permissions', () => {
-    expect(ROOT_QUERY_PRIVATE_VARIABLES.includeViewerOss).toBe(true)
+  it('requests viewer OSS feature flags when a user token exists', () => {
+    expect(
+      getRootQueryPrivateVariables('__dev__access_token=token').includeViewerOss
+    ).toBe(true)
+  })
+
+  it('skips viewer OSS feature flags for visitors', () => {
+    expect(getRootQueryPrivateVariables('').includeViewerOss).toBe(false)
   })
 })

--- a/src/components/Root/index.tsx
+++ b/src/components/Root/index.tsx
@@ -32,7 +32,7 @@ import { ChannelsProvider, FetchPolicyProvider } from '~/components/Context'
 import { RootQueryPrivateQuery } from '~/gql/graphql'
 
 import { ROOT_QUERY_PRIVATE } from './gql'
-import { ROOT_QUERY_PRIVATE_VARIABLES } from './variables'
+import { getRootQueryPrivateVariables } from './variables'
 
 const DynamicToaster = dynamic(
   () => import('~/components/Toast').then((mod) => mod.Toaster),
@@ -93,11 +93,13 @@ const Root = ({
     !isInArticleDetailEdit
 
   const referralCode = getQuery(REFERRAL_QUERY_REFERRAL_KEY)
+  const cookie =
+    headers?.cookie || (typeof document !== 'undefined' ? document.cookie : '')
 
   const { loading, data, error } = useQuery<RootQueryPrivateQuery>(
     ROOT_QUERY_PRIVATE,
     {
-      variables: ROOT_QUERY_PRIVATE_VARIABLES,
+      variables: getRootQueryPrivateVariables(cookie),
     }
   )
   const viewer = data?.viewer

--- a/src/components/Root/variables.ts
+++ b/src/components/Root/variables.ts
@@ -1,3 +1,6 @@
-export const ROOT_QUERY_PRIVATE_VARIABLES = {
-  includeViewerOss: true,
-}
+import { COOKIE_TOKEN_NAME } from '~/common/enums'
+import { getIsomorphicCookie } from '~/common/utils'
+
+export const getRootQueryPrivateVariables = (cookie: string) => ({
+  includeViewerOss: !!getIsomorphicCookie(cookie, COOKIE_TOKEN_NAME),
+})


### PR DESCRIPTION
## Summary
- only include `viewer.oss.featureFlags` in the root query when an auth token cookie exists
- keep Community Watch permissions available for logged-in users
- avoid querying `oss` for visitors, which currently returns `visitor isn't authorized for oss`

## Validation
- `npx vitest run src/components/Root/Root.test.ts`
- `npx prettier --check src/components/Root/index.tsx src/components/Root/variables.ts src/components/Root/Root.test.ts`

Note: full pre-commit lint still fails on existing generated GraphQL type drift in Fediverse / badge / admin Community Watch files, not this patch.