### PR TITLE
feat(personhood): add browser proof handoff page

### DIFF
--- a/lang/default.json
+++ b/lang/default.json
@@ -103,6 +103,9 @@
   "/GyMKa": {
     "defaultMessage": "Share Article"
   },
+  "/H/Ei0": {
+    "defaultMessage": "Copy report"
+  },
   "/IMR+8": {
     "defaultMessage": "Top Supporters"
   },
@@ -373,6 +376,9 @@
   "3EeDnu": {
     "defaultMessage": "Paste JSFiddle or CodePen link, and press enter"
   },
+  "3HKaQ4": {
+    "defaultMessage": "The next slice mounts the zkID in-browser worker here and submits the proof to Matters."
+  },
   "3KNMbJ": {
     "defaultMessage": "Articles"
   },
@@ -486,6 +492,9 @@
   },
   "5XFd/5": {
     "defaultMessage": "Manage Circle"
+  },
+  "5fjmnA": {
+    "defaultMessage": "碳基生物"
   },
   "5iii3x": {
     "defaultMessage": "Circle：",
@@ -811,6 +820,9 @@
     "defaultMessage": "Payment suspended or returned by card issuer when there are doubts about the transaction",
     "description": "src/components/Transaction/index.tsx"
   },
+  "ABDljA": {
+    "defaultMessage": "Create ticket"
+  },
   "AEiogR": {
     "defaultMessage": "This Google account is connected to a Matters account. Sign in to that account to disconnect it then try again",
     "description": "USER_SOCIAL_ACCOUNT_EXISTS"
@@ -922,6 +934,9 @@
   "C/4nS6": {
     "defaultMessage": "Connect and claim"
   },
+  "C1yL+d": {
+    "defaultMessage": "TW FidO mobile flow"
+  },
   "C3NKBg": {
     "defaultMessage": "Connected to {type}",
     "description": "src/views/Me/Settings/Settings/Socials/index.tsx"
@@ -936,6 +951,9 @@
   "CD688y": {
     "defaultMessage": "bookmarked",
     "description": "src/components/Notice/ArticleNotice/ArticleNewSubscriberNotice.tsx"
+  },
+  "CFtbZu": {
+    "defaultMessage": "Run checks"
   },
   "CNMDU5": {
     "defaultMessage": "ID must be between {MIN_USER_NAME_LENGTH} and {MAX_USER_NAME_LENGTH} characters long"
@@ -1000,6 +1018,9 @@
   "D9tEst": {
     "defaultMessage": "Matters Architect"
   },
+  "DCgQVz": {
+    "defaultMessage": "PWA feasibility"
+  },
   "DP3yqI": {
     "defaultMessage": "Donation count"
   },
@@ -1009,6 +1030,9 @@
   },
   "DUvMii": {
     "defaultMessage": "Customize your call-to-support prompt to audience, or thank-you card for those who supported you."
+  },
+  "DW68ct": {
+    "defaultMessage": "Browser signals for the carbon based badge prover."
   },
   "DX0YH3": {
     "defaultMessage": "Wallet successfully bound",
@@ -1178,6 +1202,9 @@
     "defaultMessage": "This ID cannot be modified. Are you sure you want to use {id} as your Matters ID?",
     "description": "src/components/Dialogs/SetUserNameDialog/ConfirmStep.tsx"
   },
+  "G/jeUL": {
+    "defaultMessage": "Open TW FidO"
+  },
   "G/yZLu": {
     "defaultMessage": "Remove"
   },
@@ -1320,6 +1347,9 @@
   },
   "HzB4Lk": {
     "defaultMessage": "Tell readers why you edited this time..."
+  },
+  "I3v/Va": {
+    "defaultMessage": "PWA proof handoff"
   },
   "IJ9YcQ": {
     "defaultMessage": "Unlink",
@@ -1578,6 +1608,9 @@
     "defaultMessage": "Confirm in Wallet",
     "description": "src/components/Forms/PaymentForm/PayTo/Confirm/index.tsx"
   },
+  "N73cBw": {
+    "defaultMessage": "WASM memory"
+  },
   "NACY16": {
     "defaultMessage": "Why need to set up a wallet?",
     "description": "src/components/Forms/PaymentForm/BindWallet/index.tsx"
@@ -1627,6 +1660,9 @@
   "NlX31w": {
     "defaultMessage": "After deletion, the {commentType} will be removed immediately",
     "description": "src/components/CircleComment/DropdownActions/DeleteComment/Dialog.tsx"
+  },
+  "NloKwX": {
+    "defaultMessage": "Proof worker"
   },
   "NmhF45": {
     "defaultMessage": "Adding tags helps readers find your articles. Add or create new tags."
@@ -1840,6 +1876,9 @@
     "defaultMessage": "Please confirm transaction password",
     "description": "src/components/Forms/PaymentForm/SetPassword/index.tsx"
   },
+  "RYc4X0": {
+    "defaultMessage": "Browser proof"
+  },
   "Rc4Oij": {
     "defaultMessage": "Firebolt"
   },
@@ -2025,6 +2064,9 @@
   "USOHRK": {
     "defaultMessage": "Failed to edit, please try again."
   },
+  "USq+mM": {
+    "defaultMessage": "Pornographic advertising"
+  },
   "UUJzml": {
     "defaultMessage": "Logbook 2.0 has just launched. If you are an owner of Traveloggers, and haven't claimed, you may claim one from the new Logbook page:"
   },
@@ -2057,6 +2099,9 @@
     "defaultMessage": "Publishing, please wait...",
     "description": "src/components/Editor/PreviewDialog/index.tsx"
   },
+  "V3oaoZ": {
+    "defaultMessage": "After TW FidO signs, continue in this browser. No native proof helper is required for this PWA path."
+  },
   "V5OMr4": {
     "defaultMessage": "What is a digital wallet?",
     "description": "src/components/Forms/SelectAuthMethodForm/WalletFeed.tsx"
@@ -2067,6 +2112,9 @@
   },
   "VBve8d": {
     "defaultMessage": "Settled in Matters"
+  },
+  "VFQGq7": {
+    "defaultMessage": "Check result"
   },
   "VMQPwZ": {
     "defaultMessage": "Ended",
@@ -2292,6 +2340,9 @@
   "Z39z+x": {
     "defaultMessage": "{displayName} won't be able to comment your article. Besides, he or she can't @ you and subscribe your circle. You can manage blocked list in settings."
   },
+  "Z4R3Lq": {
+    "defaultMessage": "This browser page is missing a required PWA proving capability."
+  },
   "Z7JXlF": {
     "defaultMessage": "Archived for violation.",
     "description": "src/views/ArticleDetail/StickyTopBanner/index.tsx"
@@ -2450,6 +2501,9 @@
   "cAP9g5": {
     "defaultMessage": "pinned your comment in {commentArticle}",
     "description": "src/components/Notice/CommentNotice/CommentPinnedNotice.tsx"
+  },
+  "cB6zjC": {
+    "defaultMessage": "Signed TW FidO proof input is kept in this browser for the next proving step."
   },
   "cCpbBu": {
     "defaultMessage": "Popular Channel Authors"
@@ -2683,6 +2737,9 @@
   },
   "fWZYP5": {
     "defaultMessage": "Pinned"
+  },
+  "fbxogW": {
+    "defaultMessage": "Personhood"
   },
   "fko+MR": {
     "defaultMessage": "Retry claiming"
@@ -2962,6 +3019,9 @@
     "defaultMessage": "Remove",
     "description": "src/components/Dialogs/RemoveArticleCollectionDialog/index.tsx"
   },
+  "kqQp7b": {
+    "defaultMessage": "No signed proof input was found. Return to the TW FidO step and check the result again."
+  },
   "ksIL/T": {
     "defaultMessage": "Kind reminder: This wallet address is different from the wallet address you use to log in to Matters"
   },
@@ -3010,6 +3070,9 @@
   },
   "lO7wKc": {
     "defaultMessage": "Not yet"
+  },
+  "lTleCS": {
+    "defaultMessage": "Checking"
   },
   "lYVn31": {
     "defaultMessage": "This work has been added to the schedule. Please go to the \"My Works\" page to confirm"
@@ -3213,6 +3276,9 @@
     "defaultMessage": "恢復留言",
     "description": "src/components/Comment/Content/index.tsx"
   },
+  "p556q3": {
+    "defaultMessage": "Copied"
+  },
   "p5qZnJ": {
     "defaultMessage": "liked",
     "description": "src/components/Notice/ArticleNotice/ArticleNewAppreciationNotice.tsx"
@@ -3240,6 +3306,9 @@
   },
   "ptTHBL": {
     "defaultMessage": "Call-to-Support"
+  },
+  "pw6gGa": {
+    "defaultMessage": "ID number"
   },
   "pzTOmv": {
     "defaultMessage": "Followers"
@@ -3401,6 +3470,9 @@
   "sbhWw+": {
     "defaultMessage": "Schedule publication"
   },
+  "scWFV3": {
+    "defaultMessage": "Spam advertising"
+  },
   "sfj+KG": {
     "defaultMessage": "The results are mainly based on the records on the chain and will be synchronized to Matters later.",
     "description": "src/components/Forms/PaymentForm/Processing/index.tsx"
@@ -3432,6 +3504,9 @@
   },
   "t2EpN/": {
     "defaultMessage": "Request on {network} network will be confirmed and synced to Matters in a bit"
+  },
+  "t2rFN5": {
+    "defaultMessage": "Create a signing ticket, open the TW FidO app, then return here for the proof input check."
   },
   "tBt9u0": {
     "defaultMessage": "Sign in",
@@ -3739,6 +3814,9 @@
     "defaultMessage": "New discussions",
     "description": "src/views/Me/Settings/Notifications/Circle/index.tsx"
   },
+  "xhfdqv": {
+    "defaultMessage": "Creating"
+  },
   "xiV3Wz": {
     "defaultMessage": "More events",
     "description": "src/views/CampaignDetail/InfoHeader/OtherCampaigns/index.tsx"
@@ -3828,9 +3906,15 @@
     "defaultMessage": "Archived Work",
     "description": "src/components/Notice/NoticeArticleTitle.tsx"
   },
+  "z9jdNT": {
+    "defaultMessage": "Start browser proof"
+  },
   "zAK5G+": {
     "defaultMessage": "The login link has been sent to {email}",
     "description": "src/components/Forms/Verification/LinkSent.tsx"
+  },
+  "zCCJPu": {
+    "defaultMessage": "Run browser proof"
   },
   "zE51j6": {
     "defaultMessage": "Failed to publish, please try again."

--- a/lang/en.json
+++ b/lang/en.json
@@ -103,6 +103,9 @@
   "/GyMKa": {
     "defaultMessage": "Share Article"
   },
+  "/H/Ei0": {
+    "defaultMessage": "Copy report"
+  },
   "/IMR+8": {
     "defaultMessage": "Top Supporters"
   },
@@ -373,6 +376,9 @@
   "3EeDnu": {
     "defaultMessage": "Paste JSFiddle or CodePen link, and press enter"
   },
+  "3HKaQ4": {
+    "defaultMessage": "The next slice mounts the zkID in-browser worker here and submits the proof to Matters."
+  },
   "3KNMbJ": {
     "defaultMessage": "Articles"
   },
@@ -486,6 +492,9 @@
   },
   "5XFd/5": {
     "defaultMessage": "Manage Circle"
+  },
+  "5fjmnA": {
+    "defaultMessage": "碳基生物"
   },
   "5iii3x": {
     "defaultMessage": "Circle：",
@@ -811,6 +820,9 @@
     "defaultMessage": "Payment suspended or returned by card issuer when there are doubts about the transaction",
     "description": "src/components/Transaction/index.tsx"
   },
+  "ABDljA": {
+    "defaultMessage": "Create ticket"
+  },
   "AEiogR": {
     "defaultMessage": "This Google account is connected to a Matters account. Sign in to that account to disconnect it then try again",
     "description": "USER_SOCIAL_ACCOUNT_EXISTS"
@@ -922,6 +934,9 @@
   "C/4nS6": {
     "defaultMessage": "Connect and claim"
   },
+  "C1yL+d": {
+    "defaultMessage": "TW FidO mobile flow"
+  },
   "C3NKBg": {
     "defaultMessage": "Connected to {type}",
     "description": "src/views/Me/Settings/Settings/Socials/index.tsx"
@@ -936,6 +951,9 @@
   "CD688y": {
     "defaultMessage": "bookmarked",
     "description": "src/components/Notice/ArticleNotice/ArticleNewSubscriberNotice.tsx"
+  },
+  "CFtbZu": {
+    "defaultMessage": "Run checks"
   },
   "CNMDU5": {
     "defaultMessage": "ID must be between {MIN_USER_NAME_LENGTH} and {MAX_USER_NAME_LENGTH} characters long"
@@ -1000,6 +1018,9 @@
   "D9tEst": {
     "defaultMessage": "Matters Architect"
   },
+  "DCgQVz": {
+    "defaultMessage": "PWA feasibility"
+  },
   "DP3yqI": {
     "defaultMessage": "Donation count"
   },
@@ -1009,6 +1030,9 @@
   },
   "DUvMii": {
     "defaultMessage": "Customize your call-to-support prompt to audience, or thank-you card for those who supported you."
+  },
+  "DW68ct": {
+    "defaultMessage": "Browser signals for the carbon based badge prover."
   },
   "DX0YH3": {
     "defaultMessage": "Wallet successfully bound",
@@ -1178,6 +1202,9 @@
     "defaultMessage": "This ID cannot be modified. Are you sure you want to use {id} as your Matters ID?",
     "description": "src/components/Dialogs/SetUserNameDialog/ConfirmStep.tsx"
   },
+  "G/jeUL": {
+    "defaultMessage": "Open TW FidO"
+  },
   "G/yZLu": {
     "defaultMessage": "Remove"
   },
@@ -1320,6 +1347,9 @@
   },
   "HzB4Lk": {
     "defaultMessage": "Tell readers why you edited this time..."
+  },
+  "I3v/Va": {
+    "defaultMessage": "PWA proof handoff"
   },
   "IJ9YcQ": {
     "defaultMessage": "Unlink",
@@ -1578,6 +1608,9 @@
     "defaultMessage": "Confirm in Wallet",
     "description": "src/components/Forms/PaymentForm/PayTo/Confirm/index.tsx"
   },
+  "N73cBw": {
+    "defaultMessage": "WASM memory"
+  },
   "NACY16": {
     "defaultMessage": "Why need to set up a wallet?",
     "description": "src/components/Forms/PaymentForm/BindWallet/index.tsx"
@@ -1627,6 +1660,9 @@
   "NlX31w": {
     "defaultMessage": "After deletion, the {commentType} will be removed immediately",
     "description": "src/components/CircleComment/DropdownActions/DeleteComment/Dialog.tsx"
+  },
+  "NloKwX": {
+    "defaultMessage": "Proof worker"
   },
   "NmhF45": {
     "defaultMessage": "Adding tags helps readers find your articles. Add or create new tags."
@@ -1840,6 +1876,9 @@
     "defaultMessage": "Please confirm transaction password",
     "description": "src/components/Forms/PaymentForm/SetPassword/index.tsx"
   },
+  "RYc4X0": {
+    "defaultMessage": "Browser proof"
+  },
   "Rc4Oij": {
     "defaultMessage": "Firebolt"
   },
@@ -2025,6 +2064,9 @@
   "USOHRK": {
     "defaultMessage": "Failed to edit, please try again."
   },
+  "USq+mM": {
+    "defaultMessage": "Pornographic advertising"
+  },
   "UUJzml": {
     "defaultMessage": "Logbook 2.0 has just launched. If you are an owner of Traveloggers, and haven't claimed, you may claim one from the new Logbook page:"
   },
@@ -2057,6 +2099,9 @@
     "defaultMessage": "Publishing, please wait...",
     "description": "src/components/Editor/PreviewDialog/index.tsx"
   },
+  "V3oaoZ": {
+    "defaultMessage": "After TW FidO signs, continue in this browser. No native proof helper is required for this PWA path."
+  },
   "V5OMr4": {
     "defaultMessage": "What is a digital wallet?",
     "description": "src/components/Forms/SelectAuthMethodForm/WalletFeed.tsx"
@@ -2067,6 +2112,9 @@
   },
   "VBve8d": {
     "defaultMessage": "Settled in Matters"
+  },
+  "VFQGq7": {
+    "defaultMessage": "Check result"
   },
   "VMQPwZ": {
     "defaultMessage": "Ended",
@@ -2292,6 +2340,9 @@
   "Z39z+x": {
     "defaultMessage": "{displayName} won't be able to comment your article. Besides, he or she can't @ you and subscribe your circle. You can manage blocked list in settings."
   },
+  "Z4R3Lq": {
+    "defaultMessage": "This browser page is missing a required PWA proving capability."
+  },
   "Z7JXlF": {
     "defaultMessage": "Archived for violation.",
     "description": "src/views/ArticleDetail/StickyTopBanner/index.tsx"
@@ -2450,6 +2501,9 @@
   "cAP9g5": {
     "defaultMessage": "pinned your comment in {commentArticle}",
     "description": "src/components/Notice/CommentNotice/CommentPinnedNotice.tsx"
+  },
+  "cB6zjC": {
+    "defaultMessage": "Signed TW FidO proof input is kept in this browser for the next proving step."
   },
   "cCpbBu": {
     "defaultMessage": "Popular Channel Authors"
@@ -2683,6 +2737,9 @@
   },
   "fWZYP5": {
     "defaultMessage": "Pinned"
+  },
+  "fbxogW": {
+    "defaultMessage": "Personhood"
   },
   "fko+MR": {
     "defaultMessage": "Retry claiming"
@@ -2962,6 +3019,9 @@
     "defaultMessage": "Remove",
     "description": "src/components/Dialogs/RemoveArticleCollectionDialog/index.tsx"
   },
+  "kqQp7b": {
+    "defaultMessage": "No signed proof input was found. Return to the TW FidO step and check the result again."
+  },
   "ksIL/T": {
     "defaultMessage": "Kind reminder: This wallet address is different from the wallet address you use to log in to Matters"
   },
@@ -3010,6 +3070,9 @@
   },
   "lO7wKc": {
     "defaultMessage": "Not yet"
+  },
+  "lTleCS": {
+    "defaultMessage": "Checking"
   },
   "lYVn31": {
     "defaultMessage": "This work has been added to the schedule. Please go to the \"My Works\" page to confirm"
@@ -3213,6 +3276,9 @@
     "defaultMessage": "Restore comment",
     "description": "src/components/Comment/Content/index.tsx"
   },
+  "p556q3": {
+    "defaultMessage": "Copied"
+  },
   "p5qZnJ": {
     "defaultMessage": "liked",
     "description": "src/components/Notice/ArticleNotice/ArticleNewAppreciationNotice.tsx"
@@ -3240,6 +3306,9 @@
   },
   "ptTHBL": {
     "defaultMessage": "Call-to-Support"
+  },
+  "pw6gGa": {
+    "defaultMessage": "ID number"
   },
   "pzTOmv": {
     "defaultMessage": "Followers"
@@ -3401,6 +3470,9 @@
   "sbhWw+": {
     "defaultMessage": "Schedule publication"
   },
+  "scWFV3": {
+    "defaultMessage": "Spam advertising"
+  },
   "sfj+KG": {
     "defaultMessage": "The results are mainly based on the records on the chain and will be synchronized to Matters later.",
     "description": "src/components/Forms/PaymentForm/Processing/index.tsx"
@@ -3432,6 +3504,9 @@
   },
   "t2EpN/": {
     "defaultMessage": "Request on {network} network will be confirmed and synced to Matters in a bit"
+  },
+  "t2rFN5": {
+    "defaultMessage": "Create a signing ticket, open the TW FidO app, then return here for the proof input check."
   },
   "tBt9u0": {
     "defaultMessage": "Sign in",
@@ -3739,6 +3814,9 @@
     "defaultMessage": "New discussions",
     "description": "src/views/Me/Settings/Notifications/Circle/index.tsx"
   },
+  "xhfdqv": {
+    "defaultMessage": "Creating"
+  },
   "xiV3Wz": {
     "defaultMessage": "More events",
     "description": "src/views/CampaignDetail/InfoHeader/OtherCampaigns/index.tsx"
@@ -3828,9 +3906,15 @@
     "defaultMessage": "Archived Work",
     "description": "src/components/Notice/NoticeArticleTitle.tsx"
   },
+  "z9jdNT": {
+    "defaultMessage": "Start browser proof"
+  },
   "zAK5G+": {
     "defaultMessage": "The login link has been sent to {email}",
     "description": "src/components/Forms/Verification/LinkSent.tsx"
+  },
+  "zCCJPu": {
+    "defaultMessage": "Run browser proof"
   },
   "zE51j6": {
     "defaultMessage": "Failed to publish, please try again."

--- a/lang/zh-Hans.json
+++ b/lang/zh-Hans.json
@@ -103,6 +103,9 @@
   "/GyMKa": {
     "defaultMessage": "分享作品"
   },
+  "/H/Ei0": {
+    "defaultMessage": "Copy report"
+  },
   "/IMR+8": {
     "defaultMessage": "支持排行榜"
   },
@@ -373,6 +376,9 @@
   "3EeDnu": {
     "defaultMessage": "贴上 JSFiddle 或 CodePen 链接后，Enter 进行新增"
   },
+  "3HKaQ4": {
+    "defaultMessage": "The next slice mounts the zkID in-browser worker here and submits the proof to Matters."
+  },
   "3KNMbJ": {
     "defaultMessage": "作品"
   },
@@ -486,6 +492,9 @@
   },
   "5XFd/5": {
     "defaultMessage": "管理围炉"
+  },
+  "5fjmnA": {
+    "defaultMessage": "碳基生物"
   },
   "5iii3x": {
     "defaultMessage": "围炉：",
@@ -811,6 +820,9 @@
     "defaultMessage": "信用卡交易内容有疑虑时，发卡机构暂停或退回的款项",
     "description": "src/components/Transaction/index.tsx"
   },
+  "ABDljA": {
+    "defaultMessage": "Create ticket"
+  },
   "AEiogR": {
     "defaultMessage": "该 Google 账号已关联至其他 Matters 账号，请登录该账号解绑后再试",
     "description": "USER_SOCIAL_ACCOUNT_EXISTS"
@@ -922,6 +934,9 @@
   "C/4nS6": {
     "defaultMessage": "绑定并提领"
   },
+  "C1yL+d": {
+    "defaultMessage": "TW FidO mobile flow"
+  },
   "C3NKBg": {
     "defaultMessage": "{type} 已绑定",
     "description": "src/views/Me/Settings/Settings/Socials/index.tsx"
@@ -936,6 +951,9 @@
   "CD688y": {
     "defaultMessage": "收藏了",
     "description": "src/components/Notice/ArticleNotice/ArticleNewSubscriberNotice.tsx"
+  },
+  "CFtbZu": {
+    "defaultMessage": "Run checks"
   },
   "CNMDU5": {
     "defaultMessage": "ID 字符数须介于 {MIN_USER_NAME_LENGTH} 到 {MAX_USER_NAME_LENGTH} 之间"
@@ -1000,6 +1018,9 @@
   "D9tEst": {
     "defaultMessage": "马特市建筑师"
   },
+  "DCgQVz": {
+    "defaultMessage": "PWA feasibility"
+  },
   "DP3yqI": {
     "defaultMessage": "支持人数"
   },
@@ -1009,6 +1030,9 @@
   },
   "DUvMii": {
     "defaultMessage": "可自订号召支持的内容，以及收到支持后的感谢文字"
+  },
+  "DW68ct": {
+    "defaultMessage": "Browser signals for the carbon based badge prover."
   },
   "DX0YH3": {
     "defaultMessage": "已成功绑定钱包",
@@ -1178,6 +1202,9 @@
     "defaultMessage": "ID 设置后无法修改，确认使用 {id} 作为 Matters ID 吗？",
     "description": "src/components/Dialogs/SetUserNameDialog/ConfirmStep.tsx"
   },
+  "G/jeUL": {
+    "defaultMessage": "Open TW FidO"
+  },
   "G/yZLu": {
     "defaultMessage": "移除"
   },
@@ -1320,6 +1347,9 @@
   },
   "HzB4Lk": {
     "defaultMessage": "告知读者你此次编辑的更动有哪些⋯"
+  },
+  "I3v/Va": {
+    "defaultMessage": "PWA proof handoff"
   },
   "IJ9YcQ": {
     "defaultMessage": "取消链接",
@@ -1578,6 +1608,9 @@
     "defaultMessage": "去钱包确认",
     "description": "src/components/Forms/PaymentForm/PayTo/Confirm/index.tsx"
   },
+  "N73cBw": {
+    "defaultMessage": "WASM memory"
+  },
   "NACY16": {
     "defaultMessage": "为什么需要设定钱包 ?",
     "description": "src/components/Forms/PaymentForm/BindWallet/index.tsx"
@@ -1627,6 +1660,9 @@
   "NlX31w": {
     "defaultMessage": "确认删除后，{commentType}会立即消失。",
     "description": "src/components/CircleComment/DropdownActions/DeleteComment/Dialog.tsx"
+  },
+  "NloKwX": {
+    "defaultMessage": "Proof worker"
   },
   "NmhF45": {
     "defaultMessage": "通过添加标签帮助读者更好地找到你的作品。如果没有合适的标签，你可以创建新的。"
@@ -1840,6 +1876,9 @@
     "defaultMessage": "请再次输入交易密码",
     "description": "src/components/Forms/PaymentForm/SetPassword/index.tsx"
   },
+  "RYc4X0": {
+    "defaultMessage": "Browser proof"
+  },
   "Rc4Oij": {
     "defaultMessage": "火闪电"
   },
@@ -2025,6 +2064,9 @@
   "USOHRK": {
     "defaultMessage": "修改失败，请稍候重试"
   },
+  "USq+mM": {
+    "defaultMessage": "Pornographic advertising"
+  },
   "UUJzml": {
     "defaultMessage": "Logbook 2.0 刚刚推出。如果你是 Traveloggers 的所有者，且尚未领取，你可以从新的日志页面领取："
   },
@@ -2057,6 +2099,9 @@
     "defaultMessage": "发布中，请稍候⋯",
     "description": "src/components/Editor/PreviewDialog/index.tsx"
   },
+  "V3oaoZ": {
+    "defaultMessage": "After TW FidO signs, continue in this browser. No native proof helper is required for this PWA path."
+  },
   "V5OMr4": {
     "defaultMessage": "什么是数字钱包？",
     "description": "src/components/Forms/SelectAuthMethodForm/WalletFeed.tsx"
@@ -2067,6 +2112,9 @@
   },
   "VBve8d": {
     "defaultMessage": "搬家到 Matters"
+  },
+  "VFQGq7": {
+    "defaultMessage": "Check result"
   },
   "VMQPwZ": {
     "defaultMessage": "过往活动",
@@ -2292,6 +2340,9 @@
   "Z39z+x": {
     "defaultMessage": "封锁之后，{displayName} 将无法评论你的作品，不能 @ 你，并且不能加入你的围炉。你可以在设置里管理你的封锁用户列表"
   },
+  "Z4R3Lq": {
+    "defaultMessage": "This browser page is missing a required PWA proving capability."
+  },
   "Z7JXlF": {
     "defaultMessage": "因违反用户协定而被封存，",
     "description": "src/views/ArticleDetail/StickyTopBanner/index.tsx"
@@ -2450,6 +2501,9 @@
   "cAP9g5": {
     "defaultMessage": "将你的评论在 {commentArticle} 中置顶",
     "description": "src/components/Notice/CommentNotice/CommentPinnedNotice.tsx"
+  },
+  "cB6zjC": {
+    "defaultMessage": "Signed TW FidO proof input is kept in this browser for the next proving step."
   },
   "cCpbBu": {
     "defaultMessage": "频道热门作者"
@@ -2683,6 +2737,9 @@
   },
   "fWZYP5": {
     "defaultMessage": "置顶"
+  },
+  "fbxogW": {
+    "defaultMessage": "Personhood"
   },
   "fko+MR": {
     "defaultMessage": "重试提领"
@@ -2962,6 +3019,9 @@
     "defaultMessage": "确认移出",
     "description": "src/components/Dialogs/RemoveArticleCollectionDialog/index.tsx"
   },
+  "kqQp7b": {
+    "defaultMessage": "No signed proof input was found. Return to the TW FidO step and check the result again."
+  },
   "ksIL/T": {
     "defaultMessage": "贴心提醒：此钱包地址不同于您用于登录 Matters 的钱包地址"
   },
@@ -3010,6 +3070,9 @@
   },
   "lO7wKc": {
     "defaultMessage": "再想想"
+  },
+  "lTleCS": {
+    "defaultMessage": "Checking"
   },
   "lYVn31": {
     "defaultMessage": "此作品已加入定时发布，请前往「我的创作」页确认"
@@ -3213,6 +3276,9 @@
     "defaultMessage": "恢复留言",
     "description": "src/components/Comment/Content/index.tsx"
   },
+  "p556q3": {
+    "defaultMessage": "Copied"
+  },
   "p5qZnJ": {
     "defaultMessage": "赞赏了",
     "description": "src/components/Notice/ArticleNotice/ArticleNewAppreciationNotice.tsx"
@@ -3240,6 +3306,9 @@
   },
   "ptTHBL": {
     "defaultMessage": "支持号召"
+  },
+  "pw6gGa": {
+    "defaultMessage": "ID number"
   },
   "pzTOmv": {
     "defaultMessage": "关注者"
@@ -3401,6 +3470,9 @@
   "sbhWw+": {
     "defaultMessage": "定时发布"
   },
+  "scWFV3": {
+    "defaultMessage": "Spam advertising"
+  },
   "sfj+KG": {
     "defaultMessage": "结果以链上记录为主，稍后同步至 Matters",
     "description": "src/components/Forms/PaymentForm/Processing/index.tsx"
@@ -3432,6 +3504,9 @@
   },
   "t2EpN/": {
     "defaultMessage": "持续与 {network} 网络同步，稍后更新至 Matters"
+  },
+  "t2rFN5": {
+    "defaultMessage": "Create a signing ticket, open the TW FidO app, then return here for the proof input check."
   },
   "tBt9u0": {
     "defaultMessage": "登录",
@@ -3739,6 +3814,9 @@
     "defaultMessage": "留言",
     "description": "src/views/Me/Settings/Notifications/Circle/index.tsx"
   },
+  "xhfdqv": {
+    "defaultMessage": "Creating"
+  },
   "xiV3Wz": {
     "defaultMessage": "更多活动",
     "description": "src/views/CampaignDetail/InfoHeader/OtherCampaigns/index.tsx"
@@ -3828,9 +3906,15 @@
     "defaultMessage": "已归档作品",
     "description": "src/components/Notice/NoticeArticleTitle.tsx"
   },
+  "z9jdNT": {
+    "defaultMessage": "Start browser proof"
+  },
   "zAK5G+": {
     "defaultMessage": "登录链接已发送至 {email}",
     "description": "src/components/Forms/Verification/LinkSent.tsx"
+  },
+  "zCCJPu": {
+    "defaultMessage": "Run browser proof"
   },
   "zE51j6": {
     "defaultMessage": "发布失败"

--- a/lang/zh-Hant.json
+++ b/lang/zh-Hant.json
@@ -103,6 +103,9 @@
   "/GyMKa": {
     "defaultMessage": "分享作品"
   },
+  "/H/Ei0": {
+    "defaultMessage": "Copy report"
+  },
   "/IMR+8": {
     "defaultMessage": "支持排行榜"
   },
@@ -373,6 +376,9 @@
   "3EeDnu": {
     "defaultMessage": "貼上 JSFiddle 或 CodePen 連結後，Enter 進行新增"
   },
+  "3HKaQ4": {
+    "defaultMessage": "The next slice mounts the zkID in-browser worker here and submits the proof to Matters."
+  },
   "3KNMbJ": {
     "defaultMessage": "作品"
   },
@@ -486,6 +492,9 @@
   },
   "5XFd/5": {
     "defaultMessage": "管理圍爐"
+  },
+  "5fjmnA": {
+    "defaultMessage": "碳基生物"
   },
   "5iii3x": {
     "defaultMessage": "圍爐：",
@@ -811,6 +820,9 @@
     "defaultMessage": "信用卡交易內容有疑慮時，發卡機構暫停或退回的款項",
     "description": "src/components/Transaction/index.tsx"
   },
+  "ABDljA": {
+    "defaultMessage": "Create ticket"
+  },
   "AEiogR": {
     "defaultMessage": "該 Google 帳號已關聯至其他 Matters 帳號，請登入該帳號解綁後再試",
     "description": "USER_SOCIAL_ACCOUNT_EXISTS"
@@ -922,6 +934,9 @@
   "C/4nS6": {
     "defaultMessage": "綁定並提領"
   },
+  "C1yL+d": {
+    "defaultMessage": "TW FidO mobile flow"
+  },
   "C3NKBg": {
     "defaultMessage": "{type} 已綁定",
     "description": "src/views/Me/Settings/Settings/Socials/index.tsx"
@@ -936,6 +951,9 @@
   "CD688y": {
     "defaultMessage": "收藏了",
     "description": "src/components/Notice/ArticleNotice/ArticleNewSubscriberNotice.tsx"
+  },
+  "CFtbZu": {
+    "defaultMessage": "Run checks"
   },
   "CNMDU5": {
     "defaultMessage": "字符數須介於 {MIN_USER_NAME_LENGTH} 到 {MAX_USER_NAME_LENGTH} 之間"
@@ -1000,6 +1018,9 @@
   "D9tEst": {
     "defaultMessage": "馬特市建築師"
   },
+  "DCgQVz": {
+    "defaultMessage": "PWA feasibility"
+  },
   "DP3yqI": {
     "defaultMessage": "支持人數"
   },
@@ -1009,6 +1030,9 @@
   },
   "DUvMii": {
     "defaultMessage": "可自訂號召支持的內容，以及收到支持後的感謝文字"
+  },
+  "DW68ct": {
+    "defaultMessage": "Browser signals for the carbon based badge prover."
   },
   "DX0YH3": {
     "defaultMessage": "已成功綁定錢包",
@@ -1178,6 +1202,9 @@
     "defaultMessage": "ID 設置後無法修改，確認使用 {id} 作為 Matters ID 嗎？",
     "description": "src/components/Dialogs/SetUserNameDialog/ConfirmStep.tsx"
   },
+  "G/jeUL": {
+    "defaultMessage": "Open TW FidO"
+  },
   "G/yZLu": {
     "defaultMessage": "移除"
   },
@@ -1320,6 +1347,9 @@
   },
   "HzB4Lk": {
     "defaultMessage": "告知讀者你此次編輯的更動有哪些⋯"
+  },
+  "I3v/Va": {
+    "defaultMessage": "PWA proof handoff"
   },
   "IJ9YcQ": {
     "defaultMessage": "取消連結",
@@ -1578,6 +1608,9 @@
     "defaultMessage": "去錢包確認",
     "description": "src/components/Forms/PaymentForm/PayTo/Confirm/index.tsx"
   },
+  "N73cBw": {
+    "defaultMessage": "WASM memory"
+  },
   "NACY16": {
     "defaultMessage": "為什麼需要設定錢包 ?",
     "description": "src/components/Forms/PaymentForm/BindWallet/index.tsx"
@@ -1627,6 +1660,9 @@
   "NlX31w": {
     "defaultMessage": "確認刪除後，{commentType}會立即消失。",
     "description": "src/components/CircleComment/DropdownActions/DeleteComment/Dialog.tsx"
+  },
+  "NloKwX": {
+    "defaultMessage": "Proof worker"
   },
   "NmhF45": {
     "defaultMessage": "通過添加標籤幫助讀者更好地找到你的作品。如果沒有合適的標籤，你可以創建新的。"
@@ -1840,6 +1876,9 @@
     "defaultMessage": "請再次輸入交易密碼",
     "description": "src/components/Forms/PaymentForm/SetPassword/index.tsx"
   },
+  "RYc4X0": {
+    "defaultMessage": "Browser proof"
+  },
   "Rc4Oij": {
     "defaultMessage": "火閃電"
   },
@@ -2025,6 +2064,9 @@
   "USOHRK": {
     "defaultMessage": "修改失敗，請稍候重試"
   },
+  "USq+mM": {
+    "defaultMessage": "Pornographic advertising"
+  },
   "UUJzml": {
     "defaultMessage": "Logbook 2.0 剛剛推出。如果你是 Traveloggers 的所有者，且尚未領取，你可以從新的日誌頁面領取："
   },
@@ -2057,6 +2099,9 @@
     "defaultMessage": "發布中，請稍候⋯",
     "description": "src/components/Editor/PreviewDialog/index.tsx"
   },
+  "V3oaoZ": {
+    "defaultMessage": "After TW FidO signs, continue in this browser. No native proof helper is required for this PWA path."
+  },
   "V5OMr4": {
     "defaultMessage": "什麼是數字錢包？",
     "description": "src/components/Forms/SelectAuthMethodForm/WalletFeed.tsx"
@@ -2067,6 +2112,9 @@
   },
   "VBve8d": {
     "defaultMessage": "搬家到 Matters"
+  },
+  "VFQGq7": {
+    "defaultMessage": "Check result"
   },
   "VMQPwZ": {
     "defaultMessage": "過往活動",
@@ -2292,6 +2340,9 @@
   "Z39z+x": {
     "defaultMessage": "封鎖之後，{displayName} 將無法評論你的作品，不能 @ 你，並且不能加入你的圍爐。你可以在設置裏管理你的封鎖用戶列表。`"
   },
+  "Z4R3Lq": {
+    "defaultMessage": "This browser page is missing a required PWA proving capability."
+  },
   "Z7JXlF": {
     "defaultMessage": "因違反用戶協定而被封存，",
     "description": "src/views/ArticleDetail/StickyTopBanner/index.tsx"
@@ -2450,6 +2501,9 @@
   "cAP9g5": {
     "defaultMessage": "將你的評論在 {commentArticle} 中置頂",
     "description": "src/components/Notice/CommentNotice/CommentPinnedNotice.tsx"
+  },
+  "cB6zjC": {
+    "defaultMessage": "Signed TW FidO proof input is kept in this browser for the next proving step."
   },
   "cCpbBu": {
     "defaultMessage": "頻道熱門作者"
@@ -2683,6 +2737,9 @@
   },
   "fWZYP5": {
     "defaultMessage": "置頂"
+  },
+  "fbxogW": {
+    "defaultMessage": "Personhood"
   },
   "fko+MR": {
     "defaultMessage": "重試提領"
@@ -2962,6 +3019,9 @@
     "defaultMessage": "確認移出",
     "description": "src/components/Dialogs/RemoveArticleCollectionDialog/index.tsx"
   },
+  "kqQp7b": {
+    "defaultMessage": "No signed proof input was found. Return to the TW FidO step and check the result again."
+  },
   "ksIL/T": {
     "defaultMessage": "貼心提醒：此錢包位址不同於您用於登入 Matters 的錢包位址"
   },
@@ -3010,6 +3070,9 @@
   },
   "lO7wKc": {
     "defaultMessage": "再想想"
+  },
+  "lTleCS": {
+    "defaultMessage": "Checking"
   },
   "lYVn31": {
     "defaultMessage": "此作品已加入排程，請前往「我的創作」頁面確認"
@@ -3213,6 +3276,9 @@
     "defaultMessage": "恢復留言",
     "description": "src/components/Comment/Content/index.tsx"
   },
+  "p556q3": {
+    "defaultMessage": "Copied"
+  },
   "p5qZnJ": {
     "defaultMessage": "讚賞了",
     "description": "src/components/Notice/ArticleNotice/ArticleNewAppreciationNotice.tsx"
@@ -3240,6 +3306,9 @@
   },
   "ptTHBL": {
     "defaultMessage": "支持號召"
+  },
+  "pw6gGa": {
+    "defaultMessage": "ID number"
   },
   "pzTOmv": {
     "defaultMessage": "追蹤者"
@@ -3401,6 +3470,9 @@
   "sbhWw+": {
     "defaultMessage": "排程發布"
   },
+  "scWFV3": {
+    "defaultMessage": "Spam advertising"
+  },
   "sfj+KG": {
     "defaultMessage": "結果以鏈上紀錄為主，稍後同步至 Matters",
     "description": "src/components/Forms/PaymentForm/Processing/index.tsx"
@@ -3432,6 +3504,9 @@
   },
   "t2EpN/": {
     "defaultMessage": "持續與 {network} 網絡同步，稍後更新至 Matters"
+  },
+  "t2rFN5": {
+    "defaultMessage": "Create a signing ticket, open the TW FidO app, then return here for the proof input check."
   },
   "tBt9u0": {
     "defaultMessage": "登入",
@@ -3739,6 +3814,9 @@
     "defaultMessage": "留言",
     "description": "src/views/Me/Settings/Notifications/Circle/index.tsx"
   },
+  "xhfdqv": {
+    "defaultMessage": "Creating"
+  },
   "xiV3Wz": {
     "defaultMessage": "更多活動",
     "description": "src/views/CampaignDetail/InfoHeader/OtherCampaigns/index.tsx"
@@ -3828,9 +3906,15 @@
     "defaultMessage": "已封存作品",
     "description": "src/components/Notice/NoticeArticleTitle.tsx"
   },
+  "z9jdNT": {
+    "defaultMessage": "Start browser proof"
+  },
   "zAK5G+": {
     "defaultMessage": "登入連結已發送至 {email}",
     "description": "src/components/Forms/Verification/LinkSent.tsx"
+  },
+  "zCCJPu": {
+    "defaultMessage": "Run browser proof"
   },
   "zE51j6": {
     "defaultMessage": "發布失敗"

--- a/next.config.ts
+++ b/next.config.ts
@@ -26,20 +26,21 @@ const nextConfig: NextConfig = {
     return [
       ...(personhoodCrossOriginIsolated
         ? [
-            {
-              source: '/me/settings/personhood/feasibility',
-              headers: [
-                {
-                  key: 'Cross-Origin-Opener-Policy',
-                  value: 'same-origin',
-                },
-                {
-                  key: 'Cross-Origin-Embedder-Policy',
-                  value: 'require-corp',
-                },
-              ],
-            },
-          ]
+            '/me/settings/personhood/feasibility',
+            '/me/settings/personhood/prove',
+          ].map((source) => ({
+            source,
+            headers: [
+              {
+                key: 'Cross-Origin-Opener-Policy',
+                value: 'same-origin',
+              },
+              {
+                key: 'Cross-Origin-Embedder-Policy',
+                value: 'require-corp',
+              },
+            ],
+          }))
         : []),
       {
         source: '/(.*)',

--- a/src/common/enums/route.ts
+++ b/src/common/enums/route.ts
@@ -60,6 +60,7 @@ type ROUTE_KEY =
   | 'ME_SETTINGS_MISC'
   | 'ME_SETTINGS_BLOCKED'
   | 'ME_SETTINGS_PERSONHOOD_FEASIBILITY'
+  | 'ME_SETTINGS_PERSONHOOD_PROVE'
   | 'ME_DRAFT_NEW'
   | 'ME_DRAFT_DETAIL'
   | 'ME_DRAFT_DETAIL_OPTIONS'
@@ -117,6 +118,10 @@ export const PROTECTED_ROUTES: {
   {
     key: 'ME_SETTINGS_PERSONHOOD_FEASIBILITY',
     pathname: '/me/settings/personhood/feasibility',
+  },
+  {
+    key: 'ME_SETTINGS_PERSONHOOD_PROVE',
+    pathname: '/me/settings/personhood/prove',
   },
 
   // Article

--- a/src/pages/me/settings/personhood/prove.tsx
+++ b/src/pages/me/settings/personhood/prove.tsx
@@ -1,0 +1,10 @@
+import { Protected } from '~/components'
+import PersonhoodProve from '~/views/Me/Settings/Personhood/Prove'
+
+const ProtectedPersonhoodProve = () => (
+  <Protected>
+    <PersonhoodProve />
+  </Protected>
+)
+
+export default ProtectedPersonhoodProve

--- a/src/views/Me/Settings/Personhood/Feasibility/index.tsx
+++ b/src/views/Me/Settings/Personhood/Feasibility/index.tsx
@@ -5,6 +5,12 @@ import { Head, Layout, Spacer } from '~/components'
 
 import SettingsTabs from '../../SettingsTabs'
 import settingsStyles from '../../styles.module.css'
+import {
+  BROWSER_PROOF_ROUTE,
+  buildBrowserProofHandoff,
+  type PersonhoodProofInput,
+  saveBrowserProofHandoff,
+} from '../handoff'
 import styles from './styles.module.css'
 
 type StorageEstimateReport = {
@@ -64,13 +70,7 @@ type SignResultResponse =
   | {
       cert?: string
       certSize: number
-      proofInput?: {
-        appId: string
-        cert: string
-        challenge: string
-        challengeExpiresAt?: string
-        signedResponse: string
-      }
+      proofInput?: PersonhoodProofInput
       signedResponse?: string
       signedResponseSize: number
       status: 'signed'
@@ -84,19 +84,6 @@ type SignResultResponse =
 type ProofInput = NonNullable<
   Extract<SignResultResponse, { status: 'signed' }>['proofInput']
 >
-
-type HelperHandoffPayload = {
-  certChainProvingKeyUrl: string
-  certChainType: 'rs4096'
-  handoffToken: string
-  linkVerifyUrl: string
-  proofInput: ProofInput
-  returnUrl: string
-  smtSnapshotUrl: string
-  source: 'matters-web'
-  userSigProvingKeyUrl: string
-  version: 1
-}
 
 type TwFidoState = {
   error?: string
@@ -118,13 +105,6 @@ type TwFidoState = {
 const POLL_INTERVAL_MS = 4000
 const TW_FIDO_SESSION_STORAGE_KEY = 'matters.personhood.twFidoSession.v1'
 const TW_FIDO_SESSION_MAX_AGE_MS = 15 * 60 * 1000
-const HELPER_DEEPLINK_BASE = 'openac://prove'
-const CERT_CHAIN_PROVING_KEY_URL =
-  'https://github.com/zkmopro/zkID/releases/download/latest/cert_chain_rs4096_proving.key.gz'
-const USER_SIG_PROVING_KEY_URL =
-  'https://github.com/zkmopro/zkID/releases/download/latest/user_sig_rs2048_proving.key.gz'
-const SMT_SNAPSHOT_URL =
-  'https://github.com/moven0831/moica-revocation-smt/releases/download/snapshot-latest/g3-tree-snapshot.json.gz'
 
 type StoredTwFidoSession = {
   savedAt: string
@@ -136,45 +116,6 @@ const bytesToMiB = (bytes?: number) => {
     return '0 MiB'
   }
   return `${Math.round(bytes / 1024 / 1024)} MiB`
-}
-
-const encodeBase64Url = (value: string) => {
-  const bytes = new TextEncoder().encode(value)
-  let binary = ''
-  bytes.forEach((byte) => {
-    binary += String.fromCharCode(byte)
-  })
-  return window
-    .btoa(binary)
-    .replace(/\+/g, '-')
-    .replace(/\//g, '_')
-    .replace(/=+$/, '')
-}
-
-const buildHelperHandoffUrl = (
-  proofInput: ProofInput,
-  handoffToken: string
-) => {
-  if (typeof window === 'undefined') {
-    return undefined
-  }
-
-  const payload: HelperHandoffPayload = {
-    certChainProvingKeyUrl: CERT_CHAIN_PROVING_KEY_URL,
-    certChainType: 'rs4096',
-    handoffToken,
-    linkVerifyUrl: `${window.location.origin}/api/personhood/zkid/link-verify`,
-    proofInput,
-    returnUrl: window.location.href,
-    smtSnapshotUrl: SMT_SNAPSHOT_URL,
-    source: 'matters-web',
-    userSigProvingKeyUrl: USER_SIG_PROVING_KEY_URL,
-    version: 1,
-  }
-  const encoded = encodeBase64Url(JSON.stringify(payload))
-  const url = new URL(HELPER_DEEPLINK_BASE)
-  url.searchParams.set('payload', encoded)
-  return url.toString()
 }
 
 const parseTime = (value?: string) => {
@@ -272,20 +213,6 @@ const clearTwFidoSession = () => {
   }
 }
 
-const isMobileSafari = () => {
-  if (typeof window === 'undefined') {
-    return false
-  }
-
-  const ua = window.navigator.userAgent
-  return /iP(ad|hone|od)/.test(ua) && /Safari/.test(ua)
-}
-
-const getHelperUnavailableMessage = () =>
-  isMobileSafari()
-    ? 'Safari could not find an installed proof helper for openac://prove. Install the OpenAC helper app or copy the helper link for testing.'
-    : 'Could not open proof helper. Install the OpenAC helper app or copy the helper link for testing.'
-
 const createInitialReport = (): FeasibilityReport => {
   if (typeof window === 'undefined') {
     return {
@@ -321,7 +248,7 @@ const PersonhoodFeasibility = () => {
   const [report, setReport] = useState<FeasibilityReport>(createInitialReport)
   const [running, setRunning] = useState<'basic' | 'wasm' | null>(null)
   const [copied, setCopied] = useState(false)
-  const [helperCopied, setHelperCopied] = useState(false)
+  const [browserProofError, setBrowserProofError] = useState<string>()
   const [twFido, setTwFido] = useState<TwFidoState>({
     idNum: '',
     pollCount: 0,
@@ -468,15 +395,6 @@ const PersonhoodFeasibility = () => {
     setCopied(true)
     window.setTimeout(() => setCopied(false), 1600)
   }, [reportText])
-
-  const copyHelperLink = useCallback(async (helperUrl?: string) => {
-    if (!helperUrl || !navigator.clipboard) {
-      return
-    }
-    await navigator.clipboard.writeText(helperUrl)
-    setHelperCopied(true)
-    window.setTimeout(() => setHelperCopied(false), 1600)
-  }, [])
 
   const createHandoff = useCallback(async (proofInput: ProofInput) => {
     setTwFido((current) => ({
@@ -678,16 +596,48 @@ const PersonhoodFeasibility = () => {
   const wasmProbe = report.checks.wasmMemoryProbe
   const signedResult =
     twFido.result?.status === 'signed' ? twFido.result : undefined
-  const helperHandoffUrl = useMemo(
-    () =>
-      signedResult?.proofInput && twFido.handoff?.token
-        ? buildHelperHandoffUrl(signedResult.proofInput, twFido.handoff.token)
-        : undefined,
-    [signedResult?.proofInput, twFido.handoff?.token]
-  )
-  const helperHandoffBytes = helperHandoffUrl
-    ? new TextEncoder().encode(helperHandoffUrl).byteLength
+  const browserProofHandoff = useMemo(() => {
+    if (
+      typeof window === 'undefined' ||
+      !signedResult?.proofInput ||
+      !twFido.handoff?.token
+    ) {
+      return undefined
+    }
+
+    return buildBrowserProofHandoff({
+      handoffExpiresAt: twFido.handoff.expiresAt,
+      handoffToken: twFido.handoff.token,
+      origin: window.location.origin,
+      proofInput: signedResult.proofInput,
+      returnUrl: window.location.href,
+    })
+  }, [
+    signedResult?.proofInput,
+    twFido.handoff?.expiresAt,
+    twFido.handoff?.token,
+  ])
+  const canStartBrowserProof = !!browserProofHandoff
+  const browserHandoffBytes = browserProofHandoff
+    ? new TextEncoder().encode(JSON.stringify(browserProofHandoff)).byteLength
     : 0
+  const startBrowserProof = useCallback(() => {
+    setBrowserProofError(undefined)
+
+    if (!browserProofHandoff || typeof window === 'undefined') {
+      setBrowserProofError('Browser proof handoff is not ready.')
+      return
+    }
+
+    try {
+      saveBrowserProofHandoff(browserProofHandoff)
+      window.location.assign(BROWSER_PROOF_ROUTE)
+    } catch (error) {
+      setBrowserProofError(
+        error instanceof Error ? error.message : 'Could not save handoff.'
+      )
+    }
+  }, [browserProofHandoff])
 
   return (
     <Layout.Main>
@@ -784,35 +734,24 @@ const PersonhoodFeasibility = () => {
           </section>
 
           <section className={styles.actions}>
-            <a
-              aria-disabled={!helperHandoffUrl}
-              className={styles.linkButton}
-              href={helperHandoffUrl || undefined}
-            >
-              <FormattedMessage
-                defaultMessage="Open proof helper"
-                id="y1YAx4"
-              />
-            </a>
             <button
-              className={styles.buttonSecondary}
-              disabled={!helperHandoffUrl}
-              onClick={() => copyHelperLink(helperHandoffUrl)}
+              className={styles.button}
+              disabled={!canStartBrowserProof}
+              onClick={startBrowserProof}
               type="button"
             >
-              {helperCopied ? (
-                <FormattedMessage defaultMessage="Copied" id="p556q3" />
-              ) : (
-                <FormattedMessage
-                  defaultMessage="Copy helper link"
-                  id="RcFIF3"
-                />
-              )}
+              <FormattedMessage
+                defaultMessage="Start browser proof"
+                id="z9jdNT"
+              />
             </button>
           </section>
-          {helperHandoffUrl && (
-            <p className={styles.hint}>{getHelperUnavailableMessage()}</p>
-          )}
+          <p className={styles.hint}>
+            <FormattedMessage
+              defaultMessage="After TW FidO signs, continue in this browser. No native proof helper is required for this PWA path."
+              id="V3oaoZ"
+            />
+          </p>
 
           <dl className={styles.metrics}>
             <div>
@@ -848,9 +787,9 @@ const PersonhoodFeasibility = () => {
               <dd>{twFido.proofInputReady ? 'ready' : 'server held'}</dd>
             </div>
             <div>
-              <dt>Helper handoff</dt>
+              <dt>Browser handoff</dt>
               <dd>
-                {helperHandoffUrl
+                {browserProofHandoff
                   ? 'ready'
                   : twFido.handoff?.status || 'not ready'}
               </dd>
@@ -860,8 +799,8 @@ const PersonhoodFeasibility = () => {
               <dd>{twFido.handoff?.expiresAt || 'not created'}</dd>
             </div>
             <div>
-              <dt>Helper URL bytes</dt>
-              <dd>{helperHandoffBytes}</dd>
+              <dt>Handoff bytes</dt>
+              <dd>{browserHandoffBytes}</dd>
             </div>
             <div>
               <dt>Certificate bytes</dt>
@@ -873,9 +812,9 @@ const PersonhoodFeasibility = () => {
             </div>
           </dl>
 
-          {(twFido.error || twFido.handoff?.error) && (
+          {(twFido.error || twFido.handoff?.error || browserProofError) && (
             <p className={styles.error}>
-              {twFido.error || twFido.handoff?.error}
+              {twFido.error || twFido.handoff?.error || browserProofError}
             </p>
           )}
         </section>

--- a/src/views/Me/Settings/Personhood/Prove/index.tsx
+++ b/src/views/Me/Settings/Personhood/Prove/index.tsx
@@ -1,0 +1,367 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { FormattedMessage, useIntl } from 'react-intl'
+
+import { Head, Layout, Spacer } from '~/components'
+
+import SettingsTabs from '../../SettingsTabs'
+import settingsStyles from '../../styles.module.css'
+import {
+  BROWSER_PROOF_ROUTE,
+  type BrowserProofHandoff,
+  clearBrowserProofHandoff,
+  loadBrowserProofHandoff,
+} from '../handoff'
+import styles from './styles.module.css'
+
+type StorageEstimateReport = {
+  quota?: number
+  usage?: number
+  available?: number
+}
+
+type BrowserProofReadiness = {
+  checkedAt: string
+  crossOriginIsolated: boolean
+  language: string
+  platform: string
+  secureContext: boolean
+  standalone: boolean
+  userAgent: string
+  checks: {
+    cacheStorage: boolean
+    decompressionStream: boolean
+    indexedDB: boolean
+    serviceWorker: boolean
+    sharedArrayBuffer: boolean
+    storageEstimate?: StorageEstimateReport
+    storageManager: boolean
+    webAssembly: boolean
+    worker: boolean
+  }
+}
+
+const FEASIBILITY_ROUTE = '/me/settings/personhood/feasibility'
+
+const bytesToKiB = (bytes?: number) => {
+  if (!bytes) {
+    return '0 KiB'
+  }
+
+  return `${Math.round(bytes / 1024)} KiB`
+}
+
+const bytesToMiB = (bytes?: number) => {
+  if (!bytes) {
+    return '0 MiB'
+  }
+
+  return `${Math.round(bytes / 1024 / 1024)} MiB`
+}
+
+const encodedBytes = (value?: string) =>
+  value ? new TextEncoder().encode(value).byteLength : 0
+
+const createReadiness = async (): Promise<BrowserProofReadiness> => {
+  const nav = window.navigator as Navigator & { standalone?: boolean }
+  const storageEstimate = nav.storage?.estimate
+    ? await nav.storage.estimate()
+    : undefined
+
+  return {
+    checkedAt: new Date().toISOString(),
+    crossOriginIsolated: window.crossOriginIsolated,
+    language: nav.language,
+    platform: nav.platform,
+    secureContext: window.isSecureContext,
+    standalone:
+      window.matchMedia('(display-mode: standalone)').matches ||
+      nav.standalone === true,
+    userAgent: nav.userAgent,
+    checks: {
+      cacheStorage: 'caches' in window,
+      decompressionStream: 'DecompressionStream' in window,
+      indexedDB: 'indexedDB' in window,
+      serviceWorker: 'serviceWorker' in nav,
+      sharedArrayBuffer: typeof SharedArrayBuffer !== 'undefined',
+      storageEstimate: storageEstimate
+        ? {
+            available:
+              storageEstimate.quota && storageEstimate.usage
+                ? storageEstimate.quota - storageEstimate.usage
+                : undefined,
+            quota: storageEstimate.quota,
+            usage: storageEstimate.usage,
+          }
+        : undefined,
+      storageManager: !!nav.storage,
+      webAssembly: typeof WebAssembly !== 'undefined',
+      worker: typeof Worker !== 'undefined',
+    },
+  }
+}
+
+const getReadinessStatus = (readiness?: BrowserProofReadiness) => {
+  if (!readiness) {
+    return 'not checked'
+  }
+
+  return readiness.secureContext &&
+    readiness.crossOriginIsolated &&
+    readiness.checks.webAssembly &&
+    readiness.checks.worker &&
+    readiness.checks.indexedDB &&
+    readiness.checks.decompressionStream
+    ? 'ready'
+    : 'blocked'
+}
+
+const getHandoffStatus = (handoff?: BrowserProofHandoff) =>
+  handoff ? 'ready' : 'missing'
+
+const PersonhoodProve = () => {
+  const intl = useIntl()
+  const [handoff, setHandoff] = useState<BrowserProofHandoff>()
+  const [readiness, setReadiness] = useState<BrowserProofReadiness>()
+  const [running, setRunning] = useState(false)
+  const [copied, setCopied] = useState(false)
+
+  const refreshReadiness = useCallback(async () => {
+    setRunning(true)
+    try {
+      setReadiness(await createReadiness())
+    } finally {
+      setRunning(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    setHandoff(loadBrowserProofHandoff())
+    refreshReadiness()
+  }, [refreshReadiness])
+
+  const reportText = useMemo(
+    () =>
+      JSON.stringify(
+        {
+          handoff: handoff
+            ? {
+                appId: handoff.proofInput.appId,
+                certChainType: handoff.certChainType,
+                challenge: handoff.proofInput.challenge,
+                challengeExpiresAt: handoff.proofInput.challengeExpiresAt,
+                handoffExpiresAt: handoff.handoffExpiresAt,
+                savedAt: handoff.savedAt,
+                source: handoff.source,
+                version: handoff.version,
+              }
+            : undefined,
+          location: BROWSER_PROOF_ROUTE,
+          readiness,
+        },
+        null,
+        2
+      ),
+    [handoff, readiness]
+  )
+
+  const copyReport = useCallback(async () => {
+    if (navigator.clipboard) {
+      await navigator.clipboard.writeText(reportText)
+    }
+    setCopied(true)
+    window.setTimeout(() => setCopied(false), 1600)
+  }, [reportText])
+
+  const clearHandoff = useCallback(() => {
+    clearBrowserProofHandoff()
+    setHandoff(undefined)
+  }, [])
+
+  const returnToTwFido = useCallback(() => {
+    window.location.assign(handoff?.returnUrl || FEASIBILITY_ROUTE)
+  }, [handoff?.returnUrl])
+
+  const readinessStatus = getReadinessStatus(readiness)
+  const storage = readiness?.checks.storageEstimate
+
+  return (
+    <Layout.Main>
+      <Layout.Header
+        left={
+          <Layout.Header.Title>
+            <FormattedMessage defaultMessage="Browser proof" id="RYc4X0" />
+          </Layout.Header.Title>
+        }
+      />
+
+      <Head
+        title={intl.formatMessage({
+          defaultMessage: 'Browser proof',
+          id: 'RYc4X0',
+        })}
+      />
+
+      <SettingsTabs />
+
+      <section className={settingsStyles.container}>
+        <section className={styles.panel}>
+          <header className={styles.header}>
+            <h2>
+              <FormattedMessage
+                defaultMessage="PWA proof handoff"
+                id="I3v/Va"
+              />
+            </h2>
+            <p>
+              <FormattedMessage
+                defaultMessage="Signed TW FidO proof input is kept in this browser for the next proving step."
+                id="cB6zjC"
+              />
+            </p>
+          </header>
+
+          <section className={styles.actions}>
+            <button
+              className={styles.button}
+              disabled={running}
+              onClick={refreshReadiness}
+              type="button"
+            >
+              <FormattedMessage defaultMessage="Run checks" id="CFtbZu" />
+            </button>
+            <button
+              className={styles.buttonSecondary}
+              disabled={!handoff}
+              onClick={returnToTwFido}
+              type="button"
+            >
+              <FormattedMessage defaultMessage="Back" id="cyR7Kh" />
+            </button>
+            <button
+              className={styles.buttonSecondary}
+              disabled={!handoff}
+              onClick={clearHandoff}
+              type="button"
+            >
+              <FormattedMessage defaultMessage="Clear" id="/GCoTA" />
+            </button>
+            <button
+              className={styles.buttonSecondary}
+              onClick={copyReport}
+              type="button"
+            >
+              {copied ? (
+                <FormattedMessage defaultMessage="Copied" id="p556q3" />
+              ) : (
+                <FormattedMessage defaultMessage="Copy report" id="/H/Ei0" />
+              )}
+            </button>
+          </section>
+
+          <dl className={styles.metrics}>
+            <div>
+              <dt>Handoff</dt>
+              <dd>{getHandoffStatus(handoff)}</dd>
+            </div>
+            <div>
+              <dt>Browser</dt>
+              <dd>{readinessStatus}</dd>
+            </div>
+            <div>
+              <dt>Secure context</dt>
+              <dd>{readiness?.secureContext ? 'yes' : 'no'}</dd>
+            </div>
+            <div>
+              <dt>Cross origin isolated</dt>
+              <dd>{readiness?.crossOriginIsolated ? 'yes' : 'no'}</dd>
+            </div>
+            <div>
+              <dt>SharedArrayBuffer</dt>
+              <dd>{readiness?.checks.sharedArrayBuffer ? 'yes' : 'no'}</dd>
+            </div>
+            <div>
+              <dt>DecompressionStream</dt>
+              <dd>{readiness?.checks.decompressionStream ? 'yes' : 'no'}</dd>
+            </div>
+            <div>
+              <dt>IndexedDB</dt>
+              <dd>{readiness?.checks.indexedDB ? 'yes' : 'no'}</dd>
+            </div>
+            <div>
+              <dt>Storage quota</dt>
+              <dd>{bytesToMiB(storage?.quota)}</dd>
+            </div>
+            <div>
+              <dt>APP_ID</dt>
+              <dd>{handoff?.proofInput.appId || 'missing'}</dd>
+            </div>
+            <div>
+              <dt>Challenge expires</dt>
+              <dd>{handoff?.proofInput.challengeExpiresAt || 'missing'}</dd>
+            </div>
+            <div>
+              <dt>Handoff expires</dt>
+              <dd>{handoff?.handoffExpiresAt || 'missing'}</dd>
+            </div>
+            <div>
+              <dt>Cert payload</dt>
+              <dd>{bytesToKiB(encodedBytes(handoff?.proofInput.cert))}</dd>
+            </div>
+            <div>
+              <dt>Signature payload</dt>
+              <dd>
+                {bytesToKiB(encodedBytes(handoff?.proofInput.signedResponse))}
+              </dd>
+            </div>
+            <div>
+              <dt>Proof worker</dt>
+              <dd>pending</dd>
+            </div>
+          </dl>
+
+          {!handoff && (
+            <p className={styles.error}>
+              <FormattedMessage
+                defaultMessage="No signed proof input was found. Return to the TW FidO step and check the result again."
+                id="kqQp7b"
+              />
+            </p>
+          )}
+
+          {readinessStatus === 'blocked' && (
+            <p className={styles.error}>
+              <FormattedMessage
+                defaultMessage="This browser page is missing a required PWA proving capability."
+                id="Z4R3Lq"
+              />
+            </p>
+          )}
+        </section>
+
+        <section className={styles.panel}>
+          <header className={styles.header}>
+            <h2>
+              <FormattedMessage defaultMessage="Proof worker" id="NloKwX" />
+            </h2>
+            <p>
+              <FormattedMessage
+                defaultMessage="The next slice mounts the zkID in-browser worker here and submits the proof to Matters."
+                id="3HKaQ4"
+              />
+            </p>
+          </header>
+
+          <button className={styles.button} disabled type="button">
+            <FormattedMessage defaultMessage="Run browser proof" id="zCCJPu" />
+          </button>
+        </section>
+
+        <pre className={styles.report}>{reportText}</pre>
+      </section>
+
+      <Spacer size="sp32" />
+    </Layout.Main>
+  )
+}
+
+export default PersonhoodProve

--- a/src/views/Me/Settings/Personhood/Prove/styles.module.css
+++ b/src/views/Me/Settings/Personhood/Prove/styles.module.css
@@ -1,0 +1,104 @@
+.panel {
+  padding: var(--sp16);
+  margin-bottom: var(--sp16);
+  border: 1px solid var(--color-grey-lighter);
+  border-radius: 8px;
+}
+
+.header {
+  & h2 {
+    margin: 0 0 var(--sp8);
+    font-size: var(--text18);
+    font-weight: var(--font-semibold);
+  }
+
+  & p {
+    margin: 0;
+    font-size: var(--text14);
+    color: var(--color-grey-darker);
+  }
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--sp8);
+  margin: var(--sp16) 0;
+}
+
+.button,
+.buttonSecondary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 112px;
+  min-height: 40px;
+  padding: 0 var(--sp16);
+  font-size: var(--text14);
+  font-weight: var(--font-medium);
+  text-align: center;
+  border-radius: 6px;
+}
+
+.button {
+  color: var(--color-white);
+  background: var(--color-matters-green);
+}
+
+.buttonSecondary {
+  color: var(--color-matters-green);
+  background: transparent;
+  border: 1px solid var(--color-matters-green);
+}
+
+.button:disabled,
+.buttonSecondary:disabled {
+  pointer-events: none;
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: var(--sp8);
+  margin: 0 0 var(--sp16);
+
+  & div {
+    padding: var(--sp12);
+    background: var(--color-grey-lighter);
+    border-radius: 6px;
+  }
+
+  & dt {
+    font-size: var(--text12);
+    color: var(--color-grey-darker);
+  }
+
+  & dd {
+    margin: var(--sp4) 0 0;
+    font-family: monospace;
+    font-size: var(--text14);
+    overflow-wrap: anywhere;
+  }
+}
+
+.report {
+  max-height: 420px;
+  padding: var(--sp16);
+  margin: 0;
+  overflow: auto;
+  font-size: var(--text12);
+  line-height: 1.5;
+  color: var(--color-white);
+  white-space: pre-wrap;
+  background: var(--color-black);
+  border-radius: 6px;
+}
+
+.error {
+  margin: var(--sp8) 0 0;
+  font-size: var(--text14);
+  color: var(--color-negative-red);
+  overflow-wrap: anywhere;
+}

--- a/src/views/Me/Settings/Personhood/handoff.ts
+++ b/src/views/Me/Settings/Personhood/handoff.ts
@@ -1,0 +1,160 @@
+export type PersonhoodProofInput = {
+  appId: string
+  cert: string
+  challenge: string
+  challengeExpiresAt?: string
+  signedResponse: string
+}
+
+export type BrowserProofHandoff = {
+  certChainProvingKeyUrl: string
+  certChainType: 'rs4096'
+  handoffExpiresAt?: string
+  handoffToken: string
+  linkVerifyUrl: string
+  proofInput: PersonhoodProofInput
+  returnUrl: string
+  savedAt: string
+  smtSnapshotUrl: string
+  source: 'matters-web'
+  userSigProvingKeyUrl: string
+  version: 1
+}
+
+export const BROWSER_PROOF_ROUTE = '/me/settings/personhood/prove'
+export const BROWSER_PROOF_HANDOFF_STORAGE_KEY =
+  'matters.personhood.browserProofHandoff.v1'
+
+export const CERT_CHAIN_PROVING_KEY_URL =
+  'https://github.com/zkmopro/zkID/releases/download/latest/cert_chain_rs4096_proving.key.gz'
+export const USER_SIG_PROVING_KEY_URL =
+  'https://github.com/zkmopro/zkID/releases/download/latest/user_sig_rs2048_proving.key.gz'
+export const SMT_SNAPSHOT_URL =
+  'https://github.com/moven0831/moica-revocation-smt/releases/download/snapshot-latest/g3-tree-snapshot.json.gz'
+
+const BROWSER_PROOF_HANDOFF_MAX_AGE_MS = 15 * 60 * 1000
+
+export const parseHandoffTime = (value?: string) => {
+  if (!value) {
+    return undefined
+  }
+
+  const numeric = Number(value)
+  if (Number.isFinite(numeric)) {
+    return numeric > 1_000_000_000_000 ? numeric : numeric * 1000
+  }
+
+  const parsed = Date.parse(value)
+  return Number.isNaN(parsed) ? undefined : parsed
+}
+
+const getBrowserProofHandoffStorages = () => {
+  if (typeof window === 'undefined') {
+    return []
+  }
+
+  return [window.sessionStorage, window.localStorage]
+}
+
+export const isExpiredBrowserProofHandoff = (handoff: BrowserProofHandoff) => {
+  const savedAt = parseHandoffTime(handoff.savedAt)
+  const challengeExpiresAt = parseHandoffTime(
+    handoff.proofInput.challengeExpiresAt
+  )
+  const handoffExpiresAt = parseHandoffTime(handoff.handoffExpiresAt)
+  const now = Date.now()
+
+  return (
+    (savedAt ? now - savedAt > BROWSER_PROOF_HANDOFF_MAX_AGE_MS : true) ||
+    (challengeExpiresAt ? now > challengeExpiresAt : false) ||
+    (handoffExpiresAt ? now > handoffExpiresAt : false)
+  )
+}
+
+export const buildBrowserProofHandoff = ({
+  handoffExpiresAt,
+  handoffToken,
+  origin,
+  proofInput,
+  returnUrl,
+}: {
+  handoffExpiresAt?: string
+  handoffToken: string
+  origin: string
+  proofInput: PersonhoodProofInput
+  returnUrl: string
+}): BrowserProofHandoff => ({
+  certChainProvingKeyUrl: CERT_CHAIN_PROVING_KEY_URL,
+  certChainType: 'rs4096',
+  handoffExpiresAt,
+  handoffToken,
+  linkVerifyUrl: `${origin}/api/personhood/zkid/link-verify`,
+  proofInput,
+  returnUrl,
+  savedAt: new Date().toISOString(),
+  smtSnapshotUrl: SMT_SNAPSHOT_URL,
+  source: 'matters-web',
+  userSigProvingKeyUrl: USER_SIG_PROVING_KEY_URL,
+  version: 1,
+})
+
+export const saveBrowserProofHandoff = (handoff: BrowserProofHandoff) => {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  const value = JSON.stringify(handoff)
+  for (const storage of getBrowserProofHandoffStorages()) {
+    try {
+      storage.setItem(BROWSER_PROOF_HANDOFF_STORAGE_KEY, value)
+    } catch {
+      // Keep navigation usable if one storage backend is unavailable.
+    }
+  }
+}
+
+export const loadBrowserProofHandoff = () => {
+  if (typeof window === 'undefined') {
+    return undefined
+  }
+
+  for (const storage of getBrowserProofHandoffStorages()) {
+    try {
+      const raw = storage.getItem(BROWSER_PROOF_HANDOFF_STORAGE_KEY)
+      if (!raw) {
+        continue
+      }
+
+      const handoff = JSON.parse(raw) as BrowserProofHandoff
+      if (!handoff.proofInput || !handoff.handoffToken) {
+        storage.removeItem(BROWSER_PROOF_HANDOFF_STORAGE_KEY)
+        continue
+      }
+
+      if (isExpiredBrowserProofHandoff(handoff)) {
+        storage.removeItem(BROWSER_PROOF_HANDOFF_STORAGE_KEY)
+        continue
+      }
+
+      return handoff
+    } catch {
+      storage.removeItem(BROWSER_PROOF_HANDOFF_STORAGE_KEY)
+    }
+  }
+
+  return undefined
+}
+
+export const clearBrowserProofHandoff = () => {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  for (const storage of getBrowserProofHandoffStorages()) {
+    try {
+      storage.removeItem(BROWSER_PROOF_HANDOFF_STORAGE_KEY)
+    } catch {
+      // Ignore storage cleanup failures.
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- replace the native proof helper entry with a PWA-first browser proof handoff button after TW FidO signing
- add `/me/settings/personhood/prove` to hold signed proof input in same-origin browser storage and run proving preflight checks
- add cross-origin isolation headers for the new proof route and update i18n messages

## Validation
- `npm run lint:css`
- `npx next lint --file src/pages/me/settings/personhood/prove.tsx --file src/views/Me/Settings/Personhood/handoff.ts --file src/views/Me/Settings/Personhood/Feasibility/index.tsx --file src/views/Me/Settings/Personhood/Prove/index.tsx`
- `npx prettier --check next.config.ts src/common/enums/route.ts src/pages/me/settings/personhood/prove.tsx src/views/Me/Settings/Personhood/handoff.ts src/views/Me/Settings/Personhood/Feasibility/index.tsx src/views/Me/Settings/Personhood/Prove/index.tsx src/views/Me/Settings/Personhood/Prove/styles.module.css`
- `curl -sI http://localhost:3037/me/settings/personhood/prove | rg -i 'HTTP|cross-origin|content-security'`
- `curl -sI http://localhost:3037/me/settings/personhood/feasibility | rg -i 'HTTP|cross-origin'`
- `npx tsc --project tsconfig.json --noEmit --pretty false` still fails on existing generated schema drift in Community Watch and viewer feature fields, with no Personhood errors in the filtered output

## Notes
- The proof worker is intentionally marked pending in this slice. The next PR can mount the zkID `wallet-unit-poc/web` worker on this handoff route.
- Browser render was checked with the Codex Browser plugin against local dev. The route returns 200 and protected-page login state locally; full signed mobile flow should be validated on `matters.icu` after merge because local localhost has no authenticated Matters session.
