### PR TITLE
Restore Fediverse controls via public features

### DIFF
--- a/lang/default.json
+++ b/lang/default.json
@@ -1929,6 +1929,9 @@
   "Sj+TN8": {
     "defaultMessage": "Announcement"
   },
+  "Su1LcW": {
+    "defaultMessage": "開啟後，新發佈作品預設可輸出到 Fediverse。"
+  },
   "SuRTsQ": {
     "defaultMessage": "Register for ISCN"
   },
@@ -2261,6 +2264,9 @@
   },
   "Y9IYvj": {
     "defaultMessage": "No suitable channels"
+  },
+  "YC2b3b": {
+    "defaultMessage": "Fediverse 聯邦發佈"
   },
   "YDMrKK": {
     "defaultMessage": "Users"
@@ -3056,6 +3062,9 @@
     "defaultMessage": "Hottest",
     "description": "src/views/Circle/Analytics/ContentAnalytics/index.tsx"
   },
+  "mFn/Vv": {
+    "defaultMessage": "已更新 Fediverse 設定"
+  },
   "mJEqC/": {
     "defaultMessage": "Go to {href}"
   },
@@ -3589,6 +3598,9 @@
   },
   "vX2bDy": {
     "defaultMessage": "Collect Article"
+  },
+  "vXgChH": {
+    "defaultMessage": "操作失敗，請稍後再試"
   },
   "va8Rnw": {
     "defaultMessage": "The author has closed the comment section"

--- a/lang/en.json
+++ b/lang/en.json
@@ -1929,6 +1929,9 @@
   "Sj+TN8": {
     "defaultMessage": "Announcement"
   },
+  "Su1LcW": {
+    "defaultMessage": "開啟後，新發佈作品預設可輸出到 Fediverse。"
+  },
   "SuRTsQ": {
     "defaultMessage": "Register for ISCN"
   },
@@ -2261,6 +2264,9 @@
   },
   "Y9IYvj": {
     "defaultMessage": "No suitable channels"
+  },
+  "YC2b3b": {
+    "defaultMessage": "Fediverse 聯邦發佈"
   },
   "YDMrKK": {
     "defaultMessage": "Users"
@@ -3056,6 +3062,9 @@
     "defaultMessage": "Hottest",
     "description": "src/views/Circle/Analytics/ContentAnalytics/index.tsx"
   },
+  "mFn/Vv": {
+    "defaultMessage": "已更新 Fediverse 設定"
+  },
   "mJEqC/": {
     "defaultMessage": "Go to {href}"
   },
@@ -3589,6 +3598,9 @@
   },
   "vX2bDy": {
     "defaultMessage": "Collect Article"
+  },
+  "vXgChH": {
+    "defaultMessage": "操作失敗，請稍後再試"
   },
   "va8Rnw": {
     "defaultMessage": "The author has closed the comment section"

--- a/lang/zh-Hans.json
+++ b/lang/zh-Hans.json
@@ -1929,6 +1929,9 @@
   "Sj+TN8": {
     "defaultMessage": "公告"
   },
+  "Su1LcW": {
+    "defaultMessage": "開啟後，新發佈作品預設可輸出到 Fediverse。"
+  },
   "SuRTsQ": {
     "defaultMessage": "注册 ISCN"
   },
@@ -2261,6 +2264,9 @@
   },
   "Y9IYvj": {
     "defaultMessage": "没有适合的频道"
+  },
+  "YC2b3b": {
+    "defaultMessage": "Fediverse 聯邦發佈"
   },
   "YDMrKK": {
     "defaultMessage": "用户"
@@ -3056,6 +3062,9 @@
     "defaultMessage": "站内阅读热门排行",
     "description": "src/views/Circle/Analytics/ContentAnalytics/index.tsx"
   },
+  "mFn/Vv": {
+    "defaultMessage": "已更新 Fediverse 設定"
+  },
   "mJEqC/": {
     "defaultMessage": "跳转至 {href}"
   },
@@ -3589,6 +3598,9 @@
   },
   "vX2bDy": {
     "defaultMessage": "关联作品"
+  },
+  "vXgChH": {
+    "defaultMessage": "操作失敗，請稍後再試"
   },
   "va8Rnw": {
     "defaultMessage": "作者已关闭评论区"

--- a/lang/zh-Hant.json
+++ b/lang/zh-Hant.json
@@ -1929,6 +1929,9 @@
   "Sj+TN8": {
     "defaultMessage": "公告"
   },
+  "Su1LcW": {
+    "defaultMessage": "開啟後，新發佈作品預設可輸出到 Fediverse。"
+  },
   "SuRTsQ": {
     "defaultMessage": "註冊 ISCN"
   },
@@ -2261,6 +2264,9 @@
   },
   "Y9IYvj": {
     "defaultMessage": "沒有適合的頻道"
+  },
+  "YC2b3b": {
+    "defaultMessage": "Fediverse 聯邦發佈"
   },
   "YDMrKK": {
     "defaultMessage": "用戶"
@@ -3056,6 +3062,9 @@
     "defaultMessage": "站內閱讀熱門排行",
     "description": "src/views/Circle/Analytics/ContentAnalytics/index.tsx"
   },
