### PR TITLE
Fix matters.icu viewer auth boundary

### DIFF
--- a/src/components/Comment/DropdownActions/DropdownActions.test.tsx
+++ b/src/components/Comment/DropdownActions/DropdownActions.test.tsx
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest'
 import { TEST_ID } from '~/common/enums'
 import { cleanup, fireEvent, render, screen } from '~/common/utils/test'
 import { processViewer, ViewerContext } from '~/components'
-import { CommentState, UserFeatureFlagType } from '~/gql/graphql'
+import { BadgeType, CommentState } from '~/gql/graphql'
 import { MOCK_COMMENT, MOCK_USER } from '~/stories/mocks'
 
 import DropdownActions from './'
@@ -88,14 +88,9 @@ describe('<Comment/DropdownActions>', () => {
   it('should render community watch actions for community watch members', async () => {
     const viewer = processViewer({
       ...MOCK_USER,
-      oss: {
-        ...MOCK_USER.oss,
-        featureFlags: [
-          {
-            __typename: 'UserFeatureFlag',
-            type: UserFeatureFlagType.CommunityWatch,
-          },
-        ],
+      info: {
+        ...MOCK_USER.info,
+        badges: [{ __typename: 'Badge', type: BadgeType.CommunityWatch }],
       },
     })
 

--- a/src/components/Context/Viewer/Viewer.test.tsx
+++ b/src/components/Context/Viewer/Viewer.test.tsx
@@ -1,17 +1,11 @@
-import { MockedProvider } from '@apollo/client/testing'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import { useContext } from 'react'
 import { describe, expect, it } from 'vitest'
 
-import { UserFeatureFlagType } from '~/gql/graphql'
+import { BadgeType } from '~/gql/graphql'
 import { MOCK_USER } from '~/stories/mocks'
 
-import {
-  processViewer,
-  VIEWER_FEATURE_FLAGS,
-  ViewerContext,
-  ViewerProvider,
-} from './'
+import { processViewer, ViewerContext, ViewerProvider } from './'
 
 const ViewerProbe = () => {
   const viewer = useContext(ViewerContext)
@@ -20,67 +14,39 @@ const ViewerProbe = () => {
 }
 
 describe('Viewer', () => {
-  it('treats missing OSS feature flags as not Community Watch', () => {
-    const viewer = { ...MOCK_USER, oss: undefined }
-
-    expect(processViewer(viewer).isCommunityWatch).toBe(false)
+  it('treats missing Community Watch badge as not Community Watch', () => {
+    expect(processViewer(MOCK_USER).isCommunityWatch).toBe(false)
   })
 
-  it('detects Community Watch from optional OSS feature flags', () => {
+  it('detects Community Watch from the public user badge', () => {
     expect(
       processViewer({
         ...MOCK_USER,
-        oss: {
-          ...MOCK_USER.oss,
-          featureFlags: [
-            {
-              __typename: 'UserFeatureFlag',
-              type: UserFeatureFlagType.CommunityWatch,
-            },
-          ],
+        info: {
+          ...MOCK_USER.info,
+          badges: [{ __typename: 'Badge', type: BadgeType.CommunityWatch }],
         },
       }).isCommunityWatch
     ).toBe(true)
   })
 
-  it('loads Community Watch feature flags outside the root query', async () => {
-    const viewer = { ...MOCK_USER, oss: undefined }
-
+  it('provides Community Watch state without an extra OSS query', () => {
     render(
-      <MockedProvider
-        mocks={[
+      <ViewerProvider
+        viewer={
           {
-            request: { query: VIEWER_FEATURE_FLAGS },
-            result: {
-              data: {
-                viewer: {
-                  __typename: 'User',
-                  id: viewer.id,
-                  oss: {
-                    __typename: 'UserOSS',
-                    featureFlags: [
-                      {
-                        __typename: 'UserFeatureFlag',
-                        type: UserFeatureFlagType.CommunityWatch,
-                      },
-                    ],
-                  },
-                },
-              },
+            ...MOCK_USER,
+            info: {
+              ...MOCK_USER.info,
+              badges: [{ __typename: 'Badge', type: BadgeType.CommunityWatch }],
             },
-          },
-        ]}
+          } as never
+        }
       >
-        <ViewerProvider viewer={viewer as never}>
-          <ViewerProbe />
-        </ViewerProvider>
-      </MockedProvider>
+        <ViewerProbe />
+      </ViewerProvider>
     )
 
-    expect(screen.getByText('no')).toBeInTheDocument()
-
-    await waitFor(() => {
-      expect(screen.getByText('yes')).toBeInTheDocument()
-    })
+    expect(screen.getByText('yes')).toBeInTheDocument()
   })
 })

--- a/src/components/Context/Viewer/index.tsx
+++ b/src/components/Context/Viewer/index.tsx
@@ -1,34 +1,13 @@
-import { useQuery } from '@apollo/client'
 import * as Sentry from '@sentry/nextjs'
 import gql from 'graphql-tag'
 import React from 'react'
 
 import {
-  UserFeatureFlagType,
   ViewerUserPrivateFragment,
   ViewerUserPublicFragment,
 } from '~/gql/graphql'
 
 export type ViewerUser = ViewerUserPublicFragment & ViewerUserPrivateFragment
-
-type ViewerFeatureFlags = {
-  __typename?: string
-  featureFlags: Array<{
-    __typename?: string
-    type: UserFeatureFlagType
-  }>
-}
-
-type ViewerUserWithOptionalOss = ViewerUser & {
-  oss?: ViewerFeatureFlags
-}
-
-type ViewerFeatureFlagsQuery = {
-  viewer?: {
-    id: string
-    oss?: ViewerFeatureFlags
-  } | null
-}
 
 const ViewerFragments = {
   user: {
@@ -110,20 +89,7 @@ const ViewerFragments = {
   },
 }
 
-export const VIEWER_FEATURE_FLAGS = gql`
-  query ViewerFeatureFlags {
-    viewer {
-      id
-      oss {
-        featureFlags {
-          type
-        }
-      }
-    }
-  }
-`
-
-export type Viewer = ViewerUserWithOptionalOss & {
+export type Viewer = ViewerUser & {
   isAuthed: boolean
   isActive: boolean
   isArchived: boolean
@@ -136,7 +102,7 @@ export type Viewer = ViewerUserWithOptionalOss & {
   shouldSetupLikerID: boolean
 }
 
-export const processViewer = (viewer: ViewerUserWithOptionalOss): Viewer => {
+export const processViewer = (viewer: ViewerUser): Viewer => {
   // User state
   const isAuthed = !!viewer.id
   const state = viewer?.status?.state
@@ -146,9 +112,8 @@ export const processViewer = (viewer: ViewerUserWithOptionalOss): Viewer => {
   const isFrozen = state === 'frozen'
   const isInactive = isAuthed && (isBanned || isFrozen || isArchived)
   const isCivicLiker = viewer.liker.civicLiker
-  const isCommunityWatch = !!viewer.oss?.featureFlags.some(
-    ({ type }) => type === UserFeatureFlagType.CommunityWatch
-  )
+  const isCommunityWatch =
+    viewer.info.badges?.some(({ type }) => type === 'community_watch') ?? false
   const isAdmin = viewer.status?.role === 'admin'
   const shouldSetupLikerID = isAuthed && !viewer.liker.likerId
 
@@ -187,19 +152,10 @@ export const ViewerProvider = ({
   viewer,
 }: {
   children: React.ReactNode
-  viewer: ViewerUserWithOptionalOss
+  viewer: ViewerUser
 }) => {
-  const shouldFetchFeatureFlags = !!viewer.id && !viewer.oss
-  const { data } = useQuery<ViewerFeatureFlagsQuery>(VIEWER_FEATURE_FLAGS, {
-    skip: !shouldFetchFeatureFlags,
-    errorPolicy: 'ignore',
-  })
-  const viewerWithFeatureFlags = data?.viewer?.oss
-    ? { ...viewer, oss: data.viewer.oss }
-    : viewer
-
   return (
-    <ViewerContext.Provider value={processViewer(viewerWithFeatureFlags)}>
+    <ViewerContext.Provider value={processViewer(viewer)}>
       {children}
     </ViewerContext.Provider>
   )


### PR DESCRIPTION
## Summary
- remove the post-login ViewerFeatureFlags query that hits viewer.oss for general users
- derive Community Watch viewer state from the public badge already present in the root viewer fragment
- update Viewer and comment dropdown tests to cover the badge-based path

## Verification
- npm run test:unit -- src/components/Context/Viewer/Viewer.test.tsx src/components/Comment/DropdownActions/DropdownActions.test.tsx
- npm run lint:ts -- --no-cache
- commit hook: format, i18n, lint

## Context
matters.icu is still failing for normal logged-in users after #5907 because the root query no longer fetches viewer.oss, but ViewerProvider immediately adds a follow-up ViewerFeatureFlags query for any logged-in viewer without oss. That follow-up query still reaches the admin-only viewer.oss field and can block normal users.