### PR TITLE
feat(personhood): mount zkid input preflight worker

### DIFF
--- a/src/pages/api/personhood/prover.ts
+++ b/src/pages/api/personhood/prover.ts
@@ -1,6 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 
 const HANDOFF_STORAGE_KEY = 'matters.personhood.browserProofHandoff.v1'
+const PROVER_ASSET_BASE = '/api/personhood/prover/assets'
 
 const handler = (_req: NextApiRequest, res: NextApiResponse) => {
   res.setHeader('Content-Type', 'text/html; charset=utf-8')
@@ -20,7 +21,7 @@ const handler = (_req: NextApiRequest, res: NextApiResponse) => {
       "img-src 'none'",
       "connect-src 'self'",
       "style-src 'unsafe-inline'",
-      "script-src 'unsafe-inline' 'wasm-unsafe-eval'",
+      "script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval'",
       "worker-src 'self' blob:",
     ].join('; ')
   )
@@ -178,7 +179,7 @@ const getHtml = () => `<!doctype html>
       <h2>Handoff</h2>
       <dl id="handoff"></dl>
       <p id="message" class="error"></p>
-      <button id="run" disabled>Run browser proof</button>
+      <button id="run" disabled>Run proof preflight</button>
       <button id="copy" class="secondary">Copy report</button>
       <a id="back" class="button secondary" href="/me/settings/personhood/prove">Back</a>
     </section>
@@ -191,6 +192,7 @@ const getHtml = () => `<!doctype html>
     <script>
       (() => {
         const storageKey = ${JSON.stringify(HANDOFF_STORAGE_KEY)};
+        const assetBase = ${JSON.stringify(PROVER_ASSET_BASE)};
         const maxAgeMs = 15 * 60 * 1000;
         const readinessEl = document.getElementById('readiness');
         const handoffEl = document.getElementById('handoff');
@@ -198,6 +200,7 @@ const getHtml = () => `<!doctype html>
         const reportEl = document.getElementById('report');
         const backEl = document.getElementById('back');
         const copyEl = document.getElementById('copy');
+        const runEl = document.getElementById('run');
 
         const parseTime = (value) => {
           if (!value) return undefined;
@@ -256,6 +259,11 @@ const getHtml = () => `<!doctype html>
           );
         };
 
+        const proofWorker = {
+          status: 'pending',
+          inputStatus: 'not_started',
+        };
+
         const readiness = {
           checkedAt: new Date().toISOString(),
           secureContext: window.isSecureContext,
@@ -293,24 +301,39 @@ const getHtml = () => `<!doctype html>
           messageEl.textContent = 'The browser handoff has expired. Return to Matters and request a fresh TW FidO signature.';
         } else {
           messageEl.textContent = readiness.crossOriginIsolated
-            ? 'Isolated prover container is ready. The zkID worker will mount here in the next slice.'
+            ? 'Isolated prover container is ready. Run the browser proof preflight to mount the zkID worker and build circuit inputs.'
             : 'This page is not isolated. Browser proof cannot run here.';
           messageEl.className = readiness.crossOriginIsolated ? '' : 'error';
         }
 
-        handoffEl.append(
-          metric('Handoff', handoff && !expired ? 'ready' : 'missing'),
-          metric('APP_ID', handoff?.proofInput?.appId || 'missing'),
-          metric('Challenge expires', handoff?.proofInput?.challengeExpiresAt || 'missing'),
-          metric('Handoff expires', handoff?.handoffExpiresAt || 'missing'),
-          metric('Cert payload', formatBytes(encodedBytes(handoff?.proofInput?.cert))),
-          metric('Signature payload', formatBytes(encodedBytes(handoff?.proofInput?.signedResponse))),
-          metric('Proof worker', 'pending')
-        );
+        const canRun = !!handoff && !expired && readiness.crossOriginIsolated &&
+          readiness.sharedArrayBuffer && readiness.webAssembly && readiness.worker;
+        runEl.disabled = !canRun;
+
+        const renderHandoff = () => {
+          handoffEl.innerHTML = '';
+          handoffEl.append(
+            metric('Handoff', handoff && !expired ? 'ready' : 'missing'),
+            metric('APP_ID', handoff?.proofInput?.appId || 'missing'),
+            metric('Challenge expires', handoff?.proofInput?.challengeExpiresAt || 'missing'),
+            metric('Handoff expires', handoff?.handoffExpiresAt || 'missing'),
+            metric('Cert payload', formatBytes(encodedBytes(handoff?.proofInput?.cert))),
+            metric('Signature payload', formatBytes(encodedBytes(handoff?.proofInput?.signedResponse))),
+            metric('Proof worker', proofWorker.status),
+            metric('Input builder', proofWorker.inputStatus),
+            metric('Issuer bits', proofWorker.issuerBits ? String(proofWorker.issuerBits) : 'pending'),
+            metric('Certificate serial', proofWorker.serialParsed ? 'parsed' : 'pending'),
+            metric('Cert input', proofWorker.certInputBytes ? formatBytes(proofWorker.certInputBytes) : 'pending'),
+            metric('User-sig input', proofWorker.userSigInputBytes ? formatBytes(proofWorker.userSigInputBytes) : 'pending')
+          );
+        };
+
+        renderHandoff();
 
         const report = {
           location: '/api/personhood/prover',
           readiness,
+          proofWorker,
           handoff: handoff
             ? {
                 appId: handoff.proofInput?.appId,
@@ -324,7 +347,142 @@ const getHtml = () => `<!doctype html>
               }
             : undefined,
         };
