### PR TITLE
fix(personhood): remove page-level COEP headers

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -11,10 +11,6 @@ import {
 
 const isLocal = process.env.NEXT_PUBLIC_RUNTIME_ENV === 'local'
 const nextAssetDomain = process.env.NEXT_PUBLIC_NEXT_ASSET_DOMAIN || ''
-const personhoodCrossOriginIsolatedRoutes = [
-  '/me/settings/personhood/feasibility',
-  '/me/settings/personhood/prove',
-]
 
 const nextConfig: NextConfig = {
   experimental: {
@@ -26,19 +22,6 @@ const nextConfig: NextConfig = {
 
   headers: async () => {
     return [
-      ...personhoodCrossOriginIsolatedRoutes.map((source) => ({
-        source,
-        headers: [
-          {
-            key: 'Cross-Origin-Opener-Policy',
-            value: 'same-origin',
-          },
-          {
-            key: 'Cross-Origin-Embedder-Policy',
-            value: 'require-corp',
-          },
-        ],
-      })),
       {
         source: '/(.*)',
         headers: [


### PR DESCRIPTION
## Summary
- remove page-level COOP/COEP headers from personhood routes
- restores Matters pages when assets are served from `assets-next-dev.mattersprotocol.io` without CORP/CORS headers

## Why
`Cross-Origin-Embedder-Policy: require-corp` breaks pages that load Next.js JS/CSS from the cross-origin asset domain unless the asset responses include `Cross-Origin-Resource-Policy` or CORS headers. The live `assets-next-dev.mattersprotocol.io` assets currently do not include those headers, so the page can fail to hydrate.

## Validation
- `npx prettier --check next.config.ts`
- `git diff --check`
- Live investigation confirmed personhood page HTML is 200 while cross-origin assets lack CORP/CORS headers.

## Follow-up
Browser proving still needs cross-origin isolation. That should be done by either adding CORP/CORS headers to the asset CDN or moving the actual prover into an isolated route/origin that does not load the normal Matters cross-origin asset bundle.
