### PR TITLE
feat: add personhood PWA feasibility gate

### DIFF
--- a/configs/csp.ts
+++ b/configs/csp.ts
@@ -13,8 +13,21 @@ export const SENTRY_CSP_REPORT_GROUP = 'csp-endpoint'
 
 const DEFAULT_SRC = ["'self'", process.env.NEXT_PUBLIC_NEXT_ASSET_DOMAIN]
 
+const getCspHost = (url?: string) => {
+  if (!url) {
+    return undefined
+  }
+
+  try {
+    return new URL(url).hostname
+  } catch {
+    return url
+  }
+}
+
 const SCRIPT_SRC = [
   "'self'",
+  "'wasm-unsafe-eval'",
 
   // Next.js Assets
   process.env.NEXT_PUBLIC_NEXT_ASSET_DOMAIN,
@@ -121,6 +134,8 @@ const CONNECT_SRC = [
 
   // Next.js Assets
   process.env.NEXT_PUBLIC_NEXT_ASSET_DOMAIN,
+  getCspHost(process.env.NEXT_PUBLIC_PERSONHOOD_ASSET_URL),
+  getCspHost(process.env.NEXT_PUBLIC_PERSONHOOD_VERIFIER_URL),
 
   // API
   process.env.NEXT_PUBLIC_API_URL,
@@ -213,6 +228,8 @@ const PREFETCH_SRC = [
   process.env.NEXT_PUBLIC_NEXT_ASSET_DOMAIN,
 ]
 
+const WORKER_SRC = ["'self'", 'blob:']
+
 export const CSP_POLICY = Object.entries({
   'default-src': DEFAULT_SRC,
   'script-src': SCRIPT_SRC,
@@ -223,6 +240,7 @@ export const CSP_POLICY = Object.entries({
   'connect-src': CONNECT_SRC,
   'frame-src': FRAME_SRC,
   'prefetch-src': PREFETCH_SRC,
+  'worker-src': WORKER_SRC,
   'report-uri': SENTRY_REPORT_URI,
   'report-to': SENTRY_CSP_REPORT_GROUP,
 })

--- a/next.config.ts
+++ b/next.config.ts
@@ -11,6 +11,8 @@ import {
 
 const isLocal = process.env.NEXT_PUBLIC_RUNTIME_ENV === 'local'
 const nextAssetDomain = process.env.NEXT_PUBLIC_NEXT_ASSET_DOMAIN || ''
+const personhoodCrossOriginIsolated =
+  process.env.NEXT_PUBLIC_PERSONHOOD_CROSS_ORIGIN_ISOLATED === 'true'
 
 const nextConfig: NextConfig = {
   experimental: {
@@ -22,6 +24,23 @@ const nextConfig: NextConfig = {
 
   headers: async () => {
     return [
+      ...(personhoodCrossOriginIsolated
+        ? [
+            {
+              source: '/me/settings/personhood/feasibility',
+              headers: [
+                {
+                  key: 'Cross-Origin-Opener-Policy',
+                  value: 'same-origin',
+                },
+                {
+                  key: 'Cross-Origin-Embedder-Policy',
+                  value: 'require-corp',
+                },
+              ],
+            },
+          ]
+        : []),
       {
         source: '/(.*)',
         headers: [

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,5 +1,5 @@
 {
-  "Scope": "/",
+  "scope": "/",
   "background_color": "#ffffff",
   "description": "Matters 致力搭建去中心化的寫作社群與內容生態。基於 IPFS 技術，令創作不受制於任何平台，獨立性得到保障；引入加密貨幣，以收入的形式回饋給作者；代碼開源，建立創作者自治社區。",
   "display": "standalone",

--- a/src/common/enums/route.ts
+++ b/src/common/enums/route.ts
@@ -59,6 +59,7 @@ type ROUTE_KEY =
   | 'ME_SETTINGS_NOTIFICATIONS'
   | 'ME_SETTINGS_MISC'
   | 'ME_SETTINGS_BLOCKED'
+  | 'ME_SETTINGS_PERSONHOOD_FEASIBILITY'
   | 'ME_DRAFT_NEW'
   | 'ME_DRAFT_DETAIL'
   | 'ME_DRAFT_DETAIL_OPTIONS'
@@ -113,6 +114,10 @@ export const PROTECTED_ROUTES: {
     pathname: '/me/settings/misc',
   },
   { key: 'ME_SETTINGS_BLOCKED', pathname: '/me/settings/blocked' },
+  {
+    key: 'ME_SETTINGS_PERSONHOOD_FEASIBILITY',
+    pathname: '/me/settings/personhood/feasibility',
+  },
 
   // Article
   { key: 'ARTICLE_DETAIL_EDIT', pathname: '/a/[shortHash]/edit' },

--- a/src/components/Dialogs/SubmitReportDialog/Dialog.tsx
+++ b/src/components/Dialogs/SubmitReportDialog/Dialog.tsx
@@ -38,10 +38,10 @@ const Reasons = {
     />
   ),
   [ReportReason.CommunityWatchPornAd]: (
-    <FormattedMessage defaultMessage="Pornographic advertising" id="7wo7pQ" />
+    <FormattedMessage defaultMessage="Pornographic advertising" id="USq+mM" />
   ),
   [ReportReason.CommunityWatchSpamAd]: (
-    <FormattedMessage defaultMessage="Spam advertising" id="qFeujU" />
+    <FormattedMessage defaultMessage="Spam advertising" id="scWFV3" />
   ),
   [ReportReason.Other]: (
     <FormattedMessage defaultMessage="Other malicious behavior" id="yOhatg" />

--- a/src/components/Dialogs/SubmitReportDialog/Dialog.tsx
+++ b/src/components/Dialogs/SubmitReportDialog/Dialog.tsx
@@ -40,6 +40,9 @@ const Reasons = {
   [ReportReason.CommunityWatchPornAd]: (
     <FormattedMessage defaultMessage="Pornographic advertising" id="7wo7pQ" />
   ),
+  [ReportReason.CommunityWatchSpamAd]: (
+    <FormattedMessage defaultMessage="Spam advertising" id="qFeujU" />
+  ),
   [ReportReason.Other]: (
     <FormattedMessage defaultMessage="Other malicious behavior" id="yOhatg" />
   ),

--- a/src/components/Dialogs/SubmitReportDialog/Dialog.tsx
+++ b/src/components/Dialogs/SubmitReportDialog/Dialog.tsx
@@ -37,6 +37,9 @@ const Reasons = {
       id="e3qUqn"
     />
   ),
+  [ReportReason.CommunityWatchPornAd]: (
+    <FormattedMessage defaultMessage="Pornographic advertising" id="7wo7pQ" />
+  ),
   [ReportReason.Other]: (
     <FormattedMessage defaultMessage="Other malicious behavior" id="yOhatg" />
   ),

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -72,6 +72,7 @@ const useLayoutType = () => {
     isInPath('ME_SETTINGS_NOTIFICATIONS_CIRCLE') ||
     isInPath('ME_SETTINGS_MISC') ||
     isInPath('ME_SETTINGS_BLOCKED') ||
+    isInPath('ME_SETTINGS_PERSONHOOD_FEASIBILITY') ||
     isInPath('ME_DRAFT_DETAIL') ||
     // Moment
     isInPath('MOMENT_DETAIL') ||

--- a/src/pages/api/personhood/tw-fido/result.ts
+++ b/src/pages/api/personhood/tw-fido/result.ts
@@ -1,0 +1,125 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+import {
+  assertTwFidoEnabled,
+  decodeSpTicket,
+  getSignResult,
+  getTwFidoConfig,
+  isPendingSignResult,
+} from '~/server/personhood/twFido'
+
+type ResultBody = {
+  spTicket?: unknown
+}
+
+type ResultResponse =
+  | {
+      cert?: string
+      certSize: number
+      signedResponse?: string
+      signedResponseSize: number
+      status: 'signed'
+    }
+  | {
+      errorCode: string
+      message?: string
+      status: 'pending'
+    }
+  | {
+      error: string
+    }
+
+const handler = async (
+  req: NextApiRequest,
+  res: NextApiResponse<ResultResponse>
+) => {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST')
+    res.status(405).json({ error: 'method_not_allowed' })
+    return
+  }
+
+  if (!isSameOriginRequest(req)) {
+    res.status(403).json({ error: 'forbidden_origin' })
+    return
+  }
+
+  try {
+    assertTwFidoEnabled()
+
+    const body = parseBody(req.body)
+    if (typeof body.spTicket !== 'string') {
+      res.status(400).json({ error: 'missing_sp_ticket' })
+      return
+    }
+
+    const config = getTwFidoConfig()
+    const ticketPayload = decodeSpTicket(body.spTicket)
+    const result = await getSignResult({ config, ticketPayload })
+
+    if (result.error_code !== '0') {
+      if (isPendingSignResult(result.error_code)) {
+        res.status(200).json({
+          errorCode: result.error_code,
+          message: result.error_message,
+          status: 'pending',
+        })
+        return
+      }
+
+      res.status(502).json({
+        error: `getAthOrSignResult failed: ${result.error_code} ${
+          result.error_message || ''
+        }`.trim(),
+      })
+      return
+    }
+
+    const cert = result.result?.cert
+    const signedResponse = result.result?.signed_response
+    if (!cert || !signedResponse) {
+      res.status(502).json({ error: 'missing_sign_result_payload' })
+      return
+    }
+
+    res.status(200).json({
+      cert: config.returnProofInput ? cert : undefined,
+      certSize: Buffer.byteLength(cert, 'base64'),
+      signedResponse: config.returnProofInput ? signedResponse : undefined,
+      signedResponseSize: Buffer.byteLength(signedResponse, 'base64'),
+      status: 'signed',
+    })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'unknown_error'
+    res
+      .status(message === 'personhood_tw_fido_disabled' ? 404 : 500)
+      .json({ error: message })
+  }
+}
+
+export default handler
+
+const parseBody = (body: unknown): ResultBody => {
+  if (typeof body === 'string') {
+    return JSON.parse(body) as ResultBody
+  }
+  return (body || {}) as ResultBody
+}
+
+const isSameOriginRequest = (req: NextApiRequest) => {
+  const origin = req.headers.origin
+  if (!origin) {
+    return true
+  }
+
+  const host = req.headers.host
+  if (!host) {
+    return false
+  }
+
+  try {
+    return new URL(origin).host === host
+  } catch {
+    return false
+  }
+}

--- a/src/pages/api/personhood/tw-fido/sp-ticket.ts
+++ b/src/pages/api/personhood/tw-fido/sp-ticket.ts
@@ -1,0 +1,126 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+import {
+  assertTwFidoEnabled,
+  buildTwFidoDeeplink,
+  createSpTicket,
+  getTwFidoConfig,
+  normalizeTwFidoIdNum,
+} from '~/server/personhood/twFido'
+
+type SpTicketBody = {
+  idNum?: unknown
+  returnUrl?: unknown
+}
+
+type SpTicketResponse =
+  | {
+      appId: string
+      apiBaseUrl: string
+      deeplink: string
+      expiresAt?: string
+      signType: string
+      spTicket: string
+      spTicketId: string
+      status: 'ticket_created'
+      transactionId: string
+    }
+  | {
+      error: string
+    }
+
+const handler = async (
+  req: NextApiRequest,
+  res: NextApiResponse<SpTicketResponse>
+) => {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST')
+    res.status(405).json({ error: 'method_not_allowed' })
+    return
+  }
+
+  if (!isSameOriginRequest(req)) {
+    res.status(403).json({ error: 'forbidden_origin' })
+    return
+  }
+
+  try {
+    assertTwFidoEnabled()
+
+    const body = parseBody(req.body)
+    const idNum = normalizeTwFidoIdNum(body.idNum)
+    if (!idNum) {
+      res.status(400).json({ error: 'invalid_id_num' })
+      return
+    }
+
+    const returnUrl =
+      typeof body.returnUrl === 'string' && isAllowedReturnUrl(body.returnUrl)
+        ? body.returnUrl
+        : `https://${req.headers.host}/me/settings/personhood/feasibility`
+
+    const config = getTwFidoConfig()
+    const ticket = await createSpTicket({ config, idNum })
+    const deeplink = buildTwFidoDeeplink({
+      returnUrl,
+      spTicket: ticket.spTicket,
+    })
+
+    res.status(200).json({
+      apiBaseUrl: config.apiBaseUrl,
+      appId: config.appId,
+      deeplink,
+      expiresAt: ticket.ticketPayload.expiration_time,
+      signType: config.signType,
+      spTicket: ticket.spTicket,
+      spTicketId: ticket.ticketPayload.sp_ticket_id,
+      status: 'ticket_created',
+      transactionId: ticket.ticketPayload.transaction_id,
+    })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'unknown_error'
+    res
+      .status(message === 'personhood_tw_fido_disabled' ? 404 : 500)
+      .json({ error: message })
+  }
+}
+
+export default handler
+
+const parseBody = (body: unknown): SpTicketBody => {
+  if (typeof body === 'string') {
+    return JSON.parse(body) as SpTicketBody
+  }
+  return (body || {}) as SpTicketBody
+}
+
+const isAllowedReturnUrl = (value: string) => {
+  try {
+    const url = new URL(value)
+    return (
+      url.protocol === 'https:' ||
+      (url.protocol === 'http:' &&
+        (url.hostname === 'localhost' || url.hostname === '127.0.0.1'))
+    )
+  } catch {
+    return false
+  }
+}
+
+const isSameOriginRequest = (req: NextApiRequest) => {
+  const origin = req.headers.origin
+  if (!origin) {
+    return true
+  }
+
+  const host = req.headers.host
+  if (!host) {
+    return false
+  }
+
+  try {
+    return new URL(origin).host === host
+  } catch {
+    return false
+  }
+}

--- a/src/pages/me/settings/personhood/feasibility.tsx
+++ b/src/pages/me/settings/personhood/feasibility.tsx
@@ -1,0 +1,10 @@
+import { Protected } from '~/components'
+import PersonhoodFeasibility from '~/views/Me/Settings/Personhood/Feasibility'
+
+const ProtectedPersonhoodFeasibility = () => (
+  <Protected>
+    <PersonhoodFeasibility />
+  </Protected>
+)
+
+export default ProtectedPersonhoodFeasibility

--- a/src/server/personhood/twFido.ts
+++ b/src/server/personhood/twFido.ts
@@ -64,8 +64,12 @@ export const normalizeTwFidoIdNum = (idNum: unknown) => {
 }
 
 export const getTwFidoConfig = (): TwFidoConfig => {
-  const serviceId = process.env.PERSONHOOD_FIDO_SP_SERVICE_ID
-  const aesKeyBase64 = process.env.PERSONHOOD_FIDO_AES_KEY_BASE64
+  const serviceId =
+    process.env.PERSONHOOD_FIDO_SP_SERVICE_ID || process.env.FIDO_SP_SERVICE_ID
+  const aesKeyBase64 =
+    process.env.PERSONHOOD_FIDO_AES_KEY_BASE64 ||
+    process.env.FIDO_AES_KEY_BASE64 ||
+    process.env.FIDO_AES_KEY
 
   if (!serviceId || !aesKeyBase64) {
     throw new Error('personhood_tw_fido_missing_config')

--- a/src/server/personhood/twFido.ts
+++ b/src/server/personhood/twFido.ts
@@ -1,0 +1,287 @@
+import crypto from 'node:crypto'
+
+const DEFAULT_API_BASE_URL = 'https://fidoapi.moi.gov.tw'
+const DEFAULT_APP_ID = 'e775f2805fb993e05a208dbff15d1c1'
+const DEFAULT_HINT = '待簽署資料'
+const DEFAULT_SIGN_TYPE = 'PKCS#1'
+const DEFAULT_TIME_LIMIT = '600'
+
+const PENDING_RESULT_CODES = new Set([
+  '20002',
+  '20003',
+  'SP-API-ATH-02-SPTKTID_TXNLOG_NF',
+  'SPTKTID_TXNLOG_NF',
+])
+
+export type TwFidoTicketPayload = {
+  transaction_id: string
+  sp_ticket_id: string
+  expiration_time?: string
+  sp_name?: string
+}
+
+export type TwFidoSignResult = {
+  error_code: string
+  error_message?: string
+  result?: {
+    cert?: string
+    hashed_id_num?: string
+    idp_checksum?: string
+    signed_response?: string
+  }
+}
+
+type TwFidoTicketResponse = {
+  error_code: string
+  error_message?: string
+  result?: {
+    sp_ticket?: string
+  }
+}
+
+export type TwFidoConfig = {
+  aesKeyBase64: string
+  apiBaseUrl: string
+  appId: string
+  hint: string
+  returnProofInput: boolean
+  serviceId: string
+  signType: 'PKCS#1' | 'PKCS#7' | 'RAW'
+  timeLimit: string
+}
+
+export const normalizeTwFidoIdNum = (idNum: unknown) => {
+  if (typeof idNum !== 'string') {
+    return null
+  }
+
+  const normalized = idNum.trim().toUpperCase()
+  if (!/^[A-Z][0-9A-Z]{9}$/.test(normalized)) {
+    return null
+  }
+
+  return normalized
+}
+
+export const getTwFidoConfig = (): TwFidoConfig => {
+  const serviceId = process.env.PERSONHOOD_FIDO_SP_SERVICE_ID
+  const aesKeyBase64 = process.env.PERSONHOOD_FIDO_AES_KEY_BASE64
+
+  if (!serviceId || !aesKeyBase64) {
+    throw new Error('personhood_tw_fido_missing_config')
+  }
+
+  const appId = process.env.PERSONHOOD_APP_ID || DEFAULT_APP_ID
+  if (Buffer.byteLength(appId, 'utf8') !== 31) {
+    throw new Error('personhood_tw_fido_invalid_app_id')
+  }
+
+  const signType = process.env.PERSONHOOD_FIDO_SIGN_TYPE || DEFAULT_SIGN_TYPE
+  if (signType !== 'PKCS#1' && signType !== 'PKCS#7' && signType !== 'RAW') {
+    throw new Error('personhood_tw_fido_invalid_sign_type')
+  }
+
+  const apiBaseUrl =
+    process.env.PERSONHOOD_FIDO_API_BASE_URL || DEFAULT_API_BASE_URL
+
+  return {
+    aesKeyBase64,
+    apiBaseUrl: apiBaseUrl.replace(/\/$/, ''),
+    appId,
+    hint: process.env.PERSONHOOD_FIDO_HINT || DEFAULT_HINT,
+    returnProofInput:
+      process.env.PERSONHOOD_TW_FIDO_RETURN_PROOF_INPUT === 'true',
+    serviceId,
+    signType,
+    timeLimit: process.env.PERSONHOOD_FIDO_TIME_LIMIT || DEFAULT_TIME_LIMIT,
+  }
+}
+
+export const assertTwFidoEnabled = () => {
+  if (process.env.PERSONHOOD_TW_FIDO_ENABLED !== 'true') {
+    throw new Error('personhood_tw_fido_disabled')
+  }
+}
+
+export const buildSignData = (appId: string) =>
+  Buffer.from(appId, 'utf8').toString('base64')
+
+export const decodeSpTicket = (spTicket: string): TwFidoTicketPayload => {
+  const separator = spTicket.lastIndexOf('.')
+  if (separator < 0) {
+    throw new Error('personhood_tw_fido_invalid_sp_ticket')
+  }
+
+  const payload = JSON.parse(
+    Buffer.from(spTicket.slice(0, separator), 'base64url').toString('utf8')
+  ) as Partial<TwFidoTicketPayload>
+
+  if (!payload.transaction_id || !payload.sp_ticket_id) {
+    throw new Error('personhood_tw_fido_invalid_sp_ticket_payload')
+  }
+
+  return {
+    expiration_time: payload.expiration_time,
+    sp_name: payload.sp_name,
+    sp_ticket_id: payload.sp_ticket_id,
+    transaction_id: payload.transaction_id,
+  }
+}
+
+export const buildTwFidoDeeplink = ({
+  returnUrl,
+  returnValue,
+  spTicket,
+}: {
+  returnUrl: string
+  returnValue?: string
+  spTicket: string
+}) => {
+  const deeplink = new URL('mobilemoica://moica.moi.gov.tw/a2a/verifySign')
+  deeplink.searchParams.set('sp_ticket', spTicket)
+  deeplink.searchParams.set(
+    'rtn_url',
+    Buffer.from(returnUrl, 'utf8').toString('base64url')
+  )
+  deeplink.searchParams.set(
+    'rtn_val',
+    Buffer.from(returnValue || '', 'utf8').toString('base64url')
+  )
+  return deeplink.toString()
+}
+
+export const createSpTicket = async ({
+  config,
+  idNum,
+}: {
+  config: TwFidoConfig
+  idNum: string
+}) => {
+  const transactionId = crypto.randomUUID()
+  const signData = buildSignData(config.appId)
+  const checksumPayload = [
+    transactionId,
+    config.serviceId,
+    idNum,
+    'SIGN',
+    'APP2APP',
+    config.hint,
+    signData,
+  ].join('')
+
+  const body = {
+    hint: config.hint,
+    id_num: idNum,
+    op_code: 'SIGN',
+    op_mode: 'APP2APP',
+    sign_info: {
+      hash_algorithm: 'SHA256',
+      sign_data: signData,
+      sign_type: config.signType,
+      tbs_encoding: 'base64',
+    },
+    sp_checksum: computeSpChecksum(checksumPayload, config.aesKeyBase64),
+    sp_service_id: config.serviceId,
+    time_limit: config.timeLimit,
+    transaction_id: transactionId,
+  }
+
+  const json = await postJson<TwFidoTicketResponse>(
+    `${config.apiBaseUrl}/moise/sp/getSpTicket`,
+    body
+  )
+  if (json.error_code !== '0') {
+    throw new Error(
+      `getSpTicket failed: ${json.error_code} ${
+        json.error_message || ''
+      }`.trim()
+    )
+  }
+
+  const spTicket = json.result?.sp_ticket
+  if (!spTicket || typeof spTicket !== 'string') {
+    throw new Error('personhood_tw_fido_missing_sp_ticket')
+  }
+
+  return {
+    spTicket,
+    ticketPayload: decodeSpTicket(spTicket),
+  }
+}
+
+export const getSignResult = async ({
+  config,
+  ticketPayload,
+}: {
+  config: TwFidoConfig
+  ticketPayload: TwFidoTicketPayload
+}) => {
+  const checksumPayload = [
+    ticketPayload.transaction_id,
+    config.serviceId,
+    ticketPayload.sp_ticket_id,
+  ].join('')
+
+  return postJson<TwFidoSignResult>(
+    `${config.apiBaseUrl}/moise/sp/getAthOrSignResult`,
+    {
+      sp_checksum: computeSpChecksum(checksumPayload, config.aesKeyBase64),
+      sp_service_id: config.serviceId,
+      sp_ticket_id: ticketPayload.sp_ticket_id,
+      transaction_id: ticketPayload.transaction_id,
+    }
+  )
+}
+
+export const isPendingSignResult = (errorCode: string) =>
+  PENDING_RESULT_CODES.has(errorCode)
+
+const normalizeAesKey = (base64: string) => {
+  const key = Buffer.from(base64, 'base64')
+  if (key.length !== 32) {
+    throw new Error('personhood_tw_fido_invalid_aes_key')
+  }
+  return key
+}
+
+const computeSpChecksum = (payload: string, aesKeyBase64: string) => {
+  const key = normalizeAesKey(aesKeyBase64)
+  const sha256Hex = crypto
+    .createHash('sha256')
+    .update(payload, 'utf8')
+    .digest('hex')
+  const iv = Buffer.alloc(12)
+  const cipher = crypto.createCipheriv('aes-256-gcm', key, iv, {
+    authTagLength: 16,
+  })
+  const ciphertext = Buffer.concat([
+    cipher.update(Buffer.from(sha256Hex, 'utf8')),
+    cipher.final(),
+  ])
+  const tag = cipher.getAuthTag()
+
+  return Buffer.concat([iv, ciphertext, tag]).toString('hex')
+}
+
+const postJson = async <T>(url: string, body: object): Promise<T> => {
+  const response = await fetch(url, {
+    body: JSON.stringify(body),
+    headers: {
+      'content-type': 'application/json; charset=utf-8',
+    },
+    method: 'POST',
+  })
+  const text = await response.text()
+
+  let json: unknown
+  try {
+    json = JSON.parse(text)
+  } catch {
+    throw new Error(`tw_fido_invalid_json_response_${response.status}`)
+  }
+
+  if (!response.ok) {
+    throw new Error(`tw_fido_http_${response.status}`)
+  }
+  return json as T
+}

--- a/src/views/Me/Settings/Personhood/Feasibility/index.tsx
+++ b/src/views/Me/Settings/Personhood/Feasibility/index.tsx
@@ -132,7 +132,7 @@ const PersonhoodFeasibility = () => {
     proofInputReady: false,
     status: 'idle',
   })
-  const pollingRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const pollingRef = useRef<number | null>(null)
 
   const reportText = useMemo(() => JSON.stringify(report, null, 2), [report])
   const canCreateTicket =

--- a/src/views/Me/Settings/Personhood/Feasibility/index.tsx
+++ b/src/views/Me/Settings/Personhood/Feasibility/index.tsx
@@ -1,0 +1,317 @@
+import { useCallback, useMemo, useState } from 'react'
+import { FormattedMessage, useIntl } from 'react-intl'
+
+import { Head, Layout, Spacer } from '~/components'
+
+import SettingsTabs from '../../SettingsTabs'
+import settingsStyles from '../../styles.module.css'
+import styles from './styles.module.css'
+
+type StorageEstimateReport = {
+  quota?: number
+  usage?: number
+  available?: number
+}
+
+type WasmProbeReport = {
+  startedAt: string
+  endedAt?: string
+  completed?: boolean
+  totalBytes?: number
+  error?: string
+  allocations: Array<{
+    round: number
+    bytes: number
+    totalBytes: number
+  }>
+}
+
+type FeasibilityReport = {
+  startedAt: string
+  userAgent: string
+  platform: string
+  language: string
+  standalone: boolean
+  secureContext: boolean
+  crossOriginIsolated: boolean
+  checks: {
+    webAssembly?: boolean
+    serviceWorker?: boolean
+    indexedDB?: boolean
+    storageManager?: boolean
+    hardwareConcurrency?: number | null
+    deviceMemory?: number | null
+    storageEstimate?: StorageEstimateReport
+    wasmMemoryProbe?: WasmProbeReport
+  }
+}
+
+const bytesToMiB = (bytes?: number) => {
+  if (!bytes) {
+    return '0 MiB'
+  }
+  return `${Math.round(bytes / 1024 / 1024)} MiB`
+}
+
+const createInitialReport = (): FeasibilityReport => {
+  if (typeof window === 'undefined') {
+    return {
+      startedAt: '',
+      userAgent: '',
+      platform: '',
+      language: '',
+      standalone: false,
+      secureContext: false,
+      crossOriginIsolated: false,
+      checks: {},
+    }
+  }
+
+  const nav = window.navigator as Navigator & { standalone?: boolean }
+
+  return {
+    startedAt: new Date().toISOString(),
+    userAgent: nav.userAgent,
+    platform: nav.platform,
+    language: nav.language,
+    standalone:
+      window.matchMedia('(display-mode: standalone)').matches ||
+      nav.standalone === true,
+    secureContext: window.isSecureContext,
+    crossOriginIsolated: window.crossOriginIsolated,
+    checks: {},
+  }
+}
+
+const PersonhoodFeasibility = () => {
+  const intl = useIntl()
+  const [report, setReport] = useState<FeasibilityReport>(createInitialReport)
+  const [running, setRunning] = useState<'basic' | 'wasm' | null>(null)
+  const [copied, setCopied] = useState(false)
+
+  const reportText = useMemo(() => JSON.stringify(report, null, 2), [report])
+
+  const runBasicChecks = useCallback(async () => {
+    if (typeof window === 'undefined') {
+      return
+    }
+
+    setRunning('basic')
+    const nav = window.navigator as Navigator & {
+      deviceMemory?: number
+    }
+
+    const nextReport = createInitialReport()
+    nextReport.checks = {
+      webAssembly: typeof WebAssembly !== 'undefined',
+      serviceWorker: 'serviceWorker' in nav,
+      indexedDB: 'indexedDB' in window,
+      storageManager: !!nav.storage,
+      hardwareConcurrency: nav.hardwareConcurrency || null,
+      deviceMemory: nav.deviceMemory || null,
+    }
+
+    if (nav.storage?.estimate) {
+      const estimate = await nav.storage.estimate()
+      nextReport.checks.storageEstimate = {
+        quota: estimate.quota,
+        usage: estimate.usage,
+        available:
+          estimate.quota && estimate.usage
+            ? estimate.quota - estimate.usage
+            : undefined,
+      }
+    }
+
+    setReport(nextReport)
+    setRunning(null)
+  }, [])
+
+  const runWasmProbe = useCallback(async () => {
+    if (typeof WebAssembly === 'undefined') {
+      return
+    }
+
+    setRunning('wasm')
+    const allocations: WasmProbeReport['allocations'] = []
+    const memories: WebAssembly.Memory[] = []
+    let totalBytes = 0
+    const pages = 256
+    const maxRounds = 64
+
+    const probe: WasmProbeReport = {
+      startedAt: new Date().toISOString(),
+      allocations,
+    }
+
+    setReport((current) => ({
+      ...current,
+      checks: { ...current.checks, wasmMemoryProbe: probe },
+    }))
+
+    try {
+      for (let i = 0; i < maxRounds; i += 1) {
+        const memory = new WebAssembly.Memory({ initial: pages })
+        const bytes = memory.buffer.byteLength
+        memories.push(memory)
+        totalBytes += bytes
+        allocations.push({ round: i + 1, bytes, totalBytes })
+
+        setReport((current) => ({
+          ...current,
+          checks: {
+            ...current.checks,
+            wasmMemoryProbe: {
+              ...probe,
+              totalBytes,
+              allocations: [...allocations],
+            },
+          },
+        }))
+
+        await new Promise((resolve) => setTimeout(resolve, 50))
+      }
+
+      probe.completed = true
+    } catch (error) {
+      probe.completed = false
+      probe.error =
+        error instanceof Error ? error.message : 'Unknown WASM memory error'
+    } finally {
+      probe.endedAt = new Date().toISOString()
+      probe.totalBytes = totalBytes
+      memories.length = 0
+      setReport((current) => ({
+        ...current,
+        checks: {
+          ...current.checks,
+          wasmMemoryProbe: {
+            ...probe,
+            allocations: [...allocations],
+          },
+        },
+      }))
+      setRunning(null)
+    }
+  }, [])
+
+  const copyReport = useCallback(async () => {
+    if (navigator.clipboard) {
+      await navigator.clipboard.writeText(reportText)
+    }
+    setCopied(true)
+    window.setTimeout(() => setCopied(false), 1600)
+  }, [reportText])
+
+  const storage = report.checks.storageEstimate
+  const wasmProbe = report.checks.wasmMemoryProbe
+
+  return (
+    <Layout.Main>
+      <Layout.Header
+        left={
+          <Layout.Header.Title>
+            <FormattedMessage defaultMessage="Personhood" id="SHrdDe" />
+          </Layout.Header.Title>
+        }
+      />
+
+      <Head
+        title={intl.formatMessage({
+          defaultMessage: 'Personhood',
+          id: 'SHrdDe',
+        })}
+      />
+
+      <SettingsTabs />
+
+      <section className={settingsStyles.container}>
+        <section className={styles.panel}>
+          <header className={styles.header}>
+            <h2>
+              <FormattedMessage defaultMessage="PWA feasibility" id="TGe3wU" />
+            </h2>
+            <p>
+              <FormattedMessage
+                defaultMessage="Browser signals for the carbon based badge prover."
+                id="FRyXpx"
+              />
+            </p>
+          </header>
+
+          <section className={styles.actions}>
+            <button
+              className={styles.button}
+              disabled={running !== null}
+              onClick={runBasicChecks}
+              type="button"
+            >
+              <FormattedMessage defaultMessage="Run checks" id="1cza4C" />
+            </button>
+            <button
+              className={styles.button}
+              disabled={running !== null}
+              onClick={runWasmProbe}
+              type="button"
+            >
+              <FormattedMessage defaultMessage="WASM memory" id="gxHC1l" />
+            </button>
+            <button
+              className={styles.buttonSecondary}
+              disabled={running !== null}
+              onClick={copyReport}
+              type="button"
+            >
+              {copied ? (
+                <FormattedMessage defaultMessage="Copied" id="m/wW4D" />
+              ) : (
+                <FormattedMessage defaultMessage="Copy report" id="qh8Srq" />
+              )}
+            </button>
+          </section>
+
+          <dl className={styles.metrics}>
+            <div>
+              <dt>Standalone</dt>
+              <dd>{report.standalone ? 'yes' : 'no'}</dd>
+            </div>
+            <div>
+              <dt>Secure context</dt>
+              <dd>{report.secureContext ? 'yes' : 'no'}</dd>
+            </div>
+            <div>
+              <dt>Cross origin isolated</dt>
+              <dd>{report.crossOriginIsolated ? 'yes' : 'no'}</dd>
+            </div>
+            <div>
+              <dt>Storage quota</dt>
+              <dd>{bytesToMiB(storage?.quota)}</dd>
+            </div>
+            <div>
+              <dt>WASM allocated</dt>
+              <dd>{bytesToMiB(wasmProbe?.totalBytes)}</dd>
+            </div>
+            <div>
+              <dt>WASM result</dt>
+              <dd>
+                {wasmProbe
+                  ? wasmProbe.completed === false
+                    ? 'failed'
+                    : wasmProbe.completed
+                      ? 'completed'
+                      : 'running'
+                  : 'not run'}
+              </dd>
+            </div>
+          </dl>
+
+          <pre className={styles.report}>{reportText}</pre>
+        </section>
+      </section>
+
+      <Spacer size="sp32" />
+    </Layout.Main>
+  )
+}
+
+export default PersonhoodFeasibility

--- a/src/views/Me/Settings/Personhood/Feasibility/index.tsx
+++ b/src/views/Me/Settings/Personhood/Feasibility/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { FormattedMessage, useIntl } from 'react-intl'
 
 import { Head, Layout, Spacer } from '~/components'
@@ -46,6 +46,44 @@ type FeasibilityReport = {
   }
 }
 
+type SpTicketResponse = {
+  appId: string
+  apiBaseUrl: string
+  deeplink: string
+  expiresAt?: string
+  signType: string
+  spTicket: string
+  spTicketId: string
+  status: 'ticket_created'
+  transactionId: string
+}
+
+type SignResultResponse =
+  | {
+      cert?: string
+      certSize: number
+      signedResponse?: string
+      signedResponseSize: number
+      status: 'signed'
+    }
+  | {
+      errorCode: string
+      message?: string
+      status: 'pending'
+    }
+
+type TwFidoState = {
+  error?: string
+  idNum: string
+  pollCount: number
+  proofInputReady: boolean
+  result?: SignResultResponse
+  status: 'idle' | 'creating' | 'ticket_created' | 'polling' | 'signed'
+  ticket?: SpTicketResponse
+}
+
+const POLL_INTERVAL_MS = 4000
+
 const bytesToMiB = (bytes?: number) => {
   if (!bytes) {
     return '0 MiB'
@@ -88,8 +126,19 @@ const PersonhoodFeasibility = () => {
   const [report, setReport] = useState<FeasibilityReport>(createInitialReport)
   const [running, setRunning] = useState<'basic' | 'wasm' | null>(null)
   const [copied, setCopied] = useState(false)
+  const [twFido, setTwFido] = useState<TwFidoState>({
+    idNum: '',
+    pollCount: 0,
+    proofInputReady: false,
+    status: 'idle',
+  })
+  const pollingRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   const reportText = useMemo(() => JSON.stringify(report, null, 2), [report])
+  const canCreateTicket =
+    twFido.status !== 'creating' &&
+    twFido.status !== 'polling' &&
+    /^[A-Z][0-9A-Z]{9}$/.test(twFido.idNum.trim().toUpperCase())
 
   const runBasicChecks = useCallback(async () => {
     if (typeof window === 'undefined') {
@@ -203,8 +252,128 @@ const PersonhoodFeasibility = () => {
     window.setTimeout(() => setCopied(false), 1600)
   }, [reportText])
 
+  const pollSignResult = useCallback(
+    async (spTicket?: string) => {
+      const ticket = spTicket || twFido.ticket?.spTicket
+      if (!ticket) {
+        return
+      }
+
+      setTwFido((current) => ({
+        ...current,
+        error: undefined,
+        pollCount: current.pollCount + 1,
+        status: 'polling',
+      }))
+
+      try {
+        const response = await fetch('/api/personhood/tw-fido/result', {
+          body: JSON.stringify({ spTicket: ticket }),
+          headers: {
+            'content-type': 'application/json',
+          },
+          method: 'POST',
+        })
+        const body = await response.json()
+
+        if (!response.ok) {
+          throw new Error(body.error || `HTTP ${response.status}`)
+        }
+
+        if (body.status === 'signed') {
+          setTwFido((current) => ({
+            ...current,
+            proofInputReady: !!body.cert && !!body.signedResponse,
+            result: body,
+            status: 'signed',
+          }))
+          return
+        }
+
+        setTwFido((current) => ({
+          ...current,
+          result: body,
+          status: 'ticket_created',
+        }))
+      } catch (error) {
+        setTwFido((current) => ({
+          ...current,
+          error: error instanceof Error ? error.message : 'Unknown error',
+          status: current.ticket ? 'ticket_created' : 'idle',
+        }))
+      }
+    },
+    [twFido.ticket?.spTicket]
+  )
+
+  const createTicket = useCallback(async () => {
+    if (!canCreateTicket || typeof window === 'undefined') {
+      return
+    }
+
+    const idNum = twFido.idNum.trim().toUpperCase()
+    setTwFido((current) => ({
+      ...current,
+      error: undefined,
+      pollCount: 0,
+      proofInputReady: false,
+      result: undefined,
+      status: 'creating',
+      ticket: undefined,
+    }))
+
+    try {
+      const response = await fetch('/api/personhood/tw-fido/sp-ticket', {
+        body: JSON.stringify({
+          idNum,
+          returnUrl: window.location.href,
+        }),
+        headers: {
+          'content-type': 'application/json',
+        },
+        method: 'POST',
+      })
+      const body = await response.json()
+
+      if (!response.ok) {
+        throw new Error(body.error || `HTTP ${response.status}`)
+      }
+
+      setTwFido((current) => ({
+        ...current,
+        idNum,
+        status: 'ticket_created',
+        ticket: body,
+      }))
+    } catch (error) {
+      setTwFido((current) => ({
+        ...current,
+        error: error instanceof Error ? error.message : 'Unknown error',
+        status: 'idle',
+      }))
+    }
+  }, [canCreateTicket, twFido.idNum])
+
+  useEffect(() => {
+    if (twFido.status !== 'ticket_created' || !twFido.ticket) {
+      return
+    }
+
+    pollingRef.current = window.setTimeout(() => {
+      pollSignResult(twFido.ticket?.spTicket)
+    }, POLL_INTERVAL_MS)
+
+    return () => {
+      if (pollingRef.current) {
+        window.clearTimeout(pollingRef.current)
+      }
+    }
+  }, [pollSignResult, twFido.status, twFido.ticket])
+
   const storage = report.checks.storageEstimate
   const wasmProbe = report.checks.wasmMemoryProbe
+  const signedResult =
+    twFido.result?.status === 'signed' ? twFido.result : undefined
 
   return (
     <Layout.Main>
@@ -226,6 +395,118 @@ const PersonhoodFeasibility = () => {
       <SettingsTabs />
 
       <section className={settingsStyles.container}>
+        <section className={styles.panel}>
+          <header className={styles.header}>
+            <h2>
+              <FormattedMessage
+                defaultMessage="TW FidO mobile flow"
+                id="X1EbqK"
+              />
+            </h2>
+            <p>
+              <FormattedMessage
+                defaultMessage="Create a signing ticket, open the TW FidO app, then return here for the proof input check."
+                id="3W+dzP"
+              />
+            </p>
+          </header>
+
+          <div className={styles.formRow}>
+            <label className={styles.field}>
+              <span>
+                <FormattedMessage defaultMessage="ID number" id="Pk3r4Y" />
+              </span>
+              <input
+                autoCapitalize="characters"
+                autoComplete="off"
+                autoCorrect="off"
+                inputMode="text"
+                onChange={(event) =>
+                  setTwFido((current) => ({
+                    ...current,
+                    idNum: event.target.value,
+                  }))
+                }
+                placeholder="A123456789"
+                spellCheck={false}
+                type="text"
+                value={twFido.idNum}
+              />
+            </label>
+            <button
+              className={styles.button}
+              disabled={!canCreateTicket}
+              onClick={createTicket}
+              type="button"
+            >
+              {twFido.status === 'creating' ? (
+                <FormattedMessage defaultMessage="Creating" id="rR3s8X" />
+              ) : (
+                <FormattedMessage defaultMessage="Create ticket" id="SG9hky" />
+              )}
+            </button>
+          </div>
+
+          <section className={styles.actions}>
+            <a
+              aria-disabled={!twFido.ticket}
+              className={styles.linkButton}
+              href={twFido.ticket?.deeplink || undefined}
+            >
+              <FormattedMessage defaultMessage="Open TW FidO" id="k0USfY" />
+            </a>
+            <button
+              className={styles.buttonSecondary}
+              disabled={!twFido.ticket || twFido.status === 'polling'}
+              onClick={() => pollSignResult()}
+              type="button"
+            >
+              {twFido.status === 'polling' ? (
+                <FormattedMessage defaultMessage="Checking" id="gN4pBl" />
+              ) : (
+                <FormattedMessage defaultMessage="Check result" id="bM0zey" />
+              )}
+            </button>
+          </section>
+
+          <dl className={styles.metrics}>
+            <div>
+              <dt>Status</dt>
+              <dd>{twFido.status}</dd>
+            </div>
+            <div>
+              <dt>APP_ID</dt>
+              <dd>{twFido.ticket?.appId || 'not created'}</dd>
+            </div>
+            <div>
+              <dt>Ticket ID</dt>
+              <dd>{twFido.ticket?.spTicketId || 'not created'}</dd>
+            </div>
+            <div>
+              <dt>Sign type</dt>
+              <dd>{twFido.ticket?.signType || 'not created'}</dd>
+            </div>
+            <div>
+              <dt>Poll count</dt>
+              <dd>{twFido.pollCount}</dd>
+            </div>
+            <div>
+              <dt>Proof input</dt>
+              <dd>{twFido.proofInputReady ? 'ready' : 'server held'}</dd>
+            </div>
+            <div>
+              <dt>Certificate bytes</dt>
+              <dd>{signedResult?.certSize || 0}</dd>
+            </div>
+            <div>
+              <dt>Signature bytes</dt>
+              <dd>{signedResult?.signedResponseSize || 0}</dd>
+            </div>
+          </dl>
+
+          {twFido.error && <p className={styles.error}>{twFido.error}</p>}
+        </section>
+
         <section className={styles.panel}>
           <header className={styles.header}>
             <h2>

--- a/src/views/Me/Settings/Personhood/Feasibility/index.tsx
+++ b/src/views/Me/Settings/Personhood/Feasibility/index.tsx
@@ -380,7 +380,7 @@ const PersonhoodFeasibility = () => {
       <Layout.Header
         left={
           <Layout.Header.Title>
-            <FormattedMessage defaultMessage="Personhood" id="SHrdDe" />
+            <FormattedMessage defaultMessage="Personhood" id="fbxogW" />
           </Layout.Header.Title>
         }
       />
@@ -388,7 +388,7 @@ const PersonhoodFeasibility = () => {
       <Head
         title={intl.formatMessage({
           defaultMessage: 'Personhood',
-          id: 'SHrdDe',
+          id: 'fbxogW',
         })}
       />
 
@@ -400,13 +400,13 @@ const PersonhoodFeasibility = () => {
             <h2>
               <FormattedMessage
                 defaultMessage="TW FidO mobile flow"
-                id="X1EbqK"
+                id="C1yL+d"
               />
             </h2>
             <p>
               <FormattedMessage
                 defaultMessage="Create a signing ticket, open the TW FidO app, then return here for the proof input check."
-                id="3W+dzP"
+                id="t2rFN5"
               />
             </p>
           </header>
@@ -414,7 +414,7 @@ const PersonhoodFeasibility = () => {
           <div className={styles.formRow}>
             <label className={styles.field}>
               <span>
-                <FormattedMessage defaultMessage="ID number" id="Pk3r4Y" />
+                <FormattedMessage defaultMessage="ID number" id="pw6gGa" />
               </span>
               <input
                 autoCapitalize="characters"
@@ -440,9 +440,9 @@ const PersonhoodFeasibility = () => {
               type="button"
             >
               {twFido.status === 'creating' ? (
-                <FormattedMessage defaultMessage="Creating" id="rR3s8X" />
+                <FormattedMessage defaultMessage="Creating" id="xhfdqv" />
               ) : (
-                <FormattedMessage defaultMessage="Create ticket" id="SG9hky" />
+                <FormattedMessage defaultMessage="Create ticket" id="ABDljA" />
               )}
             </button>
           </div>
@@ -453,7 +453,7 @@ const PersonhoodFeasibility = () => {
               className={styles.linkButton}
               href={twFido.ticket?.deeplink || undefined}
             >
-              <FormattedMessage defaultMessage="Open TW FidO" id="k0USfY" />
+              <FormattedMessage defaultMessage="Open TW FidO" id="G/jeUL" />
             </a>
             <button
               className={styles.buttonSecondary}
@@ -462,9 +462,9 @@ const PersonhoodFeasibility = () => {
               type="button"
             >
               {twFido.status === 'polling' ? (
-                <FormattedMessage defaultMessage="Checking" id="gN4pBl" />
+                <FormattedMessage defaultMessage="Checking" id="lTleCS" />
               ) : (
-                <FormattedMessage defaultMessage="Check result" id="bM0zey" />
+                <FormattedMessage defaultMessage="Check result" id="VFQGq7" />
               )}
             </button>
           </section>
@@ -510,12 +510,12 @@ const PersonhoodFeasibility = () => {
         <section className={styles.panel}>
           <header className={styles.header}>
             <h2>
-              <FormattedMessage defaultMessage="PWA feasibility" id="TGe3wU" />
+              <FormattedMessage defaultMessage="PWA feasibility" id="DCgQVz" />
             </h2>
             <p>
               <FormattedMessage
                 defaultMessage="Browser signals for the carbon based badge prover."
-                id="FRyXpx"
+                id="DW68ct"
               />
             </p>
           </header>
@@ -527,7 +527,7 @@ const PersonhoodFeasibility = () => {
               onClick={runBasicChecks}
               type="button"
             >
-              <FormattedMessage defaultMessage="Run checks" id="1cza4C" />
+              <FormattedMessage defaultMessage="Run checks" id="CFtbZu" />
             </button>
             <button
               className={styles.button}
@@ -535,7 +535,7 @@ const PersonhoodFeasibility = () => {
               onClick={runWasmProbe}
               type="button"
             >
-              <FormattedMessage defaultMessage="WASM memory" id="gxHC1l" />
+              <FormattedMessage defaultMessage="WASM memory" id="N73cBw" />
             </button>
             <button
               className={styles.buttonSecondary}
@@ -544,9 +544,9 @@ const PersonhoodFeasibility = () => {
               type="button"
             >
               {copied ? (
-                <FormattedMessage defaultMessage="Copied" id="m/wW4D" />
+                <FormattedMessage defaultMessage="Copied" id="p556q3" />
               ) : (
-                <FormattedMessage defaultMessage="Copy report" id="qh8Srq" />
+                <FormattedMessage defaultMessage="Copy report" id="/H/Ei0" />
               )}
             </button>
           </section>

--- a/src/views/Me/Settings/Personhood/Feasibility/styles.module.css
+++ b/src/views/Me/Settings/Personhood/Feasibility/styles.module.css
@@ -1,5 +1,6 @@
 .panel {
   padding: var(--sp16);
+  margin-bottom: var(--sp16);
   border: 1px solid var(--color-grey-lighter);
   border-radius: 8px;
 }
@@ -26,16 +27,22 @@
 }
 
 .button,
-.buttonSecondary {
+.buttonSecondary,
+.linkButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   min-width: 120px;
   min-height: 40px;
   padding: 0 var(--sp16);
   border-radius: 6px;
   font-size: var(--text14);
   font-weight: var(--font-medium);
+  text-align: center;
 }
 
-.button {
+.button,
+.linkButton {
   color: var(--color-white);
   background: var(--color-matters-green);
 }
@@ -47,9 +54,39 @@
 }
 
 .button:disabled,
-.buttonSecondary:disabled {
+.buttonSecondary:disabled,
+.linkButton[aria-disabled='true'] {
   cursor: not-allowed;
   opacity: 0.5;
+  pointer-events: none;
+}
+
+.formRow {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: var(--sp8);
+  align-items: end;
+  margin: var(--sp16) 0 0;
+}
+
+.field {
+  display: grid;
+  gap: var(--sp4);
+
+  & span {
+    color: var(--color-grey-darker);
+    font-size: var(--text12);
+  }
+
+  & input {
+    min-height: 40px;
+    padding: 0 var(--sp12);
+    border: 1px solid var(--color-grey-lighter);
+    border-radius: 6px;
+    font-family: monospace;
+    font-size: var(--text14);
+    text-transform: uppercase;
+  }
 }
 
 .metrics {
@@ -88,4 +125,11 @@
   font-size: var(--text12);
   line-height: 1.5;
   white-space: pre-wrap;
+}
+
+.error {
+  margin: var(--sp8) 0 0;
+  color: var(--color-negative-red);
+  font-size: var(--text14);
+  overflow-wrap: anywhere;
 }

--- a/src/views/Me/Settings/Personhood/Feasibility/styles.module.css
+++ b/src/views/Me/Settings/Personhood/Feasibility/styles.module.css
@@ -56,8 +56,8 @@
 .button:disabled,
 .buttonSecondary:disabled,
 .linkButton[aria-disabled='true'] {
-  cursor: not-allowed;
   pointer-events: none;
+  cursor: not-allowed;
   opacity: 0.5;
 }
 
@@ -119,9 +119,9 @@
   padding: var(--sp16);
   margin: 0;
   overflow: auto;
-  background: var(--color-black);
   font-size: var(--text12);
   line-height: 1.5;
+  background: var(--color-black);
   color: var(--color-white);
   white-space: pre-wrap;
   border-radius: 6px;

--- a/src/views/Me/Settings/Personhood/Feasibility/styles.module.css
+++ b/src/views/Me/Settings/Personhood/Feasibility/styles.module.css
@@ -1,0 +1,91 @@
+.panel {
+  padding: var(--sp16);
+  border: 1px solid var(--color-grey-lighter);
+  border-radius: 8px;
+}
+
+.header {
+  & h2 {
+    margin: 0 0 var(--sp8);
+    font-size: var(--text18);
+    font-weight: var(--font-semibold);
+  }
+
+  & p {
+    margin: 0;
+    color: var(--color-grey-darker);
+    font-size: var(--text14);
+  }
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--sp8);
+  margin: var(--sp16) 0;
+}
+
+.button,
+.buttonSecondary {
+  min-width: 120px;
+  min-height: 40px;
+  padding: 0 var(--sp16);
+  border-radius: 6px;
+  font-size: var(--text14);
+  font-weight: var(--font-medium);
+}
+
+.button {
+  color: var(--color-white);
+  background: var(--color-matters-green);
+}
+
+.buttonSecondary {
+  color: var(--color-matters-green);
+  background: transparent;
+  border: 1px solid var(--color-matters-green);
+}
+
+.button:disabled,
+.buttonSecondary:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: var(--sp8);
+  margin: 0 0 var(--sp16);
+
+  & div {
+    padding: var(--sp12);
+    background: var(--color-grey-lighter);
+    border-radius: 6px;
+  }
+
+  & dt {
+    color: var(--color-grey-darker);
+    font-size: var(--text12);
+  }
+
+  & dd {
+    margin: var(--sp4) 0 0;
+    font-family: monospace;
+    font-size: var(--text14);
+    overflow-wrap: anywhere;
+  }
+}
+
+.report {
+  max-height: 420px;
+  padding: var(--sp16);
+  margin: 0;
+  overflow: auto;
+  background: var(--color-black);
+  border-radius: 6px;
+  color: var(--color-white);
+  font-size: var(--text12);
+  line-height: 1.5;
+  white-space: pre-wrap;
+}

--- a/src/views/Me/Settings/Personhood/Feasibility/styles.module.css
+++ b/src/views/Me/Settings/Personhood/Feasibility/styles.module.css
@@ -122,8 +122,8 @@
   font-size: var(--text12);
   line-height: 1.5;
   color: var(--color-white);
-  background: var(--color-black);
   white-space: pre-wrap;
+  background: var(--color-black);
   border-radius: 6px;
 }
 

--- a/src/views/Me/Settings/Personhood/Feasibility/styles.module.css
+++ b/src/views/Me/Settings/Personhood/Feasibility/styles.module.css
@@ -121,8 +121,8 @@
   overflow: auto;
   font-size: var(--text12);
   line-height: 1.5;
-  background: var(--color-black);
   color: var(--color-white);
+  background: var(--color-black);
   white-space: pre-wrap;
   border-radius: 6px;
 }

--- a/src/views/Me/Settings/Personhood/Feasibility/styles.module.css
+++ b/src/views/Me/Settings/Personhood/Feasibility/styles.module.css
@@ -14,8 +14,8 @@
 
   & p {
     margin: 0;
-    color: var(--color-grey-darker);
     font-size: var(--text14);
+    color: var(--color-grey-darker);
   }
 }
 
@@ -35,10 +35,10 @@
   min-width: 120px;
   min-height: 40px;
   padding: 0 var(--sp16);
-  border-radius: 6px;
   font-size: var(--text14);
   font-weight: var(--font-medium);
   text-align: center;
+  border-radius: 6px;
 }
 
 .button,
@@ -57,8 +57,8 @@
 .buttonSecondary:disabled,
 .linkButton[aria-disabled='true'] {
   cursor: not-allowed;
-  opacity: 0.5;
   pointer-events: none;
+  opacity: 0.5;
 }
 
 .formRow {
@@ -74,18 +74,18 @@
   gap: var(--sp4);
 
   & span {
-    color: var(--color-grey-darker);
     font-size: var(--text12);
+    color: var(--color-grey-darker);
   }
 
   & input {
     min-height: 40px;
     padding: 0 var(--sp12);
-    border: 1px solid var(--color-grey-lighter);
-    border-radius: 6px;
     font-family: monospace;
     font-size: var(--text14);
     text-transform: uppercase;
+    border: 1px solid var(--color-grey-lighter);
+    border-radius: 6px;
   }
 }
 
@@ -102,8 +102,8 @@
   }
 
   & dt {
-    color: var(--color-grey-darker);
     font-size: var(--text12);
+    color: var(--color-grey-darker);
   }
 
   & dd {
@@ -120,16 +120,16 @@
   margin: 0;
   overflow: auto;
   background: var(--color-black);
-  border-radius: 6px;
-  color: var(--color-white);
   font-size: var(--text12);
   line-height: 1.5;
+  color: var(--color-white);
   white-space: pre-wrap;
+  border-radius: 6px;
 }
 
 .error {
   margin: var(--sp8) 0 0;
-  color: var(--color-negative-red);
   font-size: var(--text14);
+  color: var(--color-negative-red);
   overflow-wrap: anywhere;
 }


### PR DESCRIPTION
## Summary
- add a protected `/me/settings/personhood/feasibility` page for mobile/PWA personhood prover feasibility checks
- fix the PWA manifest `scope` key casing
- add gated personhood CSP/header support for WASM, worker, verifier, asset, and optional path-scoped COOP/COEP testing

## Why
This is the Matters-side M1 gate before wiring the TW FidO / zkID proof flow into matters.icu. It lets us test whether the current web/PWA shell can support client-side proving constraints on mobile without shipping the production proof flow yet.

## Verification
- `./node_modules/.bin/prettier --check public/manifest.json src/common/enums/route.ts src/components/Layout/index.tsx configs/csp.ts next.config.ts src/pages/me/settings/personhood/feasibility.tsx src/views/Me/Settings/Personhood/Feasibility/index.tsx src/views/Me/Settings/Personhood/Feasibility/styles.module.css`
- `node -e "JSON.parse(require("fs").readFileSync("public/manifest.json", "utf8")); console.log("manifest ok")"`

## Limitations
- `npm run lint:ts`, targeted `next lint`, `stylelint`, and local `next dev` were attempted but hung locally without useful output, so browser verification was not completed in this environment.
- COOP/COEP is gated by `NEXT_PUBLIC_PERSONHOOD_CROSS_ORIGIN_ISOLATED=true` because CDN asset headers may need CORP/CORS alignment before enabling this in matters.icu.