### PR TITLE
feat(campaign): discussion board on campaign detail page

### DIFF
--- a/lang/default.json
+++ b/lang/default.json
@@ -84,6 +84,10 @@
   "+vVZ/G": {
     "defaultMessage": "Connect"
   },
+  "/0OJlF": {
+    "defaultMessage": "No discussion yet",
+    "description": "src/views/CampaignDetail/Discussion"
+  },
   "/5OvMK": {
     "defaultMessage": "liked your moment"
   },
@@ -278,6 +282,10 @@
   },
   "2/C36c": {
     "defaultMessage": "You do not have permission to perform this action"
+  },
+  "2/u1aP": {
+    "defaultMessage": "Discussion",
+    "description": "src/views/CampaignDetail/Discussion"
   },
   "202PEj": {
     "defaultMessage": "Confirm Matters ID",
@@ -2169,6 +2177,10 @@
     "defaultMessage": "This URL name has already been used, try another one",
     "description": "src/components/Forms/CreateCircleForm/Init.tsx"
   },
+  "VyV+WO": {
+    "defaultMessage": "Only participants can join the discussion.",
+    "description": "src/views/CampaignDetail/Discussion"
+  },
   "VzzYJk": {
     "defaultMessage": "Create"
   },
@@ -2489,6 +2501,10 @@
   "b6x6lm": {
     "defaultMessage": "Enter a clear and concise title"
   },
