### PR TITLE
Sync Fediverse UI gate to develop

### DIFF
--- a/lang/default.json
+++ b/lang/default.json
@@ -1932,6 +1932,9 @@
   "Sj+TN8": {
     "defaultMessage": "Announcement"
   },
+  "Su1LcW": {
+    "defaultMessage": "開啟後，新發佈作品預設可輸出到 Fediverse。"
+  },
   "SuRTsQ": {
     "defaultMessage": "Register for ISCN"
   },
@@ -2264,6 +2267,9 @@
   },
   "Y9IYvj": {
     "defaultMessage": "No suitable channels"
+  },
+  "YC2b3b": {
+    "defaultMessage": "Fediverse 聯邦發佈"
   },
   "YDMrKK": {
     "defaultMessage": "Users"
@@ -3059,6 +3065,9 @@
     "defaultMessage": "Hottest",
     "description": "src/views/Circle/Analytics/ContentAnalytics/index.tsx"
   },
+  "mFn/Vv": {
+    "defaultMessage": "已更新 Fediverse 設定"
+  },
   "mJEqC/": {
     "defaultMessage": "Go to {href}"
   },
@@ -3595,6 +3604,9 @@
   },
   "vX2bDy": {
     "defaultMessage": "Collect Article"
+  },
+  "vXgChH": {
+    "defaultMessage": "操作失敗，請稍後再試"
   },
   "va8Rnw": {
     "defaultMessage": "The author has closed the comment section"

--- a/lang/default.json
+++ b/lang/default.json
@@ -1817,9 +1817,6 @@
     "defaultMessage": "Incorrect verification code",
     "description": "CODE_INVALID"
   },
-  "R6sMIX": {
-    "defaultMessage": "Fediverse"
-  },
   "R7yHDl": {
     "defaultMessage": "Circle Revenue",
     "description": "src/components/Transaction/index.tsx"
@@ -3198,9 +3195,6 @@
   },
   "ob+HDS": {
     "defaultMessage": "View Circle"
-  },
-  "oh7tJ1": {
-    "defaultMessage": "Allow eligible public articles to be exported to Fediverse."
   },
   "ohbnFU": {
     "defaultMessage": "Social Login",

--- a/lang/en.json
+++ b/lang/en.json
@@ -1932,6 +1932,9 @@
   "Sj+TN8": {
     "defaultMessage": "Announcement"
   },
+  "Su1LcW": {
+    "defaultMessage": "開啟後，新發佈作品預設可輸出到 Fediverse。"
+  },
   "SuRTsQ": {
     "defaultMessage": "Register for ISCN"
   },
@@ -2264,6 +2267,9 @@
   },
   "Y9IYvj": {
     "defaultMessage": "No suitable channels"
+  },
+  "YC2b3b": {
+    "defaultMessage": "Fediverse 聯邦發佈"
   },
   "YDMrKK": {
     "defaultMessage": "Users"
@@ -3059,6 +3065,9 @@
     "defaultMessage": "Hottest",
     "description": "src/views/Circle/Analytics/ContentAnalytics/index.tsx"
   },
+  "mFn/Vv": {
+    "defaultMessage": "已更新 Fediverse 設定"
+  },
   "mJEqC/": {
     "defaultMessage": "Go to {href}"
   },
@@ -3595,6 +3604,9 @@
   },
   "vX2bDy": {
     "defaultMessage": "Collect Article"
+  },
+  "vXgChH": {
+    "defaultMessage": "操作失敗，請稍後再試"
   },
   "va8Rnw": {
     "defaultMessage": "The author has closed the comment section"

--- a/lang/en.json
+++ b/lang/en.json
@@ -1817,9 +1817,6 @@
     "defaultMessage": "Incorrect verification code",
     "description": "CODE_INVALID"
   },
