### PR TITLE
[codex] Use DNA mark for carbon based badge

### DIFF
--- a/public/static/icons/24px/badge-carbon-based.svg
+++ b/public/static/icons/24px/badge-carbon-based.svg
@@ -1,13 +1,15 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<circle cx="12" cy="12" r="12" fill="white"/>
-<circle cx="12" cy="12" r="11" fill="#2F8F6B"/>
-<circle cx="12" cy="12" r="3.2" fill="white"/>
-<circle cx="6.8" cy="8.6" r="1.7" fill="white"/>
-<circle cx="17.2" cy="8.6" r="1.7" fill="white"/>
-<circle cx="12" cy="18" r="1.7" fill="white"/>
-<path d="M9.36 10.18L8.14 9.34" stroke="white" stroke-width="1.4" stroke-linecap="round"/>
-<path d="M14.64 10.18L15.86 9.34" stroke="white" stroke-width="1.4" stroke-linecap="round"/>
-<path d="M12 15.2V16.24" stroke="white" stroke-width="1.4" stroke-linecap="round"/>
-<path d="M8.9 5.1C10.02 4.42 11.33 4.02 12.74 4.02C16.84 4.02 20.16 7.34 20.16 11.44C20.16 13.24 19.52 14.89 18.45 16.17" stroke="white" stroke-width="1.2" stroke-linecap="round" opacity="0.64"/>
-<path d="M15.1 18.9C14.02 19.58 12.74 19.98 11.36 19.98C7.26 19.98 3.94 16.66 3.94 12.56C3.94 10.78 4.57 9.14 5.62 7.87" stroke="white" stroke-width="1.2" stroke-linecap="round" opacity="0.64"/>
+<g id="Carbon Based">
+<circle id="Outer" cx="12" cy="12" r="12" fill="white"/>
+<circle id="Inner" cx="12" cy="12" r="11" fill="#2F8F6B"/>
+<path id="Left Strand" d="M8.35 5.35C12.42 7.22 15.23 9.25 15.23 12C15.23 14.75 12.42 16.78 8.35 18.65" stroke="white" stroke-width="1.55" stroke-linecap="round"/>
+<path id="Right Strand" d="M15.65 5.35C11.58 7.22 8.77 9.25 8.77 12C8.77 14.75 11.58 16.78 15.65 18.65" stroke="white" stroke-width="1.55" stroke-linecap="round"/>
+<path id="Rung Top" d="M10.04 8.48H13.96" stroke="white" stroke-width="1.15" stroke-linecap="round"/>
+<path id="Rung Middle" d="M8.88 12H15.12" stroke="white" stroke-width="1.15" stroke-linecap="round"/>
+<path id="Rung Bottom" d="M10.04 15.52H13.96" stroke="white" stroke-width="1.15" stroke-linecap="round"/>
+<circle id="Node Top Left" cx="8.35" cy="5.35" r="0.95" fill="white"/>
+<circle id="Node Top Right" cx="15.65" cy="5.35" r="0.95" fill="white"/>
+<circle id="Node Bottom Left" cx="8.35" cy="18.65" r="0.95" fill="white"/>
+<circle id="Node Bottom Right" cx="15.65" cy="18.65" r="0.95" fill="white"/>
+</g>
 </svg>


### PR DESCRIPTION
## Summary
- replace the carbon based badge glyph with a green DNA double helix mark
- keep the existing Matters 24px badge style with a white outer circle, solid inner fill, and white symbol

## Validation
- `xmllint --noout public/static/icons/24px/badge-carbon-based.svg`

## Notes
- scoped to the badge SVG asset only