### PR TITLE
fix(personhood): always isolate proof routes

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -11,8 +11,10 @@ import {
 
 const isLocal = process.env.NEXT_PUBLIC_RUNTIME_ENV === 'local'
 const nextAssetDomain = process.env.NEXT_PUBLIC_NEXT_ASSET_DOMAIN || ''
-const personhoodCrossOriginIsolated =
-  process.env.NEXT_PUBLIC_PERSONHOOD_CROSS_ORIGIN_ISOLATED === 'true'
+const personhoodCrossOriginIsolatedRoutes = [
+  '/me/settings/personhood/feasibility',
+  '/me/settings/personhood/prove',
+]
 
 const nextConfig: NextConfig = {
   experimental: {
@@ -24,24 +26,19 @@ const nextConfig: NextConfig = {
 
   headers: async () => {
     return [
-      ...(personhoodCrossOriginIsolated
-        ? [
-            '/me/settings/personhood/feasibility',
-            '/me/settings/personhood/prove',
-          ].map((source) => ({
-            source,
-            headers: [
-              {
-                key: 'Cross-Origin-Opener-Policy',
-                value: 'same-origin',
-              },
-              {
-                key: 'Cross-Origin-Embedder-Policy',
-                value: 'require-corp',
-              },
-            ],
-          }))
-        : []),
+      ...personhoodCrossOriginIsolatedRoutes.map((source) => ({
+        source,
+        headers: [
+          {
+            key: 'Cross-Origin-Opener-Policy',
+            value: 'same-origin',
+          },
+          {
+            key: 'Cross-Origin-Embedder-Policy',
+            value: 'require-corp',
+          },
+        ],
+      })),
       {
         source: '/(.*)',
         headers: [


### PR DESCRIPTION
## Summary
- always apply COOP/COEP headers on personhood feasibility and browser proof routes
- removes the build-time env gate that made `crossOriginIsolated` false on matters.icu develop

## Validation
- `npx prettier --check next.config.ts`
- `git diff --check`
- `curl -sI http://localhost:3038/me/settings/personhood/prove | rg -i 'HTTP|cross-origin'`
- `curl -sI http://localhost:3038/me/settings/personhood/feasibility | rg -i 'HTTP|cross-origin'`

## Notes
- This is required before browser proving, otherwise SharedArrayBuffer-dependent WASM workers will stay blocked even after the PWA handoff page deploys.
