### PR TITLE
[codex] Bind personhood helper handoff to viewer

### DIFF
--- a/src/pages/api/personhood/zkid/handoff.ts
+++ b/src/pages/api/personhood/zkid/handoff.ts
@@ -1,0 +1,115 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+import { requestMattersGraphQL } from '~/server/personhood/mattersGraphql'
+import { assertTwFidoEnabled } from '~/server/personhood/twFido'
+
+type HandoffBody = {
+  challenge?: unknown
+  challengeExpiresAt?: unknown
+}
+
+type HandoffResponse =
+  | {
+      expiresAt: string
+      status: 'handoff_created'
+      token: string
+    }
+  | {
+      error: string
+    }
+
+type CreatePersonhoodHandoffData = {
+  createPersonhoodHandoff: {
+    expiresAt: string
+    token: string
+  }
+}
+
+const CREATE_PERSONHOOD_HANDOFF = [
+  'mutation CreatePersonhoodHandoff($input: CreatePersonhoodHandoffInput!) {',
+  `
+    createPersonhoodHandoff(input: $input) {
+      expiresAt
+      token
+    }
+  `,
+  '}',
+].join('\n')
+
+const handler = async (
+  req: NextApiRequest,
+  res: NextApiResponse<HandoffResponse>
+) => {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST')
+    res.status(405).json({ error: 'method_not_allowed' })
+    return
+  }
+
+  if (!isSameOriginRequest(req)) {
+    res.status(403).json({ error: 'forbidden_origin' })
+    return
+  }
+
+  try {
+    assertTwFidoEnabled()
+
+    const body = parseBody(req.body)
+    if (typeof body.challenge !== 'string' || !body.challenge) {
+      res.status(400).json({ error: 'missing_challenge' })
+      return
+    }
+
+    const data = await requestMattersGraphQL<CreatePersonhoodHandoffData>({
+      cookie: req.headers.cookie,
+      query: CREATE_PERSONHOOD_HANDOFF,
+      variables: {
+        input: {
+          challenge: body.challenge,
+          challengeExpiresAt:
+            typeof body.challengeExpiresAt === 'string'
+              ? body.challengeExpiresAt
+              : undefined,
+        },
+      },
+    })
+
+    res.status(200).json({
+      expiresAt: data.createPersonhoodHandoff.expiresAt,
+      status: 'handoff_created',
+      token: data.createPersonhoodHandoff.token,
+    })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'unknown_error'
+    res
+      .status(message === 'personhood_tw_fido_disabled' ? 404 : 500)
+      .json({ error: message })
+  }
+}
+
+export default handler
+
+const parseBody = (body: unknown): HandoffBody => {
+  if (typeof body === 'string') {
+    return JSON.parse(body) as HandoffBody
+  }
+  return (body || {}) as HandoffBody
+}
+
+const isSameOriginRequest = (req: NextApiRequest) => {
+  const origin = req.headers.origin
+  if (!origin) {
+    return true
+  }
+
+  const host = req.headers.host
+  if (!host) {
+    return false
+  }
+
+  try {
+    return new URL(origin).host === host
+  } catch {
+    return false
+  }
+}

--- a/src/pages/api/personhood/zkid/link-verify.ts
+++ b/src/pages/api/personhood/zkid/link-verify.ts
@@ -1,10 +1,16 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 
+import { requestMattersGraphQL } from '~/server/personhood/mattersGraphql'
 import { assertTwFidoEnabled } from '~/server/personhood/twFido'
 
 type LinkVerifyBody = {
+  cert_chain_proof?: unknown
+  cert_chain_type?: unknown
   certChainProof?: unknown
   certChainType?: unknown
+  handoff_token?: unknown
+  handoffToken?: unknown
+  user_sig_proof?: unknown
   userSigProof?: unknown
 }
 
@@ -13,6 +19,30 @@ type LinkVerifyResponse =
   | {
       error: string
     }