-        reportEl.textContent = JSON.stringify(report, null, 2);
+        const renderReport = () => {
+          report.proofWorker = proofWorker;
+          reportEl.textContent = JSON.stringify(report, null, 2);
+        };
+        renderReport();
+
+        const setWorkerState = (patch) => {
+          Object.assign(proofWorker, patch);
+          renderHandoff();
+          renderReport();
+        };
+
+        const createWorkerSource = () => {
+          const moduleUrl = new URL(assetBase + '/spartan2_wasm.js', location.origin).href;
+          const wasmUrl = new URL(assetBase + '/spartan2_wasm_bg.wasm', location.origin).href;
+          const issuerCertUrl = new URL(assetBase + '/moica-g3.cer', location.origin).href;
+
+          return \`
+            const base64ToBytes = (value) => {
+              const normalized = String(value || '').replace(/-/g, '+').replace(/_/g, '/');
+              const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, '=');
+              const raw = atob(padded);
+              const bytes = new Uint8Array(raw.length);
+              for (let i = 0; i < raw.length; i += 1) bytes[i] = raw.charCodeAt(i);
+              return bytes;
+            };
+
+            const byteLength = (value) => new TextEncoder().encode(value).byteLength;
+
+            self.onmessage = async (event) => {
+              const handoff = event.data?.handoff;
+              try {
+                self.postMessage({ type: 'progress', status: 'importing_wasm' });
+                const zkid = await import(\${JSON.stringify(moduleUrl)});
+
+                self.postMessage({ type: 'progress', status: 'initializing_wasm' });
+                await zkid.default(\${JSON.stringify(wasmUrl)});
+
+                self.postMessage({ type: 'progress', status: 'loading_certificates' });
+                const userCertDer = base64ToBytes(handoff.proofInput.cert);
+                const issuerCertRes = await fetch(\${JSON.stringify(issuerCertUrl)}, {
+                  cache: 'force-cache',
+                });
+                if (!issuerCertRes.ok) {
+                  throw new Error('MOICA-G3 certificate fetch failed: ' + issuerCertRes.status);
+                }
+                const issuerCertDer = new Uint8Array(await issuerCertRes.arrayBuffer());
+
+                self.postMessage({ type: 'progress', status: 'building_inputs' });
+                const serialHex = zkid.cert_serial_hex(userCertDer);
+                const issuerBits = zkid.cert_modulus_bits(issuerCertDer);
+                const appIdBytes = new TextEncoder().encode(handoff.proofInput.appId);
+                const splitInputs = zkid.build_split_inputs(
+                  userCertDer,
+                  issuerCertDer,
+                  handoff.proofInput.signedResponse,
+                  appIdBytes,
+                  serialHex,
+                  null,
+                  34,
+                  17,
+                  handoff.proofInput.challenge
+                );
+                const certJson = JSON.stringify(splitInputs.cert_chain);
+                const userSigJson = JSON.stringify(splitInputs.user_sig);
+
+                self.postMessage({
+                  type: 'input_ready',
+                  issuerBits,
+                  appIdBytes: appIdBytes.byteLength,
+                  certInputBytes: byteLength(certJson),
+                  userSigInputBytes: byteLength(userSigJson),
+                });
+              } catch (error) {
+                self.postMessage({
+                  type: 'error',
+                  message: error instanceof Error ? error.message : String(error),
+                });
+              }
+            };
+          \`;
+        };
+
+        runEl.addEventListener('click', () => {
+          if (!canRun || !handoff) return;
+          runEl.disabled = true;
+          setWorkerState({ status: 'running', inputStatus: 'starting' });
+          messageEl.textContent = 'Starting zkID browser worker preflight.';
+          messageEl.className = '';
+
+          const workerUrl = URL.createObjectURL(new Blob([createWorkerSource()], {
+            type: 'text/javascript',
+          }));
+          const worker = new Worker(workerUrl, { type: 'module' });
+          worker.onmessage = (event) => {
+            const data = event.data || {};
+            if (data.type === 'progress') {
+              setWorkerState({ inputStatus: data.status });
+              return;
+            }
+            if (data.type === 'input_ready') {
+              setWorkerState({
+                status: 'input_ready',
+                inputStatus: 'ready',
+                serialParsed: true,
+                issuerBits: data.issuerBits,
+                appIdBytes: data.appIdBytes,
+                certInputBytes: data.certInputBytes,
+                userSigInputBytes: data.userSigInputBytes,
+              });
+              messageEl.textContent = 'zkID worker mounted and circuit inputs are ready. Full witness and proof generation is the next slice.';
+              worker.terminate();
+              URL.revokeObjectURL(workerUrl);
+              runEl.disabled = false;
+              return;
+            }
+            if (data.type === 'error') {
+              setWorkerState({ status: 'error', inputStatus: data.message || 'failed' });
+              messageEl.textContent = data.message || 'zkID worker preflight failed.';
+              messageEl.className = 'error';
+              worker.terminate();
+              URL.revokeObjectURL(workerUrl);
+              runEl.disabled = false;
+            }
+          };
+          worker.onerror = (event) => {
+            setWorkerState({ status: 'error', inputStatus: event.message || 'worker crashed' });
+            messageEl.textContent = event.message || 'zkID worker crashed.';
+            messageEl.className = 'error';
+            worker.terminate();
+            URL.revokeObjectURL(workerUrl);
+            runEl.disabled = false;
+          };
+          worker.postMessage({ handoff });
+        });
+
         copyEl.addEventListener('click', async () => {
           await navigator.clipboard?.writeText(reportEl.textContent || '');
           copyEl.textContent = 'Copied';

--- a/src/pages/api/personhood/prover/assets/[[...asset]].ts
+++ b/src/pages/api/personhood/prover/assets/[[...asset]].ts
@@ -1,0 +1,104 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { gunzipSync } from 'zlib'
+
+type ProverAsset = {
+  contentType: string
+  patch?: (body: Buffer) => Buffer
+  url: string
+  gzip?: boolean
+}
+
+const ZKID_RELEASE = 'https://github.com/zkmopro/zkID/releases/download/latest'
+
+const ASSETS: Record<string, ProverAsset> = {
+  'spartan2_wasm.js': {
+    contentType: 'application/javascript; charset=utf-8',
+    gzip: true,
+    patch: patchSpartan2WasmJs,
+    url: `${ZKID_RELEASE}/spartan2_wasm.js.gz`,
+  },
+  'spartan2_wasm_bg.wasm': {
+    contentType: 'application/wasm',
+    gzip: true,
+    url: `${ZKID_RELEASE}/spartan2_wasm_bg.wasm.gz`,
+  },
+  'moica-g3.cer': {
+    contentType: 'application/pkix-cert',
+    url: 'https://moica.nat.gov.tw/repository/Certs/MOICA-G3.cer',
+  },
+}
+
+const handler = async (req: NextApiRequest, res: NextApiResponse) => {
+  const path = Array.isArray(req.query.asset)
+    ? req.query.asset.join('/')
+    : req.query.asset
+
+  if (!path) {
+    sendJs(res, 'export * from "./spartan2_wasm.js";\n')
+    return
+  }
+
+  const asset = ASSETS[path]
+  if (!asset) {
+    res.status(404).json({ error: 'asset_not_found' })
+    return
+  }
+
+  try {
+    const upstream = await fetch(asset.url, {
+      headers: { Accept: '*/*' },
+    })
+
+    if (!upstream.ok) {
+      res.status(upstream.status).json({
+        error: 'asset_fetch_failed',
+        status: upstream.status,
+        statusText: upstream.statusText,
+      })
+      return
+    }
+
+    const raw = Buffer.from(await upstream.arrayBuffer())
+    const body = asset.patch
+      ? asset.patch(asset.gzip ? gunzipSync(raw) : raw)
+      : asset.gzip
+        ? gunzipSync(raw)
+        : raw
+
+    res.setHeader('Content-Type', asset.contentType)
+    res.setHeader('Cache-Control', 'public, max-age=3600, immutable')
+    res.setHeader('Cross-Origin-Resource-Policy', 'same-origin')
+    res.setHeader('X-Content-Type-Options', 'nosniff')
+    res.status(200).send(body)
+  } catch (error) {
+    res.status(502).json({
+      error: 'asset_proxy_failed',
+      message: error instanceof Error ? error.message : String(error),
+    })
+  }
+}
+
+export default handler
+
+function sendJs(res: NextApiResponse, source: string) {
+  res.setHeader('Content-Type', 'application/javascript; charset=utf-8')
+  res.setHeader('Cache-Control', 'public, max-age=3600, immutable')
+  res.setHeader('Cross-Origin-Resource-Policy', 'same-origin')
+  res.setHeader('X-Content-Type-Options', 'nosniff')
+  res.status(200).send(source)
+}
+
+function patchSpartan2WasmJs(body: Buffer) {
+  const source = body.toString('utf8')
+  return Buffer.from(
+    source.replace(
+      "import { startWorkers } from './snippets/wasm-bindgen-rayon-38edf6e439f6d70d/src/workerHelpers.js';",
+      [
+        'async function startWorkers() {',
+        "  throw new Error('Threaded proving is disabled in the Matters browser preflight build.');",
+        '}',
+      ].join('\n')
+    ),
+    'utf8'
+  )
+}


### PR DESCRIPTION
## Summary
- add a same-origin `/api/personhood/prover/assets/*` proxy for zkID wasm bindings and MOICA-G3 issuer certificate
- update the isolated prover shell so `Run proof preflight` mounts a module Worker, initializes zkID wasm, parses the TW FidO handoff cert, and builds cert-chain/user-sig circuit inputs
- keep private payloads out of the report; the report only exposes readiness, status, input sizes, app id, challenge metadata, and issuer bit width

## Validation
- `npx next lint --file src/pages/api/personhood/prover.ts --file src/pages/api/personhood/prover/assets/[[...asset]].ts`
- `npm run lint:css`
- `git diff --check`
- `npx tsc --project tsconfig.json --noEmit --pretty false` checked for personhood paths; remaining errors are existing unrelated generated schema drift
- local curl verified same-origin asset proxy returns patched JS, wasm, and MOICA-G3 cert with CORP headers
- local mobile-size Playwright smoke verified `crossOriginIsolated=true`, `SharedArrayBuffer=true`, `Run proof preflight` reaches `input_ready`, and report does not leak full cert serial

## Notes
- this PR stops at input-builder preflight; witness generation, proving-key streaming, proof generation, and submit remain the next slice
- Browser plugin invocation failed locally because the MCP Chrome profile was already in use, so rendered validation used Playwright with system Chrome