-  "R6sMIX": {
-    "defaultMessage": "Fediverse"
-  },
   "R7yHDl": {
     "defaultMessage": "Circle Revenue",
     "description": "src/components/Transaction/index.tsx"
@@ -3198,9 +3195,6 @@
   },
   "ob+HDS": {
     "defaultMessage": "View Circle"
-  },
-  "oh7tJ1": {
-    "defaultMessage": "Allow eligible public articles to be exported to Fediverse."
   },
   "ohbnFU": {
     "defaultMessage": "Social Login",

--- a/lang/zh-Hans.json
+++ b/lang/zh-Hans.json
@@ -1817,9 +1817,6 @@
     "defaultMessage": "验证码错误",
     "description": "CODE_INVALID"
   },
-  "R6sMIX": {
-    "defaultMessage": "Fediverse"
-  },
   "R7yHDl": {
     "defaultMessage": "围炉营收",
     "description": "src/components/Transaction/index.tsx"
@@ -3198,9 +3195,6 @@
   },
   "ob+HDS": {
     "defaultMessage": "马上逛逛"
-  },
-  "oh7tJ1": {
-    "defaultMessage": "Allow eligible public articles to be exported to Fediverse."
   },
   "ohbnFU": {
     "defaultMessage": "社交登录",

--- a/lang/zh-Hans.json
+++ b/lang/zh-Hans.json
@@ -1932,6 +1932,9 @@
   "Sj+TN8": {
     "defaultMessage": "公告"
   },
+  "Su1LcW": {
+    "defaultMessage": "開啟後，新發佈作品預設可輸出到 Fediverse。"
+  },
   "SuRTsQ": {
     "defaultMessage": "注册 ISCN"
   },
@@ -2264,6 +2267,9 @@
   },
   "Y9IYvj": {
     "defaultMessage": "没有适合的频道"
+  },
+  "YC2b3b": {
+    "defaultMessage": "Fediverse 聯邦發佈"
   },
   "YDMrKK": {
     "defaultMessage": "用户"
@@ -3059,6 +3065,9 @@
     "defaultMessage": "站内阅读热门排行",
     "description": "src/views/Circle/Analytics/ContentAnalytics/index.tsx"
   },
+  "mFn/Vv": {
+    "defaultMessage": "已更新 Fediverse 設定"
+  },
   "mJEqC/": {
     "defaultMessage": "跳转至 {href}"
   },
@@ -3595,6 +3604,9 @@
   },
   "vX2bDy": {
     "defaultMessage": "关联作品"
+  },
+  "vXgChH": {
+    "defaultMessage": "操作失敗，請稍後再試"
   },
   "va8Rnw": {
     "defaultMessage": "作者已关闭评论区"

--- a/lang/zh-Hant.json
+++ b/lang/zh-Hant.json
@@ -1932,6 +1932,9 @@
   "Sj+TN8": {
     "defaultMessage": "公告"
   },
+  "Su1LcW": {
+    "defaultMessage": "開啟後，新發佈作品預設可輸出到 Fediverse。"
+  },
   "SuRTsQ": {
     "defaultMessage": "註冊 ISCN"
   },
@@ -2264,6 +2267,9 @@
   },
   "Y9IYvj": {
     "defaultMessage": "沒有適合的頻道"
+  },
+  "YC2b3b": {
+    "defaultMessage": "Fediverse 聯邦發佈"
   },
   "YDMrKK": {
     "defaultMessage": "用戶"
@@ -3059,6 +3065,9 @@
     "defaultMessage": "站內閱讀熱門排行",
     "description": "src/views/Circle/Analytics/ContentAnalytics/index.tsx"
   },
+  "mFn/Vv": {
+    "defaultMessage": "已更新 Fediverse 設定"
+  },
   "mJEqC/": {
     "defaultMessage": "跳轉至 {href}"
   },
@@ -3595,6 +3604,9 @@
   },
   "vX2bDy": {
     "defaultMessage": "關聯作品"
+  },
+  "vXgChH": {
+    "defaultMessage": "操作失敗，請稍後再試"
   },
   "va8Rnw": {
     "defaultMessage": "作者已關閉評論區"

--- a/lang/zh-Hant.json
+++ b/lang/zh-Hant.json
@@ -1817,9 +1817,6 @@
     "defaultMessage": "驗證碼錯誤",
     "description": "CODE_INVALID"
   },
