### PR TITLE
Update carbon based badge icon

### DIFF
--- a/public/static/icons/24px/badge-carbon-based.svg
+++ b/public/static/icons/24px/badge-carbon-based.svg
@@ -1,15 +1,11 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
 <g id="Carbon Based">
 <circle id="Outer" cx="12" cy="12" r="12" fill="white"/>
-<circle id="Inner" cx="12" cy="12" r="11" fill="#2F8F6B"/>
-<path id="Left Strand" d="M8.35 5.35C12.42 7.22 15.23 9.25 15.23 12C15.23 14.75 12.42 16.78 8.35 18.65" stroke="white" stroke-width="1.55" stroke-linecap="round"/>
-<path id="Right Strand" d="M15.65 5.35C11.58 7.22 8.77 9.25 8.77 12C8.77 14.75 11.58 16.78 15.65 18.65" stroke="white" stroke-width="1.55" stroke-linecap="round"/>
-<path id="Rung Top" d="M10.04 8.48H13.96" stroke="white" stroke-width="1.15" stroke-linecap="round"/>
-<path id="Rung Middle" d="M8.88 12H15.12" stroke="white" stroke-width="1.15" stroke-linecap="round"/>
-<path id="Rung Bottom" d="M10.04 15.52H13.96" stroke="white" stroke-width="1.15" stroke-linecap="round"/>
-<circle id="Node Top Left" cx="8.35" cy="5.35" r="0.95" fill="white"/>
-<circle id="Node Top Right" cx="15.65" cy="5.35" r="0.95" fill="white"/>
-<circle id="Node Bottom Left" cx="8.35" cy="18.65" r="0.95" fill="white"/>
-<circle id="Node Bottom Right" cx="15.65" cy="18.65" r="0.95" fill="white"/>
+<circle id="Inner" cx="12" cy="12" r="10.85" fill="#2F8F6B"/>
+<path id="Left Strand" d="M9.4 5.75C9.1 8.22 10.2 9.48 12 11.1C13.8 12.72 14.9 14.02 14.6 16.48C14.43 17.88 13.57 18.88 12.65 19.42" stroke="white" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"/>
+<path id="Right Strand" d="M14.6 5.75C14.9 8.22 13.8 9.48 12 11.1C10.2 12.72 9.1 14.02 9.4 16.48C9.57 17.88 10.43 18.88 11.35 19.42" stroke="white" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"/>
+<path id="Rung Top" d="M9.98 8.1H14.02" stroke="white" stroke-width="1.35" stroke-linecap="round"/>
+<path id="Rung Middle" d="M9.92 13.15H14.08" stroke="white" stroke-width="1.35" stroke-linecap="round"/>
+<path id="Rung Bottom" d="M10.35 15.65H13.65" stroke="white" stroke-width="1.35" stroke-linecap="round"/>
 </g>
 </svg>


### PR DESCRIPTION
## Summary
- update the carbon based badge icon to the selected green DNA ribbon style
- keep the asset as a 24px SVG so it stays crisp on the profile badge surface

## Validation
- `xmllint --noout public/static/icons/24px/badge-carbon-based.svg`
- `git diff --check`
- Quick Look thumbnail render for the SVG

## Deployment note
This should ride with the next `develop` deployment to matters.icu for personhood testing.
