### PR TITLE
Hide Fediverse setting until eligibility loads

### DIFF
--- a/src/views/Me/Settings/Misc/FederationSetting.test.tsx
+++ b/src/views/Me/Settings/Misc/FederationSetting.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from '@testing-library/react'
+import { IntlProvider } from 'react-intl'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import FederationSetting from './FederationSetting'
+
+const useQuery = vi.fn()
+const messages = {
+  YC2b3b: 'Fediverse 聯邦發佈',
+}
+
+vi.mock('@apollo/client', () => ({
+  useQuery: () => useQuery(),
+}))
+
+vi.mock('~/components', () => ({
+  Switch: () => <input aria-label="Fediverse 聯邦發佈" type="checkbox" />,
+  TableView: {
+    Cell: ({ title }: { title: React.ReactNode }) => <div>{title}</div>,
+  },
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+  useMutation: () => [vi.fn(), { loading: false }],
+}))
+
+describe('<FederationSetting>', () => {
+  beforeEach(() => {
+    useQuery.mockReset()
+  })
+
+  it('does not render before viewer feature eligibility is confirmed', () => {
+    useQuery.mockReturnValue({ data: undefined, loading: true })
+
+    render(
+      <IntlProvider locale="zh-Hant" messages={messages}>
+        <FederationSetting />
+      </IntlProvider>
+    )
+
+    expect(screen.queryByText('Fediverse 聯邦發佈')).not.toBeInTheDocument()
+  })
+
+  it('renders for fediverse beta users', () => {
+    useQuery.mockReturnValue({
+      data: {
+        viewer: {
+          id: '1',
+          features: { fediverseBeta: true },
+          federationSetting: { state: 'disabled' },
+        },
+      },
+      loading: false,
+    })
+
+    render(
+      <IntlProvider locale="zh-Hant" messages={messages}>
+        <FederationSetting />
+      </IntlProvider>
+    )
+
+    expect(screen.getByText('Fediverse 聯邦發佈')).toBeInTheDocument()
+  })
+})

--- a/src/views/Me/Settings/Misc/FederationSetting.tsx
+++ b/src/views/Me/Settings/Misc/FederationSetting.tsx
@@ -57,7 +57,7 @@ const FederationSetting = () => {
     }
   }, [viewer?.federationSetting?.state])
 
-  if (!loading && !isFediverseBeta) {
+  if (!isFediverseBeta) {
     return null
   }
 


### PR DESCRIPTION
## Summary
- avoid rendering the Fediverse settings cell while viewer feature eligibility is still loading
- add a focused unit test for the no-flash behavior

## Validation
- `npm run test:unit -- src/views/Me/Settings/Misc/FederationSetting.test.tsx`
- `npm run lint:ts`