-  "R6sMIX": {
-    "defaultMessage": "Fediverse"
-  },
   "R7yHDl": {
     "defaultMessage": "圍爐營收",
     "description": "src/components/Transaction/index.tsx"
@@ -3198,9 +3195,6 @@
   },
   "ob+HDS": {
     "defaultMessage": "馬上逛逛"
-  },
-  "oh7tJ1": {
-    "defaultMessage": "Allow eligible public articles to be exported to Fediverse."
   },
   "ohbnFU": {
     "defaultMessage": "社交登入",

--- a/src/common/utils/types/index.ts
+++ b/src/common/utils/types/index.ts
@@ -71,6 +71,11 @@ export default gql`
     updatedBy: ID
   }
 
+  type UserFeatures {
+    fediverseBeta: Boolean!
+    communityWatch: Boolean!
+  }
+
   type ArticleFederationSetting {
     articleId: ID!
     state: FederationArticleSettingState!
@@ -79,6 +84,7 @@ export default gql`
 
   extend type User {
     federationSetting: UserFederationSetting
+    features: UserFeatures!
   }
 
   extend type Article {

--- a/src/views/ArticleDetail/Edit/OptionContent/index.tsx
+++ b/src/views/ArticleDetail/Edit/OptionContent/index.tsx
@@ -219,22 +219,6 @@ const EditSensitive = ({
   )
 }
 
-const EditFederationSetting = ({
-  article,
-  federationSetting,
-  federationSettingSaving,
-  editFederationSetting,
-}: OptionItemProps) => {
-  return (
-    <Sidebar.FederationSetting
-      articleId={article.id}
-      federationSetting={federationSetting}
-      federationSettingSaving={federationSettingSaving}
-      editFederationSetting={editFederationSetting}
-    />
-  )
-}
-
 const EditCircle = ({
   circle,
   editAccess,

--- a/src/views/ArticleDetail/Edit/OptionContent/index.tsx
+++ b/src/views/ArticleDetail/Edit/OptionContent/index.tsx
@@ -18,7 +18,6 @@ import {
   DraftDetailViewerQueryQuery,
   EditorSelectCampaignFragment,
   FederationArticleSettingState,
-  UserFeatureFlagType,
 } from '~/gql/graphql'
 
 import { Article } from '..'
@@ -256,6 +255,22 @@ const EditCircle = ({
   )
 }
 
+const EditFederationSetting = ({
+  article,
+  federationSetting,
+  federationSettingSaving,
+  editFederationSetting,
+}: OptionItemProps) => {
+  return (
+    <Sidebar.FederationSetting
+      articleId={article.id}
+      federationSetting={federationSetting}
+      federationSettingSaving={federationSettingSaving}
+      editFederationSetting={editFederationSetting}
+    />
+  )
+}
+
 export const OptionContent = (
   props: OptionContentProps & {
     tab: OptionTab
@@ -267,9 +282,7 @@ export const OptionContent = (
   const isSettings = tab === 'settings'
   const hasOwnCollections = (props.ownCollections?.length || 0) > 0
   const hasOwnCircle = props.ownCircles && props.ownCircles.length >= 1
-  const isFediverseBeta = !!props.viewerData?.viewer?.oss?.featureFlags.some(
-    ({ type }) => type === UserFeatureFlagType.FediverseBeta
-  )
+  const isFediverseBeta = !!props.viewerData?.viewer?.features.fediverseBeta
   const disabled = false
 
   return (

--- a/src/views/Me/DraftDetail/OptionContent/index.tsx
+++ b/src/views/Me/DraftDetail/OptionContent/index.tsx
@@ -11,7 +11,6 @@ import {
   DigestRichCirclePublicFragment,
   DraftDetailViewerQueryQuery,
   EditorSelectCampaignFragment,
-  UserFeatureFlagType,
 } from '~/gql/graphql'
 import { EditMetaDraftFragment } from '~/gql/graphql'
 
@@ -242,9 +241,7 @@ export const OptionContent = (
   const isPublished = props.draft.publishState === 'published'
   const disabled = isPending || isPublished
   const hasOwnCollections = (props.ownCollections?.length || 0) > 0
-  const isFediverseBeta = !!props.draftViewer?.viewer?.oss?.featureFlags.some(
-    ({ type }) => type === UserFeatureFlagType.FediverseBeta
-  )
+  const isFediverseBeta = !!props.draftViewer?.viewer?.features.fediverseBeta
 
   return (
     <section>

--- a/src/views/Me/DraftDetail/gql.ts
+++ b/src/views/Me/DraftDetail/gql.ts
@@ -87,10 +87,8 @@ export const DRAFT_DETAIL_VIEWER = gql`
       }
       displayName
       avatar
-      oss {
-        featureFlags {
-          type
-        }
+      features {
+        fediverseBeta
       }
       collections(input: { first: 20, after: $collectionsAfter }) {
         pageInfo {

--- a/src/views/Me/Settings/Misc/FederationSetting.test.tsx
+++ b/src/views/Me/Settings/Misc/FederationSetting.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from '@testing-library/react'
+import { IntlProvider } from 'react-intl'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import FederationSetting from './FederationSetting'
+
+const useQuery = vi.fn()
+const messages = {
+  YC2b3b: 'Fediverse 聯邦發佈',
+}
+
+vi.mock('@apollo/client', () => ({
+  useQuery: () => useQuery(),
+}))
+
+vi.mock('~/components', () => ({
+  Switch: () => <input aria-label="Fediverse 聯邦發佈" type="checkbox" />,
+  TableView: {
+    Cell: ({ title }: { title: React.ReactNode }) => <div>{title}</div>,
+  },
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+  useMutation: () => [vi.fn(), { loading: false }],
+}))
+
+describe('<FederationSetting>', () => {
+  beforeEach(() => {
+    useQuery.mockReset()
+  })
+
+  it('does not render before viewer feature eligibility is confirmed', () => {
+    useQuery.mockReturnValue({ data: undefined, loading: true })
+
+    render(
+      <IntlProvider locale="zh-Hant" messages={messages}>
+        <FederationSetting />
+      </IntlProvider>
+    )
+
+    expect(screen.queryByText('Fediverse 聯邦發佈')).not.toBeInTheDocument()
+  })
+
+  it('renders for fediverse beta users', () => {
+    useQuery.mockReturnValue({
+      data: {
+        viewer: {
+          id: '1',
+          features: { fediverseBeta: true },
+          federationSetting: { state: 'disabled' },
+        },
+      },
+      loading: false,
+    })
+
+    render(
+      <IntlProvider locale="zh-Hant" messages={messages}>
+        <FederationSetting />
+      </IntlProvider>
+    )
+
+    expect(screen.getByText('Fediverse 聯邦發佈')).toBeInTheDocument()
+  })
+})

--- a/src/views/Me/Settings/Misc/FederationSetting.tsx
+++ b/src/views/Me/Settings/Misc/FederationSetting.tsx
@@ -8,7 +8,6 @@ import {
   FederationAuthorSettingState,
   SetViewerFederationSettingMutation,
   SetViewerFederationSettingMutationVariables,
-  UserFeatureFlagType,
   ViewerFederationSettingQuery,
 } from '~/gql/graphql'
 
@@ -16,13 +15,11 @@ const VIEWER_FEDERATION_SETTING = gql`
   query ViewerFederationSetting {
     viewer {
       id
+      features {
+        fediverseBeta
+      }
       federationSetting {
         state
-      }
-      oss {
-        featureFlags {
-          type
-        }
       }
     }
   }
@@ -52,9 +49,7 @@ const FederationSetting = () => {
   >(SET_VIEWER_FEDERATION_SETTING)
 
   const viewer = data?.viewer
-  const isFediverseBeta = !!viewer?.oss?.featureFlags.some(
-    ({ type }) => type === UserFeatureFlagType.FediverseBeta
-  )
+  const isFediverseBeta = !!viewer?.features.fediverseBeta
 
   useEffect(() => {
     if (viewer?.federationSetting?.state) {
@@ -89,38 +84,48 @@ const FederationSetting = () => {
         },
       })
       setSetting(state)
+      toast.success({
+        message: intl.formatMessage({
+          defaultMessage: '已更新 Fediverse 設定',
+          id: 'mFn/Vv',
+        }),
+      })
     } catch {
       toast.error({
-        message: (
-          <FormattedMessage
-            defaultMessage="Failed to edit, please try again."
-            id="USOHRK"
-          />
-        ),
+        message: intl.formatMessage({
+          defaultMessage: '操作失敗，請稍後再試',
+          id: 'vXgChH',
+        }),
       })
     }
   }
 
   return (
     <TableView.Cell
-      title={<FormattedMessage defaultMessage="Fediverse" id="R6sMIX" />}
+      title={
+        <FormattedMessage
+          defaultMessage="Fediverse 聯邦發佈"
+          id="YC2b3b"
+        />
+      }
       subtitle={
         <FormattedMessage
-          defaultMessage="Allow eligible public articles to be exported to Fediverse."
-          id="oh7tJ1"
+          defaultMessage="開啟後，新發佈作品預設可輸出到 Fediverse。"
+          id="Su1LcW"
         />
       }
       right={
         <Switch
-          name="fediverse"
-          label={intl.formatMessage({
-            defaultMessage: 'Fediverse',
-            id: 'R6sMIX',
-          })}
+          name="fediverse-federation-setting"
+          label={
+            <FormattedMessage
+              defaultMessage="Fediverse 聯邦發佈"
+              id="YC2b3b"
+            />
+          }
           checked={enabled}
-          onChange={updateSetting}
           loading={loading || saving}
-          disabled={loading || saving || !viewer?.id}
+          onChange={updateSetting}
         />
       }
     />

--- a/src/views/Me/Settings/Misc/FederationSetting.tsx
+++ b/src/views/Me/Settings/Misc/FederationSetting.tsx
@@ -57,7 +57,7 @@ const FederationSetting = () => {
     }
   }, [viewer?.federationSetting?.state])
 
-  if (!loading && !isFediverseBeta) {
+  if (!isFediverseBeta) {
     return null
   }
 
@@ -103,10 +103,7 @@ const FederationSetting = () => {
   return (
     <TableView.Cell
       title={
-        <FormattedMessage
-          defaultMessage="Fediverse 聯邦發佈"
-          id="YC2b3b"
-        />
+        <FormattedMessage defaultMessage="Fediverse 聯邦發佈" id="YC2b3b" />
       }
       subtitle={
         <FormattedMessage
@@ -118,10 +115,7 @@ const FederationSetting = () => {
         <Switch
           name="fediverse-federation-setting"
           label={
-            <FormattedMessage
-              defaultMessage="Fediverse 聯邦發佈"
-              id="YC2b3b"
-            />
+            <FormattedMessage defaultMessage="Fediverse 聯邦發佈" id="YC2b3b" />
           }
           checked={enabled}
           loading={loading || saving}


### PR DESCRIPTION
## Summary
- cherry-pick the Fediverse UI gate from master into develop
- use `viewer.features.fediverseBeta` for settings, draft, and article edit controls
- keep the no-flash loading behavior for the Fediverse settings row
- resolve develop conflicts without bringing back `viewer.oss.featureFlags` for user-facing controls

## Verification
- `npm run gen:type:prod && npm run i18n`
- `npm run test:unit -- src/views/Me/Settings/Misc/FederationSetting.test.tsx`
- `npm run lint:ts`

## Note
- codegen used production schema because `server.matters.icu` does not yet expose `User.features`; this PR should be paired after the matters-server develop sync PR deploys.