+
+type ClaimPersonhoodBadgeData = {
+  claimPersonhoodBadge: {
+    id: string
+    info: {
+      badges: Array<{ type: string }>
+    }
+  }
+}
+
+const CLAIM_PERSONHOOD_BADGE = [
+  'mutation ClaimPersonhoodBadge($input: ClaimPersonhoodBadgeInput!) {',
+  `
+    claimPersonhoodBadge(input: $input) {
+      id
+      info {
+        badges {
+          type
+        }
+      }
+    }
+  `,
+  '}',
+].join('\n')
 
 export const config = {
   api: {
@@ -40,47 +70,38 @@ const handler = async (
   try {
     assertTwFidoEnabled()
 
-    const verifierUrl =
-      process.env.PERSONHOOD_VERIFIER_URL ||
-      process.env.NEXT_PUBLIC_PERSONHOOD_VERIFIER_URL
-    if (!verifierUrl) {
-      res.status(500).json({ error: 'personhood_verifier_missing_config' })
-      return
-    }
-
     const body = parseBody(req.body)
+    const handoffToken = getString(body.handoffToken, body.handoff_token)
+    const certChainProof = getString(body.certChainProof, body.cert_chain_proof)
+    const userSigProof = getString(body.userSigProof, body.user_sig_proof)
     if (
-      typeof body.certChainProof !== 'string' ||
-      typeof body.userSigProof !== 'string'
+      typeof handoffToken !== 'string' ||
+      typeof certChainProof !== 'string' ||
+      typeof userSigProof !== 'string'
     ) {
-      res.status(400).json({ error: 'missing_proofs' })
+      res.status(400).json({ error: 'missing_claim_payload' })
       return
     }
 
     const certChainType =
-      typeof body.certChainType === 'string' ? body.certChainType : 'rs4096'
+      getString(body.certChainType, body.cert_chain_type) || 'rs4096'
 
-    const upstream = await fetch(
-      `${verifierUrl.replace(/\/$/, '')}/link-verify`,
-      {
-        body: JSON.stringify({
-          cert_chain_proof: body.certChainProof,
-          cert_chain_type: certChainType,
-          user_sig_proof: body.userSigProof,
-        }),
-        headers: {
-          'content-type': 'application/json',
+    const data = await requestMattersGraphQL<ClaimPersonhoodBadgeData>({
+      query: CLAIM_PERSONHOOD_BADGE,
+      variables: {
+        input: {
+          certChainProof,
+          certChainType,
+          handoffToken,
+          userSigProof,
         },
-        method: 'POST',
-      }
-    )
-    const text = await upstream.text()
+      },
+    })
 
-    try {
-      res.status(upstream.status).json(JSON.parse(text))
-    } catch {
-      res.status(upstream.status).json({ error: text || 'invalid_response' })
-    }
+    res.status(200).json({
+      status: 'claimed',
+      user: data.claimPersonhoodBadge,
+    })
   } catch (error) {
     const message = error instanceof Error ? error.message : 'unknown_error'
     res
@@ -97,6 +118,9 @@ const parseBody = (body: unknown): LinkVerifyBody => {
   }
   return (body || {}) as LinkVerifyBody
 }
+
+const getString = (...values: unknown[]) =>
+  values.find((value): value is string => typeof value === 'string')
 
 const isSameOriginRequest = (req: NextApiRequest) => {
   const origin = req.headers.origin

--- a/src/server/personhood/mattersGraphql.ts
+++ b/src/server/personhood/mattersGraphql.ts
@@ -1,0 +1,41 @@
+type GraphQLResponse<T> = {
+  data?: T
+  errors?: Array<{ message?: string }>
+}
+
+export const requestMattersGraphQL = async <T>({
+  cookie,
+  query,
+  variables,
+}: {
+  cookie?: string
+  query: string
+  variables?: Record<string, unknown>
+}) => {
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL
+  if (!apiUrl) {
+    throw new Error('matters_api_missing_config')
+  }
+
+  const response = await fetch(apiUrl, {
+    body: JSON.stringify({ query, variables }),
+    headers: {
+      ...(cookie ? { cookie } : null),
+      'content-type': 'application/json',
+    },
+    method: 'POST',
+  })
+  const body = (await response.json()) as GraphQLResponse<T>
+
+  if (!response.ok || body.errors?.length) {
+    throw new Error(
+      body.errors?.[0]?.message || `matters_api_error_${response.status}`
+    )
+  }
+
+  if (!body.data) {
+    throw new Error('matters_api_empty_response')
+  }
+
+  return body.data
+}

--- a/src/views/Me/Settings/Personhood/Feasibility/index.tsx
+++ b/src/views/Me/Settings/Personhood/Feasibility/index.tsx
@@ -88,6 +88,7 @@ type ProofInput = NonNullable<
 type HelperHandoffPayload = {
   certChainProvingKeyUrl: string
   certChainType: 'rs4096'
+  handoffToken: string
   linkVerifyUrl: string
   proofInput: ProofInput
   returnUrl: string
@@ -99,6 +100,13 @@ type HelperHandoffPayload = {
 
 type TwFidoState = {
   error?: string
+  handoff?: {
+    challenge: string
+    error?: string
+    expiresAt?: string
+    status: 'creating' | 'ready'
+    token?: string
+  }
   idNum: string
   pollCount: number
   proofInputReady: boolean
@@ -136,7 +144,10 @@ const encodeBase64Url = (value: string) => {
     .replace(/=+$/, '')
 }
 
-const buildHelperHandoffUrl = (proofInput: ProofInput) => {
+const buildHelperHandoffUrl = (
+  proofInput: ProofInput,
+  handoffToken: string
+) => {
   if (typeof window === 'undefined') {
     return undefined
   }
@@ -144,6 +155,7 @@ const buildHelperHandoffUrl = (proofInput: ProofInput) => {
   const payload: HelperHandoffPayload = {
     certChainProvingKeyUrl: CERT_CHAIN_PROVING_KEY_URL,
     certChainType: 'rs4096',
+    handoffToken,
     linkVerifyUrl: `${window.location.origin}/api/personhood/zkid/link-verify`,
     proofInput,
     returnUrl: window.location.href,
@@ -329,6 +341,53 @@ const PersonhoodFeasibility = () => {
     window.setTimeout(() => setHelperCopied(false), 1600)
   }, [])
 
+  const createHandoff = useCallback(async (proofInput: ProofInput) => {
+    setTwFido((current) => ({
+      ...current,
+      handoff: {
+        challenge: proofInput.challenge,
+        status: 'creating',
+      },
+    }))
+
+    try {
+      const response = await fetch('/api/personhood/zkid/handoff', {
+        body: JSON.stringify({
+          challenge: proofInput.challenge,
+          challengeExpiresAt: proofInput.challengeExpiresAt,
+        }),
+        headers: {
+          'content-type': 'application/json',
+        },
+        method: 'POST',
+      })
+      const body = await response.json()
+
+      if (!response.ok) {
+        throw new Error(body.error || `HTTP ${response.status}`)
+      }
+
+      setTwFido((current) => ({
+        ...current,
+        handoff: {
+          challenge: proofInput.challenge,
+          expiresAt: body.expiresAt,
+          status: 'ready',
+          token: body.token,
+        },
+      }))
+    } catch (error) {
+      setTwFido((current) => ({
+        ...current,
+        handoff: {
+          challenge: proofInput.challenge,
+          error: error instanceof Error ? error.message : 'Unknown error',
+          status: 'ready',
+        },
+      }))
+    }
+  }, [])
+
   const pollSignResult = useCallback(
     async (spTicket?: string) => {
       const ticket = spTicket || twFido.ticket?.spTicket
@@ -365,6 +424,7 @@ const PersonhoodFeasibility = () => {
         if (body.status === 'signed') {
           setTwFido((current) => ({
             ...current,
+            handoff: undefined,
             proofInputReady: !!body.proofInput,
             result: body,
             status: 'signed',
@@ -402,6 +462,7 @@ const PersonhoodFeasibility = () => {
     setTwFido((current) => ({
       ...current,
       error: undefined,
+      handoff: undefined,
       pollCount: 0,
       proofInputReady: false,
       result: undefined,
@@ -457,16 +518,33 @@ const PersonhoodFeasibility = () => {
     }
   }, [pollSignResult, twFido.status, twFido.ticket])
 
+  useEffect(() => {
+    if (twFido.result?.status !== 'signed' || !twFido.result.proofInput) {
+      return
+    }
+
+    if (twFido.handoff?.challenge === twFido.result.proofInput.challenge) {
+      return
+    }
+
+    createHandoff(twFido.result.proofInput)
+  }, [
+    createHandoff,
+    twFido.handoff?.challenge,
+    twFido.result,
+    twFido.result?.status,
+  ])
+
   const storage = report.checks.storageEstimate
   const wasmProbe = report.checks.wasmMemoryProbe
   const signedResult =
     twFido.result?.status === 'signed' ? twFido.result : undefined
   const helperHandoffUrl = useMemo(
     () =>
-      signedResult?.proofInput
-        ? buildHelperHandoffUrl(signedResult.proofInput)
+      signedResult?.proofInput && twFido.handoff?.token
+        ? buildHelperHandoffUrl(signedResult.proofInput, twFido.handoff.token)
         : undefined,
-    [signedResult?.proofInput]
+    [signedResult?.proofInput, twFido.handoff?.token]
   )
   const helperHandoffBytes = helperHandoffUrl
     ? new TextEncoder().encode(helperHandoffUrl).byteLength
@@ -629,7 +707,15 @@ const PersonhoodFeasibility = () => {
             </div>
             <div>
               <dt>Helper handoff</dt>
-              <dd>{helperHandoffUrl ? 'ready' : 'not ready'}</dd>
+              <dd>
+                {helperHandoffUrl
+                  ? 'ready'
+                  : twFido.handoff?.status || 'not ready'}
+              </dd>
+            </div>
+            <div>
+              <dt>Handoff expires</dt>
+              <dd>{twFido.handoff?.expiresAt || 'not created'}</dd>
             </div>
             <div>
               <dt>Helper URL bytes</dt>
@@ -645,7 +731,11 @@ const PersonhoodFeasibility = () => {
             </div>
           </dl>
 
-          {twFido.error && <p className={styles.error}>{twFido.error}</p>}
+          {(twFido.error || twFido.handoff?.error) && (
+            <p className={styles.error}>
+              {twFido.error || twFido.handoff?.error}
+            </p>
+          )}
         </section>
 
         <section className={styles.panel}>


### PR DESCRIPTION
## Summary
- add a handoff API route that asks Matters Server for a short-lived personhood token while the browser is logged in
- include that token in the `openac://prove` helper payload
- route helper proof submissions through `claimPersonhoodBadge` so proof verification and badge issuance happen server-side
- accept both camelCase and verifier-native snake_case proof request bodies from helper apps

## Validation
- `git diff --check`
- `./node_modules/.bin/tsc --project tsconfig.json --noEmit --pretty false`

## Depends on
- thematters/matters-server#4825