### PR TITLE
Add admin Community Watch restore button

### DIFF
--- a/lang/default.json
+++ b/lang/default.json
@@ -3210,6 +3210,10 @@
   "orIq4X": {
     "defaultMessage": "More than 100 supports"
   },
+  "p/Sz0T": {
+    "defaultMessage": "恢復留言",
+    "description": "src/components/Comment/Content/index.tsx"
+  },
   "p5qZnJ": {
     "defaultMessage": "liked",
     "description": "src/components/Notice/ArticleNotice/ArticleNewAppreciationNotice.tsx"
@@ -3474,6 +3478,10 @@
     "defaultMessage": "My circle",
     "description": "src/views/Me/Settings/Notifications/Circle/index.tsx"
   },
+  "u4QNpM": {
+    "defaultMessage": "恢復失敗，請稍後再試",
+    "description": "src/components/Comment/Content/index.tsx"
+  },
   "u5aHb4": {
     "defaultMessage": "Copy Link"
   },
@@ -3568,6 +3576,10 @@
   },
   "vH8sCb": {
     "defaultMessage": "Circle"
+  },
+  "vJQzbe": {
+    "defaultMessage": "已恢復留言",
+    "description": "src/components/Comment/Content/index.tsx"
   },
   "vJd1we": {
     "defaultMessage": "Comment not found",

--- a/lang/en.json
+++ b/lang/en.json
@@ -3210,6 +3210,10 @@
   "orIq4X": {
     "defaultMessage": "More than 100 supports"
   },
+  "p/Sz0T": {
+    "defaultMessage": "Restore comment",
+    "description": "src/components/Comment/Content/index.tsx"
+  },
   "p5qZnJ": {
     "defaultMessage": "liked",
     "description": "src/components/Notice/ArticleNotice/ArticleNewAppreciationNotice.tsx"
@@ -3474,6 +3478,10 @@
     "defaultMessage": "My circle",
     "description": "src/views/Me/Settings/Notifications/Circle/index.tsx"
   },
+  "u4QNpM": {
+    "defaultMessage": "Failed to restore comment. Please try again later.",
+    "description": "src/components/Comment/Content/index.tsx"
+  },
   "u5aHb4": {
     "defaultMessage": "Copy Link"
   },
@@ -3568,6 +3576,10 @@
   },
   "vH8sCb": {
     "defaultMessage": "Circle"
+  },
+  "vJQzbe": {
+    "defaultMessage": "Comment restored",
+    "description": "src/components/Comment/Content/index.tsx"
   },
   "vJd1we": {
     "defaultMessage": "Comment not found",

--- a/lang/zh-Hans.json
+++ b/lang/zh-Hans.json
@@ -3210,6 +3210,10 @@
   "orIq4X": {
     "defaultMessage": "支持超过 100 次"
   },
+  "p/Sz0T": {
+    "defaultMessage": "恢复留言",
+    "description": "src/components/Comment/Content/index.tsx"
+  },
   "p5qZnJ": {
     "defaultMessage": "赞赏了",
     "description": "src/components/Notice/ArticleNotice/ArticleNewAppreciationNotice.tsx"
@@ -3474,6 +3478,10 @@
     "defaultMessage": "我的围炉",
     "description": "src/views/Me/Settings/Notifications/Circle/index.tsx"
   },
+  "u4QNpM": {
+    "defaultMessage": "恢复失败，请稍后再试",
+    "description": "src/components/Comment/Content/index.tsx"
+  },
   "u5aHb4": {
     "defaultMessage": "复制链接"
   },
@@ -3568,6 +3576,10 @@
   },
   "vH8sCb": {
     "defaultMessage": "我的围炉"
+  },
+  "vJQzbe": {
+    "defaultMessage": "已恢复留言",
+    "description": "src/components/Comment/Content/index.tsx"
   },
   "vJd1we": {
     "defaultMessage": "评论不存在",

--- a/lang/zh-Hant.json
+++ b/lang/zh-Hant.json
@@ -3210,6 +3210,10 @@
   "orIq4X": {
     "defaultMessage": "支持超過 100 次"
   },
+  "p/Sz0T": {
+    "defaultMessage": "恢復留言",
+    "description": "src/components/Comment/Content/index.tsx"
+  },
   "p5qZnJ": {
     "defaultMessage": "讚賞了",
     "description": "src/components/Notice/ArticleNotice/ArticleNewAppreciationNotice.tsx"
@@ -3474,6 +3478,10 @@
     "defaultMessage": "我的圍爐",
     "description": "src/views/Me/Settings/Notifications/Circle/index.tsx"
   },
+  "u4QNpM": {
+    "defaultMessage": "恢復失敗，請稍後再試",
+    "description": "src/components/Comment/Content/index.tsx"
+  },
   "u5aHb4": {
     "defaultMessage": "複製連結"
   },
@@ -3568,6 +3576,10 @@
   },
   "vH8sCb": {
     "defaultMessage": "我的圍爐"
+  },
+  "vJQzbe": {
+    "defaultMessage": "已恢復留言",
+    "description": "src/components/Comment/Content/index.tsx"
   },
   "vJd1we": {
     "defaultMessage": "評論不存在",

--- a/src/components/Comment/Content/Content.test.tsx
+++ b/src/components/Comment/Content/Content.test.tsx
@@ -1,8 +1,9 @@
 import { describe, expect, it } from 'vitest'
 
 import { cleanup, render, screen } from '~/common/utils/test'
-import { CommentState } from '~/gql/graphql'
-import { MOCK_COMMENT } from '~/stories/mocks'
+import { processViewer, ViewerContext } from '~/components'
+import { CommentState, UserRole } from '~/gql/graphql'
+import { MOCK_COMMENT, MOCK_USER } from '~/stories/mocks'
 
 import { CommentContent } from './'
 
@@ -89,5 +90,36 @@ describe('<Comemnt.Content>', () => {
       'href',
       'https://community-watch.matters.town/records/community-watch-action-uuid/'
     )
+    expect(
+      screen.queryByRole('button', { name: /恢復留言|Restore comment/ })
+    ).not.toBeInTheDocument()
+  })
+
+  it('should render a Community Watch restore button for admins', () => {
+    const admin = processViewer({
+      ...MOCK_USER,
+      status: {
+        ...MOCK_USER.status,
+        role: UserRole.Admin,
+      },
+    })
+
+    render(
+      <ViewerContext.Provider value={admin}>
+        <CommentContent
+          comment={{
+            ...MOCK_COMMENT,
+            state: CommentState.Banned,
+            communityWatchAction: {
+              uuid: 'community-watch-action-uuid',
+            },
+          }}
+        />
+      </ViewerContext.Provider>
+    )
+
+    expect(
+      screen.getByRole('button', { name: /恢復留言|Restore comment/ })
+    ).toBeInTheDocument()
   })
 })