+  "mFn/Vv": {
+    "defaultMessage": "已更新 Fediverse 設定"
+  },
   "mJEqC/": {
     "defaultMessage": "跳轉至 {href}"
   },
@@ -3589,6 +3598,9 @@
   },
   "vX2bDy": {
     "defaultMessage": "關聯作品"
+  },
+  "vXgChH": {
+    "defaultMessage": "操作失敗，請稍後再試"
   },
   "va8Rnw": {
     "defaultMessage": "作者已關閉評論區"

--- a/src/common/utils/types/index.ts
+++ b/src/common/utils/types/index.ts
@@ -71,6 +71,11 @@ export default gql`
     updatedBy: ID
   }
 
+  type UserFeatures {
+    fediverseBeta: Boolean!
+    communityWatch: Boolean!
+  }
+
   type ArticleFederationSetting {
     articleId: ID!
     state: FederationArticleSettingState!
@@ -79,6 +84,7 @@ export default gql`
 
   extend type User {
     federationSetting: UserFederationSetting
+    features: UserFeatures!
   }
 
   extend type Article {

--- a/src/views/ArticleDetail/Edit/OptionContent/index.tsx
+++ b/src/views/ArticleDetail/Edit/OptionContent/index.tsx
@@ -17,6 +17,7 @@ import {
   DigestRichCirclePublicFragment,
   DraftDetailViewerQueryQuery,
   EditorSelectCampaignFragment,
+  FederationArticleSettingState,
 } from '~/gql/graphql'
 
 import { Article } from '..'
@@ -45,7 +46,11 @@ export type OptionContentProps = {
       replyToDonator: string | null
     ) => void
   } & SidebarSensitiveProps &
-  SidebarISCNProps
+  SidebarISCNProps & {
+    federationSetting?: FederationArticleSettingState | null
+    federationSettingSaving: boolean
+    editFederationSetting: (state: FederationArticleSettingState) => void
+  }
 
 type OptionItemProps = OptionContentProps & { disabled: boolean }
 
@@ -234,6 +239,22 @@ const EditCircle = ({
   )
 }
 
+const EditFederationSetting = ({
+  article,
+  federationSetting,
+  federationSettingSaving,
+  editFederationSetting,
+}: OptionItemProps) => {
+  return (
+    <Sidebar.FederationSetting
+      articleId={article.id}
+      federationSetting={federationSetting}
+      federationSettingSaving={federationSettingSaving}
+      editFederationSetting={editFederationSetting}
+    />
+  )
+}
+
 export const OptionContent = (
   props: OptionContentProps & {
     tab: OptionTab
@@ -245,6 +266,7 @@ export const OptionContent = (
   const isSettings = tab === 'settings'
   const hasOwnCollections = (props.ownCollections?.length || 0) > 0
   const hasOwnCircle = props.ownCircles && props.ownCircles.length >= 1
+  const isFediverseBeta = !!props.viewerData?.viewer?.features.fediverseBeta
   const disabled = false
 
   return (
@@ -290,6 +312,9 @@ export const OptionContent = (
             <EditLicense {...props} disabled={disabled} />
             <EditCanComment {...props} disabled={disabled} />
             <EditSupportSetting {...props} disabled={disabled} />
+            {isFediverseBeta && (
+              <EditFederationSetting {...props} disabled={disabled} />
+            )}
             <EditSensitive {...props} disabled={disabled} />
             {hasOwnCircle && <EditCircle {...props} disabled={disabled} />}
           </>

--- a/src/views/Me/DraftDetail/OptionContent/index.tsx
+++ b/src/views/Me/DraftDetail/OptionContent/index.tsx
@@ -241,6 +241,7 @@ export const OptionContent = (
   const isPublished = props.draft.publishState === 'published'
   const disabled = isPending || isPublished
   const hasOwnCollections = (props.ownCollections?.length || 0) > 0
+  const isFediverseBeta = !!props.draftViewer?.viewer?.features.fediverseBeta
 
   return (
     <section>
@@ -290,6 +291,7 @@ export const OptionContent = (
             <EditDraftLicense {...props} disabled={disabled} />
             <EditDraftCanComment {...props} disabled={disabled} />
             <EditDraftSupportSetting {...props} disabled={disabled} />
+            {isFediverseBeta && <Sidebar.FederationSetting />}
             <EditDraftSensitive {...props} disabled={disabled} />
             <EditDraftCircle {...props} disabled={disabled} />
           </>

--- a/src/views/Me/DraftDetail/gql.ts
+++ b/src/views/Me/DraftDetail/gql.ts
@@ -87,6 +87,9 @@ export const DRAFT_DETAIL_VIEWER = gql`
       }
       displayName
       avatar
+      features {
+        fediverseBeta
+      }
       collections(input: { first: 20, after: $collectionsAfter }) {
         pageInfo {
           hasNextPage

--- a/src/views/Me/Settings/Misc/FederationSetting.tsx
+++ b/src/views/Me/Settings/Misc/FederationSetting.tsx
@@ -1,3 +1,135 @@
-const FederationSetting = () => null
+import { useQuery } from '@apollo/client'
+import gql from 'graphql-tag'
+import { useEffect, useState } from 'react'
+import { FormattedMessage, useIntl } from 'react-intl'
+
+import { Switch, TableView, toast, useMutation } from '~/components'
+import {
+  FederationAuthorSettingState,
+  SetViewerFederationSettingMutation,
+  SetViewerFederationSettingMutationVariables,
+  ViewerFederationSettingQuery,
+} from '~/gql/graphql'
+
+const VIEWER_FEDERATION_SETTING = gql`
+  query ViewerFederationSetting {
+    viewer {
+      id
+      features {
+        fediverseBeta
+      }
+      federationSetting {
+        state
+      }
+    }
+  }
+`
+
+const SET_VIEWER_FEDERATION_SETTING = gql`
+  mutation SetViewerFederationSetting(
+    $input: SetViewerFederationSettingInput!
+  ) {
+    setViewerFederationSetting(input: $input) {
+      userId
+      state
+    }
+  }
+`
+
+const FederationSetting = () => {
+  const intl = useIntl()
+  const [setting, setSetting] = useState(FederationAuthorSettingState.Disabled)
+  const { data, loading } = useQuery<ViewerFederationSettingQuery>(
+    VIEWER_FEDERATION_SETTING,
+    { fetchPolicy: 'cache-and-network' }
+  )
+  const [setViewerFederationSetting, { loading: saving }] = useMutation<
+    SetViewerFederationSettingMutation,
+    SetViewerFederationSettingMutationVariables
+  >(SET_VIEWER_FEDERATION_SETTING)
+
+  const viewer = data?.viewer
+  const isFediverseBeta = !!viewer?.features.fediverseBeta
+
+  useEffect(() => {
+    if (viewer?.federationSetting?.state) {
+      setSetting(viewer.federationSetting.state)
+    }
+  }, [viewer?.federationSetting?.state])
+
+  if (!loading && !isFediverseBeta) {
+    return null
+  }
+
+  const enabled = setting === FederationAuthorSettingState.Enabled
+
+  const updateSetting = async () => {
+    if (!viewer?.id) {
+      return
+    }
+
+    const state = enabled
+      ? FederationAuthorSettingState.Disabled
+      : FederationAuthorSettingState.Enabled
+
+    try {
+      await setViewerFederationSetting({
+        variables: { input: { state } },
+        optimisticResponse: {
+          setViewerFederationSetting: {
+            __typename: 'UserFederationSetting',
+            userId: viewer.id,
+            state,
+          },
+        },
+      })
+      setSetting(state)
+      toast.success({
+        message: intl.formatMessage({
+          defaultMessage: '已更新 Fediverse 設定',
+          id: 'mFn/Vv',
+        }),
+      })
+    } catch {
+      toast.error({
+        message: intl.formatMessage({
+          defaultMessage: '操作失敗，請稍後再試',
+          id: 'vXgChH',
+        }),
+      })
+    }
+  }
+
+  return (
+    <TableView.Cell
+      title={
+        <FormattedMessage
+          defaultMessage="Fediverse 聯邦發佈"
+          id="YC2b3b"
+        />
+      }
+      subtitle={
+        <FormattedMessage
+          defaultMessage="開啟後，新發佈作品預設可輸出到 Fediverse。"
+          id="Su1LcW"
+        />
+      }
+      right={
+        <Switch
+          name="fediverse-federation-setting"
+          label={
+            <FormattedMessage
+              defaultMessage="Fediverse 聯邦發佈"
+              id="YC2b3b"
+            />
+          }
+          checked={enabled}
+          loading={loading || saving}
+          onChange={updateSetting}
+        />
+      }
+    />
+  )
+}
 
 export default FederationSetting


### PR DESCRIPTION
## Summary
- query `viewer.features.fediverseBeta` instead of `viewer.oss.featureFlags` for Fediverse UI gating
- restore author default Fediverse setting in Misc settings
- restore draft/article Fediverse controls behind the public-safe feature field

## Validation
- `npm run gen:type`
- `npm run i18n`
- `npm run lint:ts`
- `npm run test:unit -- src/common/utils/graphqlAuthBoundary.test.ts`
- `npm run build`

## Notes
- Includes a temporary local `UserFeatures` schema extension until the server schema is deployed and available to web codegen.
- This PR should merge after the matters-server PR that adds `User.features`.