### PR TITLE
Return Community Watch restore appeal state

### DIFF
--- a/src/components/Comment/Content/index.tsx
+++ b/src/components/Comment/Content/index.tsx
@@ -70,6 +70,7 @@ const RESTORE_COMMUNITY_WATCH_COMMENT = gql`
     restoreCommunityWatchComment(input: { uuid: $uuid, note: $note }) {
       uuid
       actionState
+      appealState
       reviewState
       commentId
     }


### PR DESCRIPTION
## Summary
- include appealState in restoreCommunityWatchComment mutation result so the client receives the full restored audit state

## Tests
- npm run gen:type:prod
- npm run i18n
- npm run test:unit -- src/components/Comment/Content/Content.test.tsx
- npm run lint:ts