### PR TITLE
Gate Community Watch restore action to admin view

### DIFF
--- a/src/components/Comment/Content/Content.test.tsx
+++ b/src/components/Comment/Content/Content.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { cleanup, render, screen } from '~/common/utils/test'
 import { processViewer, ViewerContext } from '~/components'
@@ -8,6 +8,10 @@ import { MOCK_COMMENT, MOCK_USER } from '~/stories/mocks'
 import { CommentContent } from './'
 
 describe('<Comemnt.Content>', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
   it('should render a Comment.Content', () => {
     render(<CommentContent comment={MOCK_COMMENT} />)
 
@@ -95,7 +99,37 @@ describe('<Comemnt.Content>', () => {
     ).not.toBeInTheDocument()
   })
 
-  it('should render a Community Watch restore button for admins', () => {
+  it('should not render a Community Watch restore button for admins outside admin view', () => {
+    const admin = processViewer({
+      ...MOCK_USER,
+      status: {
+        ...MOCK_USER.status,
+        role: UserRole.Admin,
+      },
+    })
+
+    render(
+      <ViewerContext.Provider value={admin}>
+        <CommentContent
+          comment={{
+            ...MOCK_COMMENT,
+            state: CommentState.Banned,
+            communityWatchAction: {
+              uuid: 'community-watch-action-uuid',
+            },
+          }}
+        />
+      </ViewerContext.Provider>
+    )
+
+    expect(
+      screen.queryByRole('button', { name: /恢復留言|Restore comment/ })
+    ).not.toBeInTheDocument()
+  })
+
+  it('should render a Community Watch restore button for admins in admin view', () => {
+    vi.stubEnv('NEXT_PUBLIC_ADMIN_VIEW', 'true')
+
     const admin = processViewer({
       ...MOCK_USER,
       status: {

--- a/src/components/Comment/Content/index.tsx
+++ b/src/components/Comment/Content/index.tsx
@@ -28,6 +28,8 @@ import {
 import Collapsed from './Collapsed'
 import styles from './styles.module.css'
 
+const isAdminView = () => process.env.NEXT_PUBLIC_ADMIN_VIEW === 'true'
+
 interface ContentProps {
   comment: CommentContentCommentPublicFragment &
     Partial<CommentContentCommentPrivateFragment>
@@ -178,7 +180,7 @@ export const CommentContent = ({
             description="src/components/Comment/Content/index.tsx"
           />
         </Link>
-        {viewer.isAdmin && (
+        {isAdminView() && viewer.isAdmin && (
           <CommunityWatchRestoreButton
             commentId={comment.id}
             actionUuid={communityWatchAction.uuid}


### PR DESCRIPTION
## Summary\n- Show the Community Watch restore button only when the build is an admin view and the viewer is admin.\n- Add coverage for admin users outside admin view and inside admin view.\n\n## Validation\n- npm run test:unit -- src/components/Comment/Content/Content.test.tsx\n- npm run lint:ts\n- cp .env.prod .env.local && npm run build