### PR TITLE
feat: bind personhood mobile flow to verifier challenge

### DIFF
--- a/src/pages/api/personhood/tw-fido/result.ts
+++ b/src/pages/api/personhood/tw-fido/result.ts
@@ -9,6 +9,9 @@ import {
 } from '~/server/personhood/twFido'
 
 type ResultBody = {
+  appId?: unknown
+  challenge?: unknown
+  challengeExpiresAt?: unknown
   spTicket?: unknown
 }
 
@@ -16,6 +19,13 @@ type ResultResponse =
   | {
       cert?: string
       certSize: number
+      proofInput?: {
+        appId: string
+        cert: string
+        challenge: string
+        challengeExpiresAt?: string
+        signedResponse: string
+      }
       signedResponse?: string
       signedResponseSize: number
       status: 'signed'
@@ -85,6 +95,15 @@ const handler = async (
     res.status(200).json({
       cert: config.returnProofInput ? cert : undefined,
       certSize: Buffer.byteLength(cert, 'base64'),
+      proofInput: config.returnProofInput
+        ? createProofInput({
+            appId: body.appId,
+            cert,
+            challenge: body.challenge,
+            challengeExpiresAt: body.challengeExpiresAt,
+            signedResponse,
+          })
+        : undefined,
       signedResponse: config.returnProofInput ? signedResponse : undefined,
       signedResponseSize: Buffer.byteLength(signedResponse, 'base64'),
       status: 'signed',
@@ -104,6 +123,38 @@ const parseBody = (body: unknown): ResultBody => {
     return JSON.parse(body) as ResultBody
   }
   return (body || {}) as ResultBody
+}
+
+const createProofInput = ({
+  appId,
+  cert,
+  challenge,
+  challengeExpiresAt,
+  signedResponse,
+}: {
+  appId: unknown
+  cert: string
+  challenge: unknown
+  challengeExpiresAt: unknown
+  signedResponse: string
+}) => {
+  if (
+    typeof appId !== 'string' ||
+    typeof challenge !== 'string' ||
+    !appId ||
+    !challenge
+  ) {
+    return undefined
+  }
+
+  return {
+    appId,
+    cert,
+    challenge,
+    challengeExpiresAt:
+      typeof challengeExpiresAt === 'string' ? challengeExpiresAt : undefined,
+    signedResponse,
+  }
 }
 
 const isSameOriginRequest = (req: NextApiRequest) => {

--- a/src/pages/api/personhood/tw-fido/sp-ticket.ts
+++ b/src/pages/api/personhood/tw-fido/sp-ticket.ts
@@ -3,6 +3,7 @@ import type { NextApiRequest, NextApiResponse } from 'next'
 import {
   assertTwFidoEnabled,
   buildTwFidoDeeplink,
+  createPersonhoodChallenge,
   createSpTicket,
   getTwFidoConfig,
   normalizeTwFidoIdNum,
@@ -17,6 +18,8 @@ type SpTicketResponse =
   | {
       appId: string
       apiBaseUrl: string
+      challenge: string
+      challengeExpiresAt?: string
       deeplink: string
       expiresAt?: string
       signType: string
@@ -60,7 +63,12 @@ const handler = async (
         : `https://${req.headers.host}/me/settings/personhood/feasibility`
 
     const config = getTwFidoConfig()
-    const ticket = await createSpTicket({ config, idNum })
+    const challenge = await createPersonhoodChallenge(config)
+    const ticket = await createSpTicket({
+      appId: challenge.appId,
+      config,
+      idNum,
+    })
     const deeplink = buildTwFidoDeeplink({
       returnUrl,
       spTicket: ticket.spTicket,
@@ -68,7 +76,9 @@ const handler = async (
 
     res.status(200).json({
       apiBaseUrl: config.apiBaseUrl,
-      appId: config.appId,
+      appId: challenge.appId,
+      challenge: challenge.challenge,
+      challengeExpiresAt: challenge.expiresAt,
       deeplink,
       expiresAt: ticket.ticketPayload.expiration_time,
       signType: config.signType,

--- a/src/pages/api/personhood/zkid/link-verify.ts
+++ b/src/pages/api/personhood/zkid/link-verify.ts
@@ -1,0 +1,117 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+import { assertTwFidoEnabled } from '~/server/personhood/twFido'
+
+type LinkVerifyBody = {
+  certChainProof?: unknown
+  certChainType?: unknown
+  userSigProof?: unknown
+}
+
+type LinkVerifyResponse =
+  | Record<string, unknown>
+  | {
+      error: string
+    }
+
+export const config = {
+  api: {
+    bodyParser: {
+      sizeLimit: '2mb',
+    },
+  },
+}
+
+const handler = async (
+  req: NextApiRequest,
+  res: NextApiResponse<LinkVerifyResponse>
+) => {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST')
+    res.status(405).json({ error: 'method_not_allowed' })
+    return
+  }
+
+  if (!isSameOriginRequest(req)) {
+    res.status(403).json({ error: 'forbidden_origin' })
+    return
+  }
+
+  try {
+    assertTwFidoEnabled()
+
+    const verifierUrl =
+      process.env.PERSONHOOD_VERIFIER_URL ||
+      process.env.NEXT_PUBLIC_PERSONHOOD_VERIFIER_URL
+    if (!verifierUrl) {
+      res.status(500).json({ error: 'personhood_verifier_missing_config' })
+      return
+    }
+
+    const body = parseBody(req.body)
+    if (
+      typeof body.certChainProof !== 'string' ||
+      typeof body.userSigProof !== 'string'
+    ) {
+      res.status(400).json({ error: 'missing_proofs' })
+      return
+    }
+
+    const certChainType =
+      typeof body.certChainType === 'string' ? body.certChainType : 'rs4096'
+
+    const upstream = await fetch(
+      `${verifierUrl.replace(/\/$/, '')}/link-verify`,
+      {
+        body: JSON.stringify({
+          cert_chain_proof: body.certChainProof,
+          cert_chain_type: certChainType,
+          user_sig_proof: body.userSigProof,
+        }),
+        headers: {
+          'content-type': 'application/json',
+        },
+        method: 'POST',
+      }
+    )
+    const text = await upstream.text()
+
+    try {
+      res.status(upstream.status).json(JSON.parse(text))
+    } catch {
+      res.status(upstream.status).json({ error: text || 'invalid_response' })
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'unknown_error'
+    res
+      .status(message === 'personhood_tw_fido_disabled' ? 404 : 500)
+      .json({ error: message })
+  }
+}
+
+export default handler
+
+const parseBody = (body: unknown): LinkVerifyBody => {
+  if (typeof body === 'string') {
+    return JSON.parse(body) as LinkVerifyBody
+  }
+  return (body || {}) as LinkVerifyBody
+}
+
+const isSameOriginRequest = (req: NextApiRequest) => {
+  const origin = req.headers.origin
+  if (!origin) {
+    return true
+  }
+
+  const host = req.headers.host
+  if (!host) {
+    return false
+  }
+
+  try {
+    return new URL(origin).host === host
+  } catch {
+    return false
+  }
+}

--- a/src/server/personhood/twFido.ts
+++ b/src/server/personhood/twFido.ts
@@ -39,6 +39,18 @@ type TwFidoTicketResponse = {
   }
 }
 
+export type PersonhoodChallenge = {
+  appId: string
+  challenge: string
+  expiresAt?: string
+}
+
+type ChallengeResponse = {
+  app_id?: string
+  challenge?: string
+  expires_at?: string
+}
+
 export type TwFidoConfig = {
   aesKeyBase64: string
   apiBaseUrl: string
@@ -48,6 +60,7 @@ export type TwFidoConfig = {
   serviceId: string
   signType: 'PKCS#1' | 'PKCS#7' | 'RAW'
   timeLimit: string
+  verifierUrl?: string
 }
 
 export const normalizeTwFidoIdNum = (idNum: unknown) => {
@@ -87,6 +100,9 @@ export const getTwFidoConfig = (): TwFidoConfig => {
 
   const apiBaseUrl =
     process.env.PERSONHOOD_FIDO_API_BASE_URL || DEFAULT_API_BASE_URL
+  const verifierUrl =
+    process.env.PERSONHOOD_VERIFIER_URL ||
+    process.env.NEXT_PUBLIC_PERSONHOOD_VERIFIER_URL
 
   return {
     aesKeyBase64,
@@ -98,6 +114,7 @@ export const getTwFidoConfig = (): TwFidoConfig => {
     serviceId,
     signType,
     timeLimit: process.env.PERSONHOOD_FIDO_TIME_LIMIT || DEFAULT_TIME_LIMIT,
+    verifierUrl: verifierUrl ? verifierUrl.replace(/\/$/, '') : undefined,
   }
 }
 
@@ -109,6 +126,36 @@ export const assertTwFidoEnabled = () => {
 
 export const buildSignData = (appId: string) =>
   Buffer.from(appId, 'utf8').toString('base64')
+
+export const createPersonhoodChallenge = async (
+  config: TwFidoConfig
+): Promise<PersonhoodChallenge> => {
+  if (!config.verifierUrl) {
+    return {
+      appId: config.appId,
+      challenge: '',
+    }
+  }
+
+  const json = await postJson<ChallengeResponse>(
+    `${config.verifierUrl}/challenge`,
+    {}
+  )
+
+  if (!json.app_id || !json.challenge) {
+    throw new Error('personhood_verifier_invalid_challenge')
+  }
+
+  if (Buffer.byteLength(json.app_id, 'utf8') !== 31) {
+    throw new Error('personhood_verifier_invalid_app_id')
+  }
+
+  return {
+    appId: json.app_id,
+    challenge: json.challenge,
+    expiresAt: json.expires_at,
+  }
+}
 
 export const decodeSpTicket = (spTicket: string): TwFidoTicketPayload => {
   const separator = spTicket.lastIndexOf('.')
@@ -155,14 +202,17 @@ export const buildTwFidoDeeplink = ({
 }
 
 export const createSpTicket = async ({
+  appId,
   config,
   idNum,
 }: {
+  appId?: string
   config: TwFidoConfig
   idNum: string
 }) => {
   const transactionId = crypto.randomUUID()
-  const signData = buildSignData(config.appId)
+  const signAppId = appId || config.appId
+  const signData = buildSignData(signAppId)
   const checksumPayload = [
     transactionId,
     config.serviceId,

--- a/src/views/Me/Settings/Personhood/Feasibility/index.tsx
+++ b/src/views/Me/Settings/Personhood/Feasibility/index.tsx
@@ -49,6 +49,8 @@ type FeasibilityReport = {
 type SpTicketResponse = {
   appId: string
   apiBaseUrl: string
+  challenge: string
+  challengeExpiresAt?: string
   deeplink: string
   expiresAt?: string
   signType: string
@@ -62,6 +64,13 @@ type SignResultResponse =
   | {
       cert?: string
       certSize: number
+      proofInput?: {
+        appId: string
+        cert: string
+        challenge: string
+        challengeExpiresAt?: string
+        signedResponse: string
+      }
       signedResponse?: string
       signedResponseSize: number
       status: 'signed'
@@ -268,7 +277,12 @@ const PersonhoodFeasibility = () => {
 
       try {
         const response = await fetch('/api/personhood/tw-fido/result', {
-          body: JSON.stringify({ spTicket: ticket }),
+          body: JSON.stringify({
+            appId: twFido.ticket?.appId,
+            challenge: twFido.ticket?.challenge,
+            challengeExpiresAt: twFido.ticket?.challengeExpiresAt,
+            spTicket: ticket,
+          }),
           headers: {
             'content-type': 'application/json',
           },
@@ -283,7 +297,7 @@ const PersonhoodFeasibility = () => {
         if (body.status === 'signed') {
           setTwFido((current) => ({
             ...current,
-            proofInputReady: !!body.cert && !!body.signedResponse,
+            proofInputReady: !!body.proofInput,
             result: body,
             status: 'signed',
           }))
@@ -303,7 +317,12 @@ const PersonhoodFeasibility = () => {
         }))
       }
     },
-    [twFido.ticket?.spTicket]
+    [
+      twFido.ticket?.appId,
+      twFido.ticket?.challenge,
+      twFido.ticket?.challengeExpiresAt,
+      twFido.ticket?.spTicket,
+    ]
   )
 
   const createTicket = useCallback(async () => {
@@ -477,6 +496,14 @@ const PersonhoodFeasibility = () => {
             <div>
               <dt>APP_ID</dt>
               <dd>{twFido.ticket?.appId || 'not created'}</dd>
+            </div>
+            <div>
+              <dt>Challenge</dt>
+              <dd>{twFido.ticket?.challenge || 'not created'}</dd>
+            </div>
+            <div>
+              <dt>Challenge expires</dt>
+              <dd>{twFido.ticket?.challengeExpiresAt || 'not created'}</dd>
             </div>
             <div>
               <dt>Ticket ID</dt>


### PR DESCRIPTION
## Summary

This continues the merged personhood PWA slice by binding the TW FidO mobile flow to zkID verifier challenge semantics.

- Fetches verifier `/challenge` server-side before creating a TW FidO SP ticket.
- Uses the verifier-provided `app_id` as the signed payload so later `/link-verify` can validate app_id and challenge.
- Carries challenge metadata through the PWA polling flow.
- Returns raw proof input only behind `PERSONHOOD_TW_FIDO_RETURN_PROOF_INPUT=true`.
- Adds `/api/personhood/zkid/link-verify` as a same-origin proxy for browser/native-helper proof submission.

## Validation

- Formatted changed files with Prettier 3.5.3 using repo style flags.
- TS syntax checked changed files with TypeScript transpileModule.

## Deployment notes

Required for challenge-bound proving:

```bash
PERSONHOOD_VERIFIER_URL=https://<zkid-verifier-host>
PERSONHOOD_TW_FIDO_RETURN_PROOF_INPUT=true # matters.icu proof-generation testing only
```

`PERSONHOOD_TW_FIDO_RETURN_PROOF_INPUT` should stay false for production until the browser/native proof path consumes and discards the raw TW FidO result without logging.