### PR TITLE
Add desktop personhood prover handoff link

### DIFF
--- a/docs/personhood-proving-rollout.md
+++ b/docs/personhood-proving-rollout.md
@@ -1,0 +1,43 @@
+# Personhood Proving Rollout
+
+## Current split
+
+The personhood rollout now has two proving lanes.
+
+1. Desktop browser proving
+   - TW FidO signing still starts on the phone.
+   - Matters creates the zkID handoff after the phone returns with a signature.
+   - The user can copy a Mac proof link and open it on a desktop browser.
+   - The handoff is carried in the URL fragment, so it is not sent in the HTTP request for the isolated prover page.
+   - The isolated prover imports the fragment into local storage, removes the fragment from browser history, and runs the browser proof.
+
+2. iPhone Safari proving
+   - iPhone Safari exposes the required APIs on the isolated page.
+   - The current RS4096 browser prover is not safe to run there because the proof key and wasm allocations can trigger WebKit WebContent process termination.
+   - The iPhone path is guarded so users do not repeatedly hit Safari's reload loop.
+   - `?force=1` remains available only for controlled debugging.
+
+## Why iPhone is blocked
+
+The current proof path needs a 693 MiB decompressed cert-chain proving key plus wasm runtime and witness memory. Even after streaming the key and proving sequentially, iPhone Safari still reloads the page and eventually shows "A problem repeatedly occurred" on the isolated prover URL. This behavior matches WebKit WebContent memory termination rather than a normal JavaScript exception.
+
+Relevant external notes:
+
+- Apple Developer Forums have recent reports of `com.apple.WebKit.WebContent` being killed by iOS `memorystatus` after hitting an ActiveHard memory limit around 2048 MiB: https://developer.apple.com/forums/thread/823061
+- WebKit memory analysis from Catch Metrics describes iOS WebKit page termination by Jetsam under high memory pressure: https://www.catchmetrics.io/blog/deep-dive-ram-internals-webkit
+- Existing WebAssembly issue reports from Godot and Emscripten show iOS Safari failures when wasm memory is configured too high or repeatedly loaded: https://github.com/godotengine/godot/issues/70621 and https://github.com/emscripten-core/emscripten/issues/19374
+
+## Next iPhone options
+
+Recommended order:
+
+1. Keep iPhone as TW FidO signer plus handoff carrier, and use desktop browser proof for develop testing.
+2. Measure the exact high-water memory on desktop and Android Chrome for the current circuits, then set a browser support matrix.
+3. Prototype a server-side proving queue where the server receives only the already-minimized zkID private witness inputs needed for proof generation, never the raw ID number.
+4. Revisit iPhone browser proving only if the zkID circuit or proving key can be reduced enough to stay well below iOS WebContent limits.
+
+Non-goals for the next slice:
+
+- Do not ask general users to install Xcode or a native helper app.
+- Do not keep retrying the current full RS4096 browser proof on iPhone Safari.
+- Do not send TW FidO `signed_response` through query strings or server logs.

--- a/src/pages/api/personhood/prover.ts
+++ b/src/pages/api/personhood/prover.ts
@@ -2,6 +2,7 @@ import type { NextApiRequest, NextApiResponse } from 'next'
 
 const HANDOFF_STORAGE_KEY = 'matters.personhood.browserProofHandoff.v1'
 const RUN_STATE_STORAGE_KEY = 'matters.personhood.browserProofRunState.v1'