+  "b8LMpq": {
+    "defaultMessage": "View all {count} comments",
+    "description": "src/views/CampaignDetail/Discussion"
+  },
   "b8ogKp": {
     "defaultMessage": "Add Invitation",
     "description": "src/views/Circle/Settings/ManageInvitation/AddButton/index.tsx"
@@ -2619,6 +2635,10 @@
   "dE4mlL": {
     "defaultMessage": "Submit",
     "description": "src/views/CampaignDetail/Apply/Button/index.tsx"
+  },
+  "dHVTYM": {
+    "defaultMessage": "Share your thoughts with other participants",
+    "description": "src/views/CampaignDetail/Discussion"
   },
   "dK7Dnj": {
     "defaultMessage": "🔥 Claim for free"
@@ -2783,6 +2803,9 @@
   },
   "ftg7GK": {
     "defaultMessage": "Select Date"
+  },
+  "fyKoL1": {
+    "defaultMessage": "Comment sent"
   },
   "g//2O2": {
     "defaultMessage": "Uncollapse",

--- a/lang/en.json
+++ b/lang/en.json
@@ -84,6 +84,10 @@
   "+vVZ/G": {
     "defaultMessage": "Connect"
   },
+  "/0OJlF": {
+    "defaultMessage": "No discussion yet",
+    "description": "src/views/CampaignDetail/Discussion"
+  },
   "/5OvMK": {
     "defaultMessage": "liked your moment"
   },
@@ -278,6 +282,10 @@
   },
   "2/C36c": {
     "defaultMessage": "You do not have permission to perform this action"
+  },
+  "2/u1aP": {
+    "defaultMessage": "Discussion",
+    "description": "src/views/CampaignDetail/Discussion"
   },
   "202PEj": {
     "defaultMessage": "Confirm Matters ID",
@@ -2169,6 +2177,10 @@
     "defaultMessage": "This URL name has already been used, try another one",
     "description": "src/components/Forms/CreateCircleForm/Init.tsx"
   },
+  "VyV+WO": {
+    "defaultMessage": "Only participants can join the discussion.",
+    "description": "src/views/CampaignDetail/Discussion"
+  },
   "VzzYJk": {
     "defaultMessage": "Create"
   },
@@ -2489,6 +2501,10 @@
   "b6x6lm": {
     "defaultMessage": "Enter a clear and concise title"
   },
+  "b8LMpq": {
+    "defaultMessage": "View all {count} comments",
+    "description": "src/views/CampaignDetail/Discussion"
+  },
   "b8ogKp": {
     "defaultMessage": "Add Invitation",
     "description": "src/views/Circle/Settings/ManageInvitation/AddButton/index.tsx"
@@ -2619,6 +2635,10 @@
   "dE4mlL": {
     "defaultMessage": "Submit",
     "description": "src/views/CampaignDetail/Apply/Button/index.tsx"
+  },
+  "dHVTYM": {
+    "defaultMessage": "Share your thoughts with other participants",
+    "description": "src/views/CampaignDetail/Discussion"
   },
   "dK7Dnj": {
     "defaultMessage": "🔥 Claim for free"
@@ -2783,6 +2803,9 @@
   },
   "ftg7GK": {
     "defaultMessage": "Select Date"
+  },
+  "fyKoL1": {
+    "defaultMessage": "Comment sent"
   },
   "g//2O2": {
     "defaultMessage": "Uncollapse",

--- a/lang/zh-Hans.json
+++ b/lang/zh-Hans.json
@@ -84,6 +84,10 @@
   "+vVZ/G": {
     "defaultMessage": "绑定"
   },
+  "/0OJlF": {
+    "defaultMessage": "No discussion yet",
+    "description": "src/views/CampaignDetail/Discussion"
+  },
   "/5OvMK": {
     "defaultMessage": "喜欢你的动态"
   },
@@ -278,6 +282,10 @@
   },
   "2/C36c": {
     "defaultMessage": "你无权进行此操作"
+  },
+  "2/u1aP": {
+    "defaultMessage": "Discussion",
+    "description": "src/views/CampaignDetail/Discussion"
   },
   "202PEj": {
     "defaultMessage": "确认 Matters ID",
@@ -2169,6 +2177,10 @@
     "defaultMessage": "Oops！此网址名称已被使用了，换一个试试",
     "description": "src/components/Forms/CreateCircleForm/Init.tsx"
   },
+  "VyV+WO": {
+    "defaultMessage": "Only participants can join the discussion.",
+    "description": "src/views/CampaignDetail/Discussion"
+  },
   "VzzYJk": {
     "defaultMessage": "新建"
   },
@@ -2489,6 +2501,10 @@
   "b6x6lm": {
     "defaultMessage": "输入简单明了的标题"
   },
+  "b8LMpq": {
+    "defaultMessage": "View all {count} comments",
+    "description": "src/views/CampaignDetail/Discussion"
+  },
   "b8ogKp": {
     "defaultMessage": "新增邀请",
     "description": "src/views/Circle/Settings/ManageInvitation/AddButton/index.tsx"
@@ -2619,6 +2635,10 @@
   "dE4mlL": {
     "defaultMessage": "投稿",
     "description": "src/views/CampaignDetail/Apply/Button/index.tsx"
+  },
+  "dHVTYM": {
+    "defaultMessage": "Share your thoughts with other participants",
+    "description": "src/views/CampaignDetail/Discussion"
   },
   "dK7Dnj": {
     "defaultMessage": "🔥 免费提领"
@@ -2783,6 +2803,9 @@
   },
   "ftg7GK": {
     "defaultMessage": "选择日期"
+  },
+  "fyKoL1": {
+    "defaultMessage": "Comment sent"
   },
   "g//2O2": {
     "defaultMessage": "取消折叠",

--- a/lang/zh-Hant.json
+++ b/lang/zh-Hant.json
@@ -84,6 +84,10 @@
   "+vVZ/G": {
     "defaultMessage": "綁定"
   },
+  "/0OJlF": {
+    "defaultMessage": "No discussion yet",
+    "description": "src/views/CampaignDetail/Discussion"
+  },
   "/5OvMK": {
     "defaultMessage": "喜歡你的動態"
   },
@@ -278,6 +282,10 @@
   },
   "2/C36c": {
     "defaultMessage": "你無權進行此操作"
+  },
+  "2/u1aP": {
+    "defaultMessage": "Discussion",
+    "description": "src/views/CampaignDetail/Discussion"
   },
   "202PEj": {
     "defaultMessage": "確認 Matters ID",
@@ -2169,6 +2177,10 @@
     "defaultMessage": "Oops！此網址已被使用了，換一個試試",
     "description": "src/components/Forms/CreateCircleForm/Init.tsx"
   },
+  "VyV+WO": {
+    "defaultMessage": "Only participants can join the discussion.",
+    "description": "src/views/CampaignDetail/Discussion"
+  },
   "VzzYJk": {
     "defaultMessage": "新建"
   },
@@ -2489,6 +2501,10 @@
   "b6x6lm": {
     "defaultMessage": "輸入簡單明瞭的標題"
   },
+  "b8LMpq": {
+    "defaultMessage": "View all {count} comments",
+    "description": "src/views/CampaignDetail/Discussion"
+  },
   "b8ogKp": {
     "defaultMessage": "新增邀請",
     "description": "src/views/Circle/Settings/ManageInvitation/AddButton/index.tsx"
@@ -2619,6 +2635,10 @@
   "dE4mlL": {
     "defaultMessage": "投稿",
     "description": "src/views/CampaignDetail/Apply/Button/index.tsx"
+  },
+  "dHVTYM": {
+    "defaultMessage": "Share your thoughts with other participants",
+    "description": "src/views/CampaignDetail/Discussion"
   },
   "dK7Dnj": {
     "defaultMessage": "🔥 免費提領"
@@ -2783,6 +2803,9 @@
   },
   "ftg7GK": {
     "defaultMessage": "選擇日期"
+  },
+  "fyKoL1": {
+    "defaultMessage": "Comment sent"
   },
   "g//2O2": {
     "defaultMessage": "取消闔上",

--- a/src/common/enums/index.ts
+++ b/src/common/enums/index.ts
@@ -67,6 +67,8 @@ export const MAX_ARTICLE_COLLECT_LENGTH = 3
 
 export const MAX_MOMENT_CONTENT_LENGTH = 240
 export const MAX_MOMENT_COMMENT_LENGTH = 240
+// campaign discussion comment length cap (matches 短動態 = 240)
+export const MAX_CAMPAIGN_COMMENT_LENGTH = 240
 export const MAX_FIGURE_CAPTION_LENGTH = 100
 
 export const MAX_TAG_CONTENT_LENGTH = 50

--- a/src/common/enums/text.ts
+++ b/src/common/enums/text.ts
@@ -3,16 +3,19 @@ export const COMMENT_TYPE_TEXT = {
     article: '評論',
     circleBroadcast: '廣播',
     circleDiscussion: '眾聊',
+    campaignDiscussion: '留言',
   },
   zh_hans: {
     article: '评论',
     circleBroadcast: '广播',
     circleDiscussion: '众聊',
+    campaignDiscussion: '留言',
   },
   en: {
     article: 'comment',
     circleBroadcast: 'broadcast',
     circleDiscussion: 'thread',
+    campaignDiscussion: 'comment',
   },
 }
 

--- a/src/common/utils/route.ts
+++ b/src/common/utils/route.ts
@@ -48,7 +48,12 @@ interface CampaignStageArgs {
 
 interface CommentArgs {
   id: string
-  type: 'article' | 'circleDiscussion' | 'circleBroadcast' | 'moment' // comment type: article/discussion/broadcast
+  type:
+    | 'article'
+    | 'circleDiscussion'
+    | 'circleBroadcast'
+    | 'moment'
+    | 'campaignDiscussion' // comment type: article/discussion/broadcast/campaign
   parentComment?: {
     id: string
   } | null

--- a/src/components/CircleComment/Content/index.tsx
+++ b/src/components/CircleComment/Content/index.tsx
@@ -63,6 +63,10 @@ export const CircleCommentContent = ({
   const { content, state } = comment
   const isBlocked = comment.author?.isBlocked
 
+  // campaign discussion: collapse long comments after fewer lines (tunable),
+  // since they are capped at 240 chars and would never hit the default of 10
+  const expandLimit = type === 'campaignDiscussion' ? 4 : limit
+
   const contentClasses = classNames({
     [styles.content]: true,
     [size ? styles[`size${size}`] : '']: !!size,
@@ -96,7 +100,7 @@ export const CircleCommentContent = ({
       <>
         <Expandable
           content={content}
-          limit={limit}
+          limit={expandLimit}
           isRichShow={isRichShow}
           bgColor={bgColor}
           textIndent={textIndent}

--- a/src/components/CircleComment/DropdownActions/index.tsx
+++ b/src/components/CircleComment/DropdownActions/index.tsx
@@ -90,6 +90,9 @@ const fragments = {
               id
             }
           }
+          ... on WritingChallenge {
+            id
+          }
         }
         ...CircleCommentPinButtonComment
       }
@@ -110,6 +113,9 @@ const fragments = {
               id
               isBlocking
             }
+          }
+          ... on WritingChallenge {
+            id
           }
         }
       }
@@ -185,6 +191,8 @@ const DropdownActions = (props: DropdownActionsProps) => {
   const { isArchived, isBanned, isFrozen } = viewer
 
   const circle = comment.node.__typename === 'Circle' ? comment.node : undefined
+  const campaign =
+    comment.node.__typename === 'WritingChallenge' ? comment.node : undefined
   const targetAuthor = circle?.owner
 
   const isTargetAuthor = viewer.id === targetAuthor?.id
@@ -222,7 +230,8 @@ const DropdownActions = (props: DropdownActionsProps) => {
     BaseDropdownActions as React.ComponentType<object>,
     CircleCommentFormDialog,
     {
-      circleId: circle?.id || '',
+      circleId: circle?.id,
+      campaignId: campaign?.id,
       type,
       commentId: comment.id,
       defaultContent: comment.content,

--- a/src/components/CircleComment/FooterActions/ReplyButton/index.tsx
+++ b/src/components/CircleComment/FooterActions/ReplyButton/index.tsx
@@ -44,6 +44,9 @@ const fragments = {
             id
           }
         }
+        ... on WritingChallenge {
+          id
+        }
       }
       parentComment {
         id
@@ -86,6 +89,7 @@ const ReplyButton = ({
 
   const { id, parentComment, author, node } = comment
   const circle = node.__typename === 'Circle' ? node : undefined
+  const campaign = node.__typename === 'WritingChallenge' ? node : undefined
 
   const submitCallback = () => {
     if (replySubmitCallback) {
@@ -126,7 +130,8 @@ const ReplyButton = ({
 
   return (
     <CircleCommentFormDialog
-      circleId={circle?.id || ''}
+      circleId={circle?.id}
+      campaignId={campaign?.id}
       type={type}
       replyToId={id}
       parentId={parentComment?.id || id}

--- a/src/components/Dialogs/CircleCommentFormDialog/CommentForm/index.tsx
+++ b/src/components/Dialogs/CircleCommentFormDialog/CommentForm/index.tsx
@@ -2,7 +2,7 @@ import dynamic from 'next/dynamic'
 import { useContext, useState } from 'react'
 import { FormattedMessage } from 'react-intl'
 
-import { COMMENT_TYPE_TEXT } from '~/common/enums'
+import { COMMENT_TYPE_TEXT, MAX_CAMPAIGN_COMMENT_LENGTH } from '~/common/enums'
 import { dom, formStorage, stripHtml } from '~/common/utils'
 import {
   CircleCommentFormType,
@@ -28,7 +28,9 @@ export interface CircleCommentFormProps {
   commentId?: string
   replyToId?: string
   parentId?: string
-  circleId: string
+  // exactly one of circleId / campaignId is set, depending on `type`
+  circleId?: string
+  campaignId?: string
   type: CircleCommentFormType
 
   defaultContent?: string | null
@@ -43,6 +45,7 @@ const CommentForm: React.FC<CircleCommentFormProps> = ({
   replyToId,
   parentId,
   circleId,
+  campaignId,
   type,
 
   defaultContent,
@@ -65,7 +68,7 @@ const CommentForm: React.FC<CircleCommentFormProps> = ({
 
   const formStorageKey = formStorage.genCircleCommentKey({
     authorId: viewer.id,
-    circleId,
+    circleId: circleId ?? campaignId ?? '',
     type,
     commentId,
     parentId,
@@ -77,7 +80,12 @@ const CommentForm: React.FC<CircleCommentFormProps> = ({
       defaultContent ||
       ''
   )
-  const isValid = stripHtml(content).length > 0
+  // campaign discussion comments are capped at 240 chars (like 短動態)
+  const maxLength =
+    type === 'campaignDiscussion' ? MAX_CAMPAIGN_COMMENT_LENGTH : undefined
+  const contentLength = stripHtml(content).length
+  const isOverLength = maxLength !== undefined && contentLength > maxLength
+  const isValid = contentLength > 0 && !isOverLength
 
   const handleSubmit = async (event?: React.FormEvent<HTMLFormElement>) => {
     const mentions = dom.getAttributes('data-id', content)
@@ -88,6 +96,7 @@ const CommentForm: React.FC<CircleCommentFormProps> = ({
         content,
         replyTo: replyToId,
         circleId,
+        campaignId,
         parentId,
         type,
         mentions,
@@ -181,6 +190,14 @@ const CommentForm: React.FC<CircleCommentFormProps> = ({
               window.dispatchEvent(new CustomEvent(formStorageKey))
             }
           />
+          {maxLength !== undefined && (
+            <p
+              className={styles.counter}
+              data-over={isOverLength ? 'true' : undefined}
+            >
+              {contentLength} / {maxLength}
+            </p>
+          )}
         </form>
       </Dialog.Content>
 

--- a/src/components/Dialogs/CircleCommentFormDialog/CommentForm/styles.module.css
+++ b/src/components/Dialogs/CircleCommentFormDialog/CommentForm/styles.module.css
@@ -11,3 +11,14 @@
   flex-grow: 1;
   overflow-y: auto;
 }
+
+.counter {
+  margin-top: var(--sp8);
+  font-size: var(--text12);
+  color: var(--color-grey);
+  text-align: right;
+}
+
+.counter[data-over='true'] {
+  color: var(--color-red);
+}

--- a/src/components/Forms/CircleCommentForm/index.tsx
+++ b/src/components/Forms/CircleCommentForm/index.tsx
@@ -3,6 +3,7 @@ import dynamic from 'next/dynamic'
 import { useContext, useState } from 'react'
 import { useIntl } from 'react-intl'
 
+import { MAX_CAMPAIGN_COMMENT_LENGTH } from '~/common/enums'
 import { dom, formStorage, stripHtml } from '~/common/utils'
 import {
   Button,
@@ -24,13 +25,18 @@ const CommentEditor = dynamic(() => import('~/components/Editor/Comment'), {
   loading: () => <SpinnerBlock />,
 })
 
-export type CircleCommentFormType = 'circleDiscussion' | 'circleBroadcast'
+export type CircleCommentFormType =
+  | 'circleDiscussion'
+  | 'circleBroadcast'
+  | 'campaignDiscussion'
 
 export interface CircleCommentFormProps {
   commentId?: string
   replyToId?: string
   parentId?: string
-  circleId: string
+  // exactly one of circleId / campaignId is set, depending on `type`
+  circleId?: string
+  campaignId?: string
   type: CircleCommentFormType
 
   defaultContent?: string | null
@@ -44,6 +50,7 @@ export const CircleCommentForm: React.FC<CircleCommentFormProps> = ({
   replyToId,
   parentId,
   circleId,
+  campaignId,
   type,
 
   defaultContent,
@@ -64,7 +71,7 @@ export const CircleCommentForm: React.FC<CircleCommentFormProps> = ({
 
   const formStorageKey = formStorage.genCircleCommentKey({
     authorId: viewer.id,
-    circleId,
+    circleId: circleId ?? campaignId ?? '',
     type,
     commentId,
     parentId,
@@ -77,7 +84,13 @@ export const CircleCommentForm: React.FC<CircleCommentFormProps> = ({
       defaultContent ||
       ''
   )
-  const isValid = stripHtml(content).length > 0
+  // campaign discussion comments are capped at 240 chars (like 短動態)
+  const maxLength =
+    type === 'campaignDiscussion' ? MAX_CAMPAIGN_COMMENT_LENGTH : undefined
+  const contentLength = stripHtml(content).length
+  const isOverLength =
+    maxLength !== undefined && contentLength > maxLength
+  const isValid = contentLength > 0 && !isOverLength
 
   const handleSubmit = async (event?: React.FormEvent<HTMLFormElement>) => {
     const mentions = dom.getAttributes('data-id', content)
@@ -87,6 +100,7 @@ export const CircleCommentForm: React.FC<CircleCommentFormProps> = ({
         content,
         replyTo: replyToId,
         circleId,
+        campaignId,
         parentId,
         type,
         mentions,
@@ -161,6 +175,14 @@ export const CircleCommentForm: React.FC<CircleCommentFormProps> = ({
       </section>
 
       <footer className={styles.footer}>
+        {maxLength !== undefined && (
+          <span
+            className={styles.counter}
+            data-over={isOverLength ? 'true' : undefined}
+          >
+            {contentLength} / {maxLength}
+          </span>
+        )}
         <Button
           type="submit"
           form={formStorageKey}

--- a/src/components/Forms/CircleCommentForm/styles.module.css
+++ b/src/components/Forms/CircleCommentForm/styles.module.css
@@ -11,9 +11,9 @@
 
 .footer {
   display: flex;
+  gap: var(--sp8);
   align-items: center;
   justify-content: flex-end;
-  gap: var(--sp8);
 }
 
 .counter {

--- a/src/components/Forms/CircleCommentForm/styles.module.css
+++ b/src/components/Forms/CircleCommentForm/styles.module.css
@@ -10,5 +10,17 @@
 }
 
 .footer {
-  text-align: right;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--sp8);
+}
+
+.counter {
+  font-size: var(--text12);
+  color: var(--color-grey);
+}
+
+.counter[data-over='true'] {
+  color: var(--color-red);
 }

--- a/src/views/CampaignDetail/Discussion/Dialog.tsx
+++ b/src/views/CampaignDetail/Discussion/Dialog.tsx
@@ -23,10 +23,7 @@ import { CAMPAIGN_DISCUSSION_COMMENTS } from './gql'
 import styles from './styles.module.css'
 
 type DiscussionConnection = NonNullable<
-  Extract<
-    NonNullable<CampaignDiscussionCommentsQuery['campaign']>,
-    { __typename: 'WritingChallenge' }
-  >['discussion']
+  NonNullable<CampaignDiscussionCommentsQuery['campaign']>['discussion']
 >
 type Comment = NonNullable<DiscussionConnection['edges']>[0]['node']
 
@@ -82,7 +79,7 @@ const BaseDiscussionDialog = ({
 
   const submitCallback = () => {
     toast.info({
-      message: <FormattedMessage defaultMessage="Comment sent" id="iSUeWj" />,
+      message: <FormattedMessage defaultMessage="Comment sent" id="fyKoL1" />,
     })
     refetch()
     afterSubmit?.()
@@ -98,7 +95,7 @@ const BaseDiscussionDialog = ({
             <>
               <FormattedMessage
                 defaultMessage="Discussion"
-                id="aLkBs2"
+                id="2/u1aP"
                 description="src/views/CampaignDetail/Discussion"
               />{' '}
               {totalCount > 0 && (
@@ -121,7 +118,7 @@ const BaseDiscussionDialog = ({
               type="campaignDiscussion"
               placeholder={intl.formatMessage({
                 defaultMessage: 'Share your thoughts with other participants',
-                id: 'b3aGfp',
+                id: 'dHVTYM',
                 description: 'src/views/CampaignDetail/Discussion',
               })}
               submitCallback={submitCallback}
@@ -134,7 +131,7 @@ const BaseDiscussionDialog = ({
             <EmptyComment
               description={intl.formatMessage({
                 defaultMessage: 'No discussion yet',
-                id: 'Mh+PgK',
+                id: '/0OJlF',
                 description: 'src/views/CampaignDetail/Discussion',
               })}
             />

--- a/src/views/CampaignDetail/Discussion/Dialog.tsx
+++ b/src/views/CampaignDetail/Discussion/Dialog.tsx
@@ -1,0 +1,177 @@
+import { useContext } from 'react'
+import { FormattedMessage, useIntl } from 'react-intl'
+
+import IconTimes from '@/public/static/icons/24px/times.svg'
+import { filterComments, mergeConnections } from '~/common/utils'
+import {
+  CircleCommentForm,
+  CircleThreadComment,
+  Dialog,
+  EmptyComment,
+  Icon,
+  InfiniteScroll,
+  List,
+  SpinnerBlock,
+  toast,
+  useDialogSwitch,
+  usePublicQuery,
+  ViewerContext,
+} from '~/components'
+import { CampaignDiscussionCommentsQuery } from '~/gql/graphql'
+
+import { CAMPAIGN_DISCUSSION_COMMENTS } from './gql'
+import styles from './styles.module.css'
+
+type DiscussionConnection = NonNullable<
+  Extract<
+    NonNullable<CampaignDiscussionCommentsQuery['campaign']>,
+    { __typename: 'WritingChallenge' }
+  >['discussion']
+>
+type Comment = NonNullable<DiscussionConnection['edges']>[0]['node']
+
+const RESPONSES_COUNT = 15
+
+interface DiscussionDialogProps {
+  campaignId: string
+  shortHash: string
+  canComment: boolean
+  totalCount: number
+  afterSubmit?: () => void
+  children: ({ openDialog }: { openDialog: () => void }) => React.ReactNode
+}
+
+const BaseDiscussionDialog = ({
+  campaignId,
+  shortHash,
+  canComment,
+  totalCount,
+  afterSubmit,
+  children,
+}: DiscussionDialogProps) => {
+  const viewer = useContext(ViewerContext)
+  const intl = useIntl()
+  const { show, openDialog, closeDialog } = useDialogSwitch(true)
+
+  const { data, loading, fetchMore, refetch } =
+    usePublicQuery<CampaignDiscussionCommentsQuery>(
+      CAMPAIGN_DISCUSSION_COMMENTS,
+      { variables: { shortHash } },
+      { publicQuery: !viewer.isAuthed }
+    )
+
+  const campaign =
+    data?.campaign?.__typename === 'WritingChallenge'
+      ? data.campaign
+      : undefined
+  const { edges, pageInfo } = campaign?.discussion || {}
+  const comments = filterComments<Comment>(
+    (edges || []).map(({ node }) => node)
+  )
+
+  const loadMore = async () =>
+    fetchMore({
+      variables: { after: pageInfo?.endCursor, first: RESPONSES_COUNT },
+      updateQuery: (previousResult, { fetchMoreResult }) =>
+        mergeConnections({
+          oldData: previousResult,
+          newData: fetchMoreResult,
+          path: 'campaign.discussion',
+        }),
+    })
+
+  const submitCallback = () => {
+    toast.info({
+      message: <FormattedMessage defaultMessage="Comment sent" id="iSUeWj" />,
+    })
+    refetch()
+    afterSubmit?.()
+  }
+
+  return (
+    <>
+      {children({ openDialog })}
+
+      <Dialog isOpen={show} onDismiss={closeDialog}>
+        <Dialog.Header
+          title={
+            <>
+              <FormattedMessage
+                defaultMessage="Discussion"
+                id="aLkBs2"
+                description="src/views/CampaignDetail/Discussion"
+              />{' '}
+              {totalCount > 0 && (
+                <span className={styles.count}>{totalCount}</span>
+              )}
+            </>
+          }
+          titleLeft
+          rightBtn={
+            <button onClick={closeDialog}>
+              <Icon icon={IconTimes} size={24} />
+            </button>
+          }
+        />
+
+        <Dialog.Content>
+          {canComment && (
+            <CircleCommentForm
+              campaignId={campaignId}
+              type="campaignDiscussion"
+              placeholder={intl.formatMessage({
+                defaultMessage: 'Share your thoughts with other participants',
+                id: 'b3aGfp',
+                description: 'src/views/CampaignDetail/Discussion',
+              })}
+              submitCallback={submitCallback}
+            />
+          )}
+
+          {loading && <SpinnerBlock />}
+
+          {!loading && comments.length <= 0 && (
+            <EmptyComment
+              description={intl.formatMessage({
+                defaultMessage: 'No discussion yet',
+                id: 'Mh+PgK',
+                description: 'src/views/CampaignDetail/Discussion',
+              })}
+            />
+          )}
+
+          {!loading && comments.length > 0 && (
+            <InfiniteScroll
+              hasNextPage={!!pageInfo?.hasNextPage}
+              loadMore={loadMore}
+              eof
+            >
+              <List spacing={['xloose', 0]}>
+                {comments.map((comment) => (
+                  <List.Item key={comment.id}>
+                    <CircleThreadComment
+                      comment={comment}
+                      type="campaignDiscussion"
+                      hasLink
+                      hasUpvote={false}
+                      hasDownvote={false}
+                      hasPin={false}
+                    />
+                  </List.Item>
+                ))}
+              </List>
+            </InfiniteScroll>
+          )}
+        </Dialog.Content>
+      </Dialog>
+    </>
+  )
+}
+
+const DiscussionDialog = (props: DiscussionDialogProps) => (
+  <Dialog.Lazy mounted={<BaseDiscussionDialog {...props} />}>
+    {({ openDialog }) => <>{props.children({ openDialog })}</>}
+  </Dialog.Lazy>
+)
+
+export default DiscussionDialog

--- a/src/views/CampaignDetail/Discussion/gql.ts
+++ b/src/views/CampaignDetail/Discussion/gql.ts
@@ -1,0 +1,63 @@
+import gql from 'graphql-tag'
+
+import { CircleThreadComment } from '~/components'
+
+// public: anyone can read the campaign discussion
+export const CAMPAIGN_DISCUSSION_COMMENTS = gql`
+  query CampaignDiscussionComments(
+    $shortHash: String!
+    $before: String
+    $after: String
+    $first: first_Int_min_0 = 15
+    $includeAfter: Boolean
+    $includeBefore: Boolean
+  ) {
+    campaign(input: { shortHash: $shortHash }) {
+      id
+      ... on WritingChallenge {
+        id
+        discussionCount
+        discussion(
+          input: {
+            after: $after
+            before: $before
+            first: $first
+            includeAfter: $includeAfter
+            includeBefore: $includeBefore
+          }
+        ) {
+          totalCount
+          pageInfo {
+            startCursor
+            endCursor
+            hasNextPage
+          }
+          edges {
+            node {
+              ...CircleCommentThreadCommentCommentPublic
+              ...CircleCommentThreadCommentCommentPrivate
+            }
+          }
+        }
+      }
+    }
+  }
+  ${CircleThreadComment.fragments.comment.public}
+  ${CircleThreadComment.fragments.comment.private}
+`
+
+// private: whether the viewer (a logged-in user) is a succeeded participant,
+// which decides if they may post
+export const CAMPAIGN_DISCUSSION_VIEWER = gql`
+  query CampaignDiscussionViewer($shortHash: String!) {
+    campaign(input: { shortHash: $shortHash }) {
+      id
+      ... on WritingChallenge {
+        id
+        application {
+          state
+        }
+      }
+    }
+  }
+`

--- a/src/views/CampaignDetail/Discussion/index.tsx
+++ b/src/views/CampaignDetail/Discussion/index.tsx
@@ -21,10 +21,7 @@ import { CAMPAIGN_DISCUSSION_COMMENTS, CAMPAIGN_DISCUSSION_VIEWER } from './gql'
 import styles from './styles.module.css'
 
 type DiscussionConnection = NonNullable<
-  Extract<
-    NonNullable<CampaignDiscussionCommentsQuery['campaign']>,
-    { __typename: 'WritingChallenge' }
-  >['discussion']
+  NonNullable<CampaignDiscussionCommentsQuery['campaign']>['discussion']
 >
 type Comment = NonNullable<DiscussionConnection['edges']>[0]['node']
 
@@ -92,7 +89,7 @@ const CampaignDiscussion = ({
 
   const submitCallback = () => {
     toast.info({
-      message: <FormattedMessage defaultMessage="Comment sent" id="iSUeWj" />,
+      message: <FormattedMessage defaultMessage="Comment sent" id="fyKoL1" />,
     })
     refetch()
   }
@@ -118,7 +115,7 @@ const CampaignDiscussion = ({
               💬{' '}
               <FormattedMessage
                 defaultMessage="Discussion"
-                id="aLkBs2"
+                id="2/u1aP"
                 description="src/views/CampaignDetail/Discussion"
               />
               {totalCount > 0 && (
@@ -138,7 +135,7 @@ const CampaignDiscussion = ({
         <h2 className={styles.title}>
           <FormattedMessage
             defaultMessage="Discussion"
-            id="aLkBs2"
+            id="2/u1aP"
             description="src/views/CampaignDetail/Discussion"
           />
           {totalCount > 0 && <span className={styles.count}>{totalCount}</span>}
@@ -151,7 +148,7 @@ const CampaignDiscussion = ({
           type="campaignDiscussion"
           placeholder={intl.formatMessage({
             defaultMessage: 'Share your thoughts with other participants',
-            id: 'b3aGfp',
+            id: 'dHVTYM',
             description: 'src/views/CampaignDetail/Discussion',
           })}
           submitCallback={submitCallback}
@@ -160,7 +157,7 @@ const CampaignDiscussion = ({
         <section className={styles.hint}>
           <FormattedMessage
             defaultMessage="Only participants can join the discussion."
-            id="Aq0aMp"
+            id="VyV+WO"
             description="src/views/CampaignDetail/Discussion"
           />
         </section>
@@ -202,7 +199,7 @@ const CampaignDiscussion = ({
               <TextIcon size={14} weight="medium">
                 <FormattedMessage
                   defaultMessage="View all {count} comments"
-                  id="Vj0Hbd"
+                  id="b8LMpq"
                   description="src/views/CampaignDetail/Discussion"
                   values={{ count: totalCount }}
                 />

--- a/src/views/CampaignDetail/Discussion/index.tsx
+++ b/src/views/CampaignDetail/Discussion/index.tsx
@@ -1,0 +1,218 @@
+import { useContext, useEffect, useState } from 'react'
+import { FormattedMessage, useIntl } from 'react-intl'
+
+import { filterComments } from '~/common/utils'
+import {
+  Button,
+  CircleCommentForm,
+  CircleThreadComment,
+  TextIcon,
+  toast,
+  usePublicQuery,
+  ViewerContext,
+} from '~/components'
+import {
+  CampaignDiscussionCommentsQuery,
+  CampaignDiscussionViewerQuery,
+} from '~/gql/graphql'
+
+import DiscussionDialog from './Dialog'
+import { CAMPAIGN_DISCUSSION_COMMENTS, CAMPAIGN_DISCUSSION_VIEWER } from './gql'
+import styles from './styles.module.css'
+
+type DiscussionConnection = NonNullable<
+  Extract<
+    NonNullable<CampaignDiscussionCommentsQuery['campaign']>,
+    { __typename: 'WritingChallenge' }
+  >['discussion']
+>
+type Comment = NonNullable<DiscussionConnection['edges']>[0]['node']
+
+// how many latest comments to preview in the compact module
+const PREVIEW_COUNT = 3
+
+interface CampaignDiscussionProps {
+  campaignId: string
+  shortHash: string
+  // 'module': compact module (desktop right aside) — input box + latest few
+  // comments + "view all". 'chip': one-line entry button (mobile main column)
+  // that opens the full discussion dialog.
+  entry?: 'module' | 'chip'
+}
+
+const CampaignDiscussion = ({
+  campaignId,
+  shortHash,
+  entry = 'module',
+}: CampaignDiscussionProps) => {
+  const viewer = useContext(ViewerContext)
+  const intl = useIntl()
+
+  const { data, refetch, client } =
+    usePublicQuery<CampaignDiscussionCommentsQuery>(
+      CAMPAIGN_DISCUSSION_COMMENTS,
+      { variables: { shortHash, first: PREVIEW_COUNT } },
+      { publicQuery: !viewer.isAuthed }
+    )
+
+  const campaign =
+    data?.campaign?.__typename === 'WritingChallenge'
+      ? data.campaign
+      : undefined
+  const totalCount = campaign?.discussion?.totalCount ?? 0
+  const comments = filterComments<Comment>(
+    (campaign?.discussion?.edges || []).map(({ node }) => node)
+  ).slice(0, PREVIEW_COUNT)
+
+  // viewer's participation decides whether they may post
+  const [canComment, setCanComment] = useState(false)
+  useEffect(() => {
+    if (!viewer.isAuthed) {
+      setCanComment(false)
+      return
+    }
+    ;(async () => {
+      try {
+        const { data: viewerData } =
+          await client.query<CampaignDiscussionViewerQuery>({
+            query: CAMPAIGN_DISCUSSION_VIEWER,
+            fetchPolicy: 'network-only',
+            variables: { shortHash },
+          })
+        const c =
+          viewerData?.campaign?.__typename === 'WritingChallenge'
+            ? viewerData.campaign
+            : undefined
+        setCanComment(c?.application?.state === 'succeeded')
+      } catch {
+        setCanComment(false)
+      }
+    })()
+  }, [viewer.id])
+
+  const submitCallback = () => {
+    toast.info({
+      message: <FormattedMessage defaultMessage="Comment sent" id="iSUeWj" />,
+    })
+    refetch()
+  }
+
+  // mobile: one-line entry that opens the full discussion dialog
+  if (entry === 'chip') {
+    return (
+      <DiscussionDialog
+        campaignId={campaignId}
+        shortHash={shortHash}
+        canComment={canComment}
+        totalCount={totalCount}
+        afterSubmit={refetch}
+      >
+        {({ openDialog }) => (
+          <button
+            type="button"
+            className={styles.chip}
+            onClick={openDialog}
+            aria-haspopup="dialog"
+          >
+            <span>
+              💬{' '}
+              <FormattedMessage
+                defaultMessage="Discussion"
+                id="aLkBs2"
+                description="src/views/CampaignDetail/Discussion"
+              />
+              {totalCount > 0 && (
+                <span className={styles.count}>{totalCount}</span>
+              )}
+            </span>
+            <span className={styles.chevron}>›</span>
+          </button>
+        )}
+      </DiscussionDialog>
+    )
+  }
+
+  return (
+    <section className={styles.discussion}>
+      <header className={styles.header}>
+        <h2 className={styles.title}>
+          <FormattedMessage
+            defaultMessage="Discussion"
+            id="aLkBs2"
+            description="src/views/CampaignDetail/Discussion"
+          />
+          {totalCount > 0 && <span className={styles.count}>{totalCount}</span>}
+        </h2>
+      </header>
+
+      {canComment ? (
+        <CircleCommentForm
+          campaignId={campaignId}
+          type="campaignDiscussion"
+          placeholder={intl.formatMessage({
+            defaultMessage: 'Share your thoughts with other participants',
+            id: 'b3aGfp',
+            description: 'src/views/CampaignDetail/Discussion',
+          })}
+          submitCallback={submitCallback}
+        />
+      ) : (
+        <section className={styles.hint}>
+          <FormattedMessage
+            defaultMessage="Only participants can join the discussion."
+            id="Aq0aMp"
+            description="src/views/CampaignDetail/Discussion"
+          />
+        </section>
+      )}
+
+      {comments.length > 0 && (
+        <ul className={styles.preview}>
+          {comments.map((comment) => (
+            <li key={comment.id}>
+              <CircleThreadComment
+                comment={comment}
+                type="campaignDiscussion"
+                hasLink
+                hasUpvote={false}
+                hasDownvote={false}
+                hasPin={false}
+              />
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {totalCount > comments.length && (
+        <DiscussionDialog
+          campaignId={campaignId}
+          shortHash={shortHash}
+          canComment={canComment}
+          totalCount={totalCount}
+          afterSubmit={refetch}
+        >
+          {({ openDialog }) => (
+            <Button
+              spacing={[8, 0]}
+              textColor="green"
+              textActiveColor="greenDark"
+              onClick={openDialog}
+              aria-haspopup="dialog"
+            >
+              <TextIcon size={14} weight="medium">
+                <FormattedMessage
+                  defaultMessage="View all {count} comments"
+                  id="Vj0Hbd"
+                  description="src/views/CampaignDetail/Discussion"
+                  values={{ count: totalCount }}
+                />
+              </TextIcon>
+            </Button>
+          )}
+        </DiscussionDialog>
+      )}
+    </section>
+  )
+}
+
+export default CampaignDiscussion

--- a/src/views/CampaignDetail/Discussion/styles.module.css
+++ b/src/views/CampaignDetail/Discussion/styles.module.css
@@ -1,0 +1,60 @@
+.discussion {
+  padding: var(--sp16) 0;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--sp12);
+}
+
+.title {
+  font-size: var(--text16);
+  font-weight: var(--font-medium);
+}
+
+.count {
+  margin-left: var(--sp4);
+  font-weight: var(--font-normal);
+  color: var(--color-grey);
+}
+
+.hint {
+  padding: var(--sp12);
+  margin-bottom: var(--sp12);
+  font-size: var(--text14);
+  color: var(--color-grey-dark);
+  text-align: center;
+  background: var(--color-grey-lighter);
+  border-radius: var(--sp8);
+}
+
+.preview {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp16);
+  padding: 0;
+  margin: var(--sp12) 0;
+  list-style: none;
+}
+
+/* mobile one-line entry */
+.chip {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: var(--sp12) var(--sp16);
+  font-size: var(--text14);
+  font-weight: var(--font-medium);
+  color: var(--color-matters-green);
+  cursor: pointer;
+  background: var(--color-green-lighter);
+  border: 1px solid var(--color-line-matters-green-light);
+  border-radius: var(--sp8);
+}
+
+.chevron {
+  color: var(--color-grey);
+}

--- a/src/views/CampaignDetail/InfoHeader/styles.module.css
+++ b/src/views/CampaignDetail/InfoHeader/styles.module.css
@@ -23,6 +23,7 @@
 
   &::after {
     display: block;
+
     /* cover height roughly halved, to lift the discussion area up the page */
     padding-bottom: 11%;
     content: '';

--- a/src/views/CampaignDetail/InfoHeader/styles.module.css
+++ b/src/views/CampaignDetail/InfoHeader/styles.module.css
@@ -23,11 +23,12 @@
 
   &::after {
     display: block;
-    padding-bottom: 21%;
+    /* cover height roughly halved, to lift the discussion area up the page */
+    padding-bottom: 11%;
     content: '';
 
     @media (--sm-up) {
-      padding-bottom: 23.26%;
+      padding-bottom: 12%;
     }
   }
 }

--- a/src/views/CampaignDetail/SideParticipants/index.tsx
+++ b/src/views/CampaignDetail/SideParticipants/index.tsx
@@ -73,7 +73,8 @@ const SideParticipants = ({ campaign }: SideParticipantsProps) => {
   const edges = campaign.sideParticipants.edges
   const totalCount = campaign.sideParticipants.totalCount
   const isViewerApplySucceeded = campaign.application?.state === 'succeeded'
-  const maxAvatarCount = 60
+  // trimmed from 60 to make room for the discussion module below the avatars
+  const maxAvatarCount = 12
   const [openDrawer, setOpenDrawer] = useState(false)
   const toggleDrawer = () => {
     setOpenDrawer((prevState) => !prevState)

--- a/src/views/CampaignDetail/index.tsx
+++ b/src/views/CampaignDetail/index.tsx
@@ -1,6 +1,7 @@
 import dynamic from 'next/dynamic'
 import { useContext, useEffect } from 'react'
 
+import { BREAKPOINTS } from '~/common/enums'
 import { toPath } from '~/common/utils'
 import {
   EmptyLayout,
@@ -9,6 +10,7 @@ import {
   Layout,
   SpinnerBlock,
   Throw404,
+  useMediaQuery,
   usePublicQuery,
   useRoute,
   ViewerContext,
@@ -26,6 +28,11 @@ const DynamicOtherCampaigns = dynamic(() => import('./OtherCampaigns'), {
   ssr: false,
 })
 
+const DynamicDiscussion = dynamic(() => import('./Discussion'), {
+  loading: () => <SpinnerBlock />,
+  ssr: false,
+})
+
 const DynamicSideParticipants = dynamic(() => import('./SideParticipants'), {
   loading: () => <SpinnerBlock />,
   ssr: false,
@@ -36,6 +43,9 @@ const CampaignDetail = () => {
   const { lang } = useContext(LanguageContext)
   const { getQuery } = useRoute()
   const shortHash = getQuery('shortHash')
+  // desktop (md-up): discussion in the right aside; mobile: in the main column.
+  // rendered once (not double-mounted) to avoid duplicate comment-form ids.
+  const isMdUp = useMediaQuery(`(min-width: ${BREAKPOINTS.MD}px)`)
 
   const { data, loading, error, client } =
     usePublicQuery<CampaignDetailPublicQuery>(
@@ -94,6 +104,13 @@ const CampaignDetail = () => {
         <>
           {campaign.showOther && <DynamicOtherCampaigns id={campaign.id} />}
           <DynamicSideParticipants campaign={campaign} />
+          {/* desktop: discussion sits in the right aside, below the avatars */}
+          {isMdUp && (
+            <DynamicDiscussion
+              campaignId={campaign.id}
+              shortHash={campaign.shortHash}
+            />
+          )}
           {campaign.showAd && <Billboard />}
         </>
       }
@@ -122,6 +139,17 @@ const CampaignDetail = () => {
       />
 
       <InfoHeader campaign={campaign} />
+
+      {/* mobile: the aside is hidden, so the discussion shrinks to a one-line
+          entry under the header (still on the first screen); tapping it opens
+          the full discussion dialog */}
+      {!isMdUp && (
+        <DynamicDiscussion
+          campaignId={campaign.id}
+          shortHash={campaign.shortHash}
+          entry="chip"
+        />
+      )}
 
       <ArticleFeeds campaign={campaign} />
     </Layout.Main>


### PR DESCRIPTION
## 這是什麼

寫作活動頁（`/e/<shortHash>`）新增「留言區」討論板的前端。**依賴後端 PR**（thematters/matters-server 的 `feat/campaign-discussion`，新增 `campaignDiscussion` 評論類型與 `WritingChallenge.discussion` 欄位），請先合後端。

- 公開可讀；只有報名成功者可發言（前端以既有 `application { state }` 控制輸入框、後端最終把關）。
- 桌機：右側欄、參與者下方放**精簡模組**（輸入框＋最新 3 則＋「展開全部」彈窗）。
- 手機：主欄 InfoHeader 下方放**單行入口**（`entry="chip"`），點開彈出完整留言對話框。`useMediaQuery` 確保同時只渲染一份（避免表單 DOM id 重複）。
- 留言 240 字上限（比照 moment）：輸入框字數計、超限鎖送出。長留言沿用既有 `Expandable` 收合。

## 改動

| 範圍 | 內容 |
|---|---|
| `src/views/CampaignDetail/Discussion/`（新） | `index.tsx`（精簡模組＋chip 入口模式）、`Dialog.tsx`（完整討論串彈窗：分頁、回覆）、`gql.ts`、`styles.module.css` |
| `src/views/CampaignDetail/index.tsx` | 雙落點掛載（桌機 aside／手機主欄 chip） |
| `Forms/CircleCommentForm`、`Dialogs/CircleCommentFormDialog` | 一般化：`circleId` 改 optional、新增 `campaignId`；type 加 `campaignDiscussion`；campaign 留言顯示 `0/240` 字數計 |
| `CircleComment/FooterActions/ReplyButton`、`CircleComment/DropdownActions` | fragment `node` 加 `... on WritingChallenge { id }`，回覆／編輯傳回 campaignId |
| `src/common/enums/` | `MAX_CAMPAIGN_COMMENT_LENGTH = 240`；`COMMENT_TYPE_TEXT` 加 campaignDiscussion |
| 版面（產品已拍板，全活動頁生效） | 封面高度 23.26% → 12%（`InfoHeader/styles.module.css`）；右欄參與者頭像上限 60 → 12（`SideParticipants`） |

## ⚠️ Merge 前需要（Draft 原因）

貢獻環境 node < 22，以下生成步驟未跑，CI typecheck 預期會紅：

1. **GraphQL codegen**：產生 `CampaignDiscussionCommentsQuery` 等型別（需後端 schema 先合）。
2. **formatjs 抽字**：新文案（Discussion／報名提示／placeholder）需重跑抽取並補 zh-Hant / zh-Hans 翻譯（目前 fallback 英文）。
3. lint / typecheck / 既有測試。

## 建議 QA

- md 斷點切換：桌機右欄模組 ↔ 手機 chip（同時只存在一份表單）。
- 權限矩陣：未登入／未報名／pending／succeeded 四種帳號的讀寫行為。
- 彈窗在手機的呈現（底部抽屜）、分頁載入、回覆樓中樓。
- 版面變更過目：封面高度與頭像數量（影響所有活動頁）。

## 範圍外（後續 PR）

InfoHeader 重構（標題壓封面、說明兩行收合，等新封面圖）、通知、檢舉、金句牆。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