--- a/src/components/Comment/Content/index.tsx
+++ b/src/components/Comment/Content/index.tsx
@@ -1,3 +1,4 @@
+import { useApolloClient } from '@apollo/client'
 import classNames from 'classnames'
 import gql from 'graphql-tag'
 import Link from 'next/link'
@@ -9,10 +10,19 @@ import {
   TEST_ID,
   toCommunityWatchRecordUrl,
 } from '~/common/enums'
-import { Expandable, LanguageContext } from '~/components'
+import {
+  Button,
+  Expandable,
+  LanguageContext,
+  toast,
+  useMutation,
+  ViewerContext,
+} from '~/components'
 import {
   CommentContentCommentPrivateFragment,
   CommentContentCommentPublicFragment,
+  CommentState,
+  RestoreCommunityWatchCommentMutation,
 } from '~/gql/graphql'
 
 import Collapsed from './Collapsed'
@@ -53,6 +63,90 @@ const fragments = {
   },
 }
 
+const RESTORE_COMMUNITY_WATCH_COMMENT = gql`
+  mutation RestoreCommunityWatchComment($uuid: ID!, $note: String) {
+    restoreCommunityWatchComment(input: { uuid: $uuid, note: $note }) {
+      uuid
+      actionState
+      reviewState
+      commentId
+    }
+  }
+`
+
+const CommunityWatchRestoreButton = ({
+  commentId,
+  actionUuid,
+}: {
+  commentId: string
+  actionUuid: string
+}) => {
+  const client = useApolloClient()
+  const [restoreComment, { loading }] =
+    useMutation<RestoreCommunityWatchCommentMutation>(
+      RESTORE_COMMUNITY_WATCH_COMMENT
+    )
+
+  const restore = async () => {
+    try {
+      await restoreComment({
+        variables: {
+          uuid: actionUuid,
+          note: 'Restored from Matters frontend admin action',
+        },
+        update: (cache) => {
+          cache.modify({
+            id: cache.identify({ __typename: 'Comment', id: commentId }),
+            fields: {
+              state: () => CommentState.Active,
+              communityWatchAction: () => null,
+            },
+          })
+        },
+      })
+      await client.refetchQueries({ include: 'active' })
+
+      toast.success({
+        message: (
+          <FormattedMessage
+            defaultMessage="已恢復留言"
+            id="vJQzbe"
+            description="src/components/Comment/Content/index.tsx"
+          />
+        ),
+      })
+    } catch (error) {
+      console.error(error)
+      toast.error({
+        message: (
+          <FormattedMessage
+            defaultMessage="恢復失敗，請稍後再試"
+            id="u4QNpM"
+            description="src/components/Comment/Content/index.tsx"
+          />
+        ),
+      })
+    }
+  }
+
+  return (
+    <Button
+      className={styles.restoreButton}
+      disabled={loading}
+      onClick={restore}
+      spacing={[0, 0]}
+      textColor="green"
+      textActiveColor="greenDark"
+    >
+      <FormattedMessage
+        defaultMessage="恢復留言"
+        id="p/Sz0T"
+        description="src/components/Comment/Content/index.tsx"
+      />
+    </Button>
+  )
+}
+
 export const CommentContent = ({
   comment,
   size,
@@ -63,6 +157,7 @@ export const CommentContent = ({
   expandable = true,
 }: ContentProps) => {
   const { lang } = useContext(LanguageContext)
+  const viewer = useContext(ViewerContext)
   const { content, state } = comment
   const isBlocked = comment.author?.isBlocked
   const communityWatchAction = comment.communityWatchAction
@@ -83,6 +178,12 @@ export const CommentContent = ({
             description="src/components/Comment/Content/index.tsx"
           />
         </Link>
+        {viewer.isAdmin && (
+          <CommunityWatchRestoreButton
+            commentId={comment.id}
+            actionUuid={communityWatchAction.uuid}
+          />
+        )}
       </p>
     )
   }

--- a/src/components/Comment/Content/styles.module.css
+++ b/src/components/Comment/Content/styles.module.css
@@ -11,3 +11,9 @@
 .text15 {
   font-size: var(--text15);
 }
+
+.restoreButton {
+  margin-left: var(--sp8);
+  font-size: inherit;
+  vertical-align: baseline;
+}


### PR DESCRIPTION
## Summary

Add a minimal admin-only restore button for comments removed by Community Watch.

Admins now see a `恢復留言` action next to the Community Watch placeholder in the existing comment UI. The action calls the existing `restoreCommunityWatchComment` mutation, clears the local `communityWatchAction` cache field, marks the comment active locally, refetches active queries, and shows a success toast.

## Scope

- Reuses the existing frontend comment placeholder instead of building a new staff dashboard.
- Reuses the existing server mutation; no server/schema change.
- Only visible to `viewer.isAdmin` when `comment.state === banned` and `comment.communityWatchAction.uuid` exists.

## Validation

- `npm run gen:type`
- `npm run test:unit -- src/components/Comment/Content/Content.test.tsx`
- `npm run lint:ts`
- `npm run lint:css -- src/components/Comment/Content/styles.module.css`
- `npm run build`
- Commit hook also reran i18n + lint successfully.

## Notes

This is the small production-prep UX fix so staff no longer needs to manually call GraphQL for the common restore case. It does not replace a future full Community Watch review dashboard.