+const HANDOFF_FRAGMENT_KEY = 'personhood_handoff'
 const PROVER_ASSET_BASE = '/api/personhood/prover/assets'
 
 const handler = (_req: NextApiRequest, res: NextApiResponse) => {
@@ -194,6 +195,7 @@ const getHtml = () => `<!doctype html>
       (() => {
         const storageKey = ${JSON.stringify(HANDOFF_STORAGE_KEY)};
         const runStateKey = ${JSON.stringify(RUN_STATE_STORAGE_KEY)};
+        const handoffFragmentKey = ${JSON.stringify(HANDOFF_FRAGMENT_KEY)};
         const assetBase = ${JSON.stringify(PROVER_ASSET_BASE)};
         const maxAgeMs = 15 * 60 * 1000;
         const readinessEl = document.getElementById('readiness');
@@ -204,6 +206,7 @@ const getHtml = () => `<!doctype html>
         const copyEl = document.getElementById('copy');
         const runEl = document.getElementById('run');
         const forceRun = new URLSearchParams(window.location.search).get('force') === '1';
+        let fragmentImportError;
 
         const parseTime = (value) => {
           if (!value) return undefined;
@@ -236,7 +239,55 @@ const getHtml = () => `<!doctype html>
           return item;
         };
 
+        const base64UrlToBytes = (value) => {
+          const normalized = value.replace(/-/g, '+').replace(/_/g, '/');
+          const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, '=');
+          const raw = atob(padded);
+          const bytes = new Uint8Array(raw.length);
+          for (let i = 0; i < raw.length; i += 1) bytes[i] = raw.charCodeAt(i);
+          return bytes;
+        };
+
+        const getFragmentHandoff = () => {
+          if (!window.location.hash) return undefined;
+          const fragment = window.location.hash.startsWith('#')
+            ? window.location.hash.slice(1)
+            : window.location.hash;
+          const params = new URLSearchParams(fragment);
+          const encoded = params.get(handoffFragmentKey);
+          if (!encoded) return undefined;
+
+          try {
+            const handoff = JSON.parse(
+              new TextDecoder().decode(base64UrlToBytes(encoded))
+            );
+            if (!handoff?.proofInput || !handoff?.handoffToken) {
+              throw new Error('invalid handoff');
+            }
+            return handoff;
+          } catch {
+            fragmentImportError = 'The desktop proof handoff link is invalid. Return to Matters and copy a fresh link.';
+            return undefined;
+          }
+        };
+
         const getStoredHandoff = () => {
+          const fragmentHandoff = getFragmentHandoff();
+          if (fragmentHandoff) {
+            const value = JSON.stringify(fragmentHandoff);
+            for (const storage of [window.sessionStorage, window.localStorage]) {
+              try {
+                storage.setItem(storageKey, value);
+              } catch {}
+            }
+            window.history.replaceState(
+              null,
+              document.title,
+              window.location.pathname + window.location.search
+            );
+            return fragmentHandoff;
+          }
+
           for (const storage of [window.sessionStorage, window.localStorage]) {
             try {
               const raw = storage.getItem(storageKey);
@@ -354,7 +405,10 @@ const getHtml = () => `<!doctype html>
           backEl.href = handoff.returnUrl;
         }
 
-        if (!handoff) {
+        if (fragmentImportError) {
+          messageEl.textContent = fragmentImportError;
+          messageEl.className = 'error';
+        } else if (!handoff) {
           messageEl.textContent = 'No browser handoff was found. Return to Matters and start from the proof page.';
         } else if (expired) {
           messageEl.textContent = 'The browser handoff has expired. Return to Matters and request a fresh TW FidO signature.';

--- a/src/views/Me/Settings/Personhood/Feasibility/index.tsx
+++ b/src/views/Me/Settings/Personhood/Feasibility/index.tsx
@@ -8,6 +8,7 @@ import settingsStyles from '../../styles.module.css'
 import {
   BROWSER_PROOF_ROUTE,
   buildBrowserProofHandoff,
+  buildIsolatedProverUrl,
   type PersonhoodProofInput,
   saveBrowserProofHandoff,
 } from '../handoff'
@@ -249,6 +250,7 @@ const PersonhoodFeasibility = () => {
   const [running, setRunning] = useState<'basic' | 'wasm' | null>(null)
   const [copied, setCopied] = useState(false)
   const [browserProofError, setBrowserProofError] = useState<string>()
+  const [desktopLinkCopied, setDesktopLinkCopied] = useState(false)
   const [twFido, setTwFido] = useState<TwFidoState>({
     idNum: '',
     pollCount: 0,
@@ -621,6 +623,20 @@ const PersonhoodFeasibility = () => {
   const browserHandoffBytes = browserProofHandoff
     ? new TextEncoder().encode(JSON.stringify(browserProofHandoff)).byteLength
     : 0
+  const desktopProverUrl = useMemo(() => {
+    if (!browserProofHandoff || typeof window === 'undefined') {
+      return undefined
+    }
+
+    return buildIsolatedProverUrl({
+      handoff: browserProofHandoff,
+      origin: window.location.origin,
+    })
+  }, [browserProofHandoff])
+  const desktopProverLinkBytes = desktopProverUrl
+    ? new TextEncoder().encode(desktopProverUrl).byteLength
+    : 0
+
   const startBrowserProof = useCallback(() => {
     setBrowserProofError(undefined)
 
@@ -638,6 +654,25 @@ const PersonhoodFeasibility = () => {
       )
     }
   }, [browserProofHandoff])
+
+  const copyDesktopProverLink = useCallback(async () => {
+    setBrowserProofError(undefined)
+
+    if (!desktopProverUrl) {
+      setBrowserProofError('Desktop proof link is not ready.')
+      return
+    }
+
+    try {
+      await navigator.clipboard?.writeText(desktopProverUrl)
+      setDesktopLinkCopied(true)
+      window.setTimeout(() => setDesktopLinkCopied(false), 1600)
+    } catch (error) {
+      setBrowserProofError(
+        error instanceof Error ? error.message : 'Could not copy desktop link.'
+      )
+    }
+  }, [desktopProverUrl])
 
   return (
     <Layout.Main>
@@ -745,11 +780,26 @@ const PersonhoodFeasibility = () => {
                 id="z9jdNT"
               />
             </button>
+            <button
+              className={styles.buttonSecondary}
+              disabled={!desktopProverUrl}
+              onClick={copyDesktopProverLink}
+              type="button"
+            >
+              {desktopLinkCopied ? (
+                <FormattedMessage defaultMessage="Copied" id="p556q3" />
+              ) : (
+                <FormattedMessage
+                  defaultMessage="Copy Mac proof link"
+                  id="Dx5Sas"
+                />
+              )}
+            </button>
           </section>
           <p className={styles.hint}>
             <FormattedMessage
-              defaultMessage="After TW FidO signs, continue in this browser. No native proof helper is required for this PWA path."
-              id="V3oaoZ"
+              defaultMessage="After TW FidO signs, continue here on desktop, or copy the Mac proof link to a desktop browser."
+              id="5YuSaZ"
             />
           </p>
 
@@ -801,6 +851,10 @@ const PersonhoodFeasibility = () => {
             <div>
               <dt>Handoff bytes</dt>
               <dd>{browserHandoffBytes}</dd>
+            </div>
+            <div>
+              <dt>Mac link bytes</dt>
+              <dd>{desktopProverLinkBytes}</dd>
             </div>
             <div>
               <dt>Certificate bytes</dt>

--- a/src/views/Me/Settings/Personhood/handoff.ts
+++ b/src/views/Me/Settings/Personhood/handoff.ts
@@ -25,6 +25,7 @@ export const BROWSER_PROOF_ROUTE = '/me/settings/personhood/prove'
 export const ISOLATED_PROVER_ROUTE = '/api/personhood/prover'
 export const BROWSER_PROOF_HANDOFF_STORAGE_KEY =
   'matters.personhood.browserProofHandoff.v1'
+export const BROWSER_PROOF_HANDOFF_FRAGMENT_KEY = 'personhood_handoff'
 
 export const CERT_CHAIN_PROVING_KEY_URL =
   'https://github.com/zkmopro/zkID/releases/download/latest/cert_chain_rs4096_proving.key.gz'
@@ -113,6 +114,43 @@ export const saveBrowserProofHandoff = (handoff: BrowserProofHandoff) => {
     }
   }
 }
+
+const bytesToBase64Url = (bytes: Uint8Array) => {
+  let binary = ''
+  const chunkSize = 0x8000
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + chunkSize))
+  }
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+const base64UrlToBytes = (value: string) => {
+  const normalized = value.replace(/-/g, '+').replace(/_/g, '/')
+  const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, '=')
+  const raw = atob(padded)
+  const bytes = new Uint8Array(raw.length)
+  for (let i = 0; i < raw.length; i += 1) {
+    bytes[i] = raw.charCodeAt(i)
+  }
+  return bytes
+}
+
+export const encodeBrowserProofHandoff = (handoff: BrowserProofHandoff) =>
+  bytesToBase64Url(new TextEncoder().encode(JSON.stringify(handoff)))
+
+export const decodeBrowserProofHandoff = (encoded: string) =>
+  JSON.parse(
+    new TextDecoder().decode(base64UrlToBytes(encoded))
+  ) as BrowserProofHandoff
+
+export const buildIsolatedProverUrl = ({
+  handoff,
+  origin,
+}: {
+  handoff: BrowserProofHandoff
+  origin: string
+}) =>
+  `${origin}${ISOLATED_PROVER_ROUTE}#${BROWSER_PROOF_HANDOFF_FRAGMENT_KEY}=${encodeBrowserProofHandoff(handoff)}`
 
 export const loadBrowserProofHandoff = () => {
   if (typeof window === 'undefined') {


### PR DESCRIPTION
## Summary
- add a Mac proof link for the TW FidO flow so signed proof input can be transferred from phone to desktop without server-side storage
- import `#personhood_handoff=...` fragments in the isolated prover, persist the handoff locally, then remove the fragment from the visible URL
- document the two-lane rollout: desktop browser proof for develop testing, iPhone Safari guarded while we evaluate lower-memory or server-assisted proving

## Privacy notes
- the handoff is encoded in the URL fragment, so it is not sent in the HTTP request for `/api/personhood/prover`
- the prover removes the fragment with `history.replaceState` immediately after importing it into browser storage

## Validation
- `npx prettier --check src/views/Me/Settings/Personhood/handoff.ts src/views/Me/Settings/Personhood/Feasibility/index.tsx src/pages/api/personhood/prover.ts docs/personhood-proving-rollout.md`
- `npx next lint --file src/views/Me/Settings/Personhood/handoff.ts --file src/views/Me/Settings/Personhood/Feasibility/index.tsx --file src/pages/api/personhood/prover.ts`
- `git diff --check`
- local Chrome-channel Playwright smoke verified desktop fragment import stores the handoff, strips the hash, and enables `Run browser proof`
- local Chrome-channel Playwright smoke verified iPhone Safari UA still disables proving with `ios_safari_rs4096_memory_risk`

## References
- Apple Developer Forums: WebKit.WebContent jetsam memory limit, https://developer.apple.com/forums/thread/823061
- Catch Metrics: WebKit memory and iOS Jetsam behavior, https://www.catchmetrics.io/blog/deep-dive-ram-internals-webkit
- Godot iOS Safari wasm memory issue, https://github.com/godotengine/godot/issues/70621
- Emscripten Safari wasm reload OOM issue, https://github.com/emscripten-core/emscripten/issues/19374
