### PR TITLE
feat(quote-wall): post-to-wall + campaign quote wall

### DIFF
--- a/lang/default.json
+++ b/lang/default.json
@@ -248,6 +248,9 @@
   "1EYCdR": {
     "defaultMessage": "Tags"
   },
+  "1HLo+Y": {
+    "defaultMessage": "Quote wall"
+  },
   "1PORwh": {
     "defaultMessage": "Archived article.",
     "description": "src/views/ArticleDetail/StickyTopBanner/index.tsx"
@@ -413,6 +416,9 @@
   "3cxMQp": {
     "defaultMessage": "Violet"
   },
+  "3jmniZ": {
+    "defaultMessage": "Retract"
+  },
   "3kbIhS": {
     "defaultMessage": "Untitled"
   },
@@ -492,6 +498,9 @@
   },
   "5IS+ui": {
     "defaultMessage": "Support Setting"
+  },
+  "5IlTNw": {
+    "defaultMessage": "Failed to post to the wall"
   },
   "5JN+nl": {
     "defaultMessage": "Check your inbox",
@@ -1028,6 +1037,9 @@
     "defaultMessage": "Comment deleted",
     "description": "src/components/Notice/NoticeComment.tsx/moment"
   },
+  "Cmc/He": {
+    "defaultMessage": "On the wall ✓"
+  },
   "CnPG8j": {
     "defaultMessage": "Featured"
   },
@@ -1050,6 +1062,9 @@
   },
   "D3idYv": {
     "defaultMessage": "Settings"
+  },
+  "D8FJf9": {
+    "defaultMessage": "Wall quota reached for today — come back tomorrow!"
   },
   "D9/QIR": {
     "defaultMessage": "Register ISCN"
@@ -1112,6 +1127,9 @@
   "DrBuEI": {
     "defaultMessage": "Unpin Broadcast",
     "description": "src/components/CircleComment/DropdownActions/PinButton.tsx"
+  },
+  "Ds+7ro": {
+    "defaultMessage": "Full wall →"
   },
   "DtO278": {
     "defaultMessage": "We’ve detected that several of your recent works have been recommended to related channels. They may not appear at the same time"
@@ -1245,6 +1263,9 @@
   },
   "FuYW4i": {
     "defaultMessage": "Subscribe circle and chat together!"
+  },
+  "Fx9x/w": {
+    "defaultMessage": "Full wall / Museum →"
   },
   "FxrSCh": {
     "defaultMessage": "This ID cannot be modified. Are you sure you want to use {id} as your Matters ID?",
@@ -1424,6 +1445,9 @@
   "IW6zQv": {
     "defaultMessage": "Select Time"
   },
+  "IWLb33": {
+    "defaultMessage": "Posted to the quote wall"
+  },
   "IXycMo": {
     "defaultMessage": "Resend"
   },
@@ -1450,6 +1474,9 @@
   },
   "J7hiLV": {
     "defaultMessage": "The author has not bound the LikeCoin wallet yet"
+  },
+  "JBnAOd": {
+    "defaultMessage": "🔀 Shuffle"
   },
   "JCZFqh": {
     "defaultMessage": "Sign up now and start writing the annual questionnaire. Please check the announcement for event details."
@@ -2064,6 +2091,9 @@
   "TF1OhT": {
     "defaultMessage": "This login code has expired, please try to resend"
   },
+  "TIWVxK": {
+    "defaultMessage": "Quote retracted from the wall"
+  },
   "TInwt3": {
     "defaultMessage": "Disable Responses"
   },
@@ -2094,6 +2124,9 @@
   "TgU+Mf": {
     "defaultMessage": "Optimism is a standalone blockchain. If you have USDT on other chains, you need to transfer them to Optimism. See details in the {tutorial}.",
     "description": "src/components/Forms/PaymentForm/SwitchNetwork/index.tsx"
+  },
+  "Thr8QX": {
+    "defaultMessage": "To article ↩"
   },
   "TjWWxF": {
     "defaultMessage": "Broadcast sent",
@@ -2416,6 +2449,9 @@
   "Z7JXlF": {
     "defaultMessage": "Archived for violation.",
     "description": "src/views/ArticleDetail/StickyTopBanner/index.tsx"
+  },
+  "Z82+dw": {
+    "defaultMessage": "Confirm retract"
   },
   "ZAoAcG": {
     "defaultMessage": "Threads, Mastodon, Misskey 這些地方的粉絲也會看到"
@@ -2781,6 +2817,9 @@
   "eov+J2": {
     "defaultMessage": "Custom URL Name"
   },
+  "epZb9X": {
+    "defaultMessage": "View all {count} quotes"
+  },
   "erE5/4": {
     "defaultMessage": "Followed",
     "description": "src/components/Buttons/FollowUser/FollowState.tsx"
@@ -3009,6 +3048,9 @@
   },
   "iSM+et": {
     "defaultMessage": "All rights reserved"
+  },
+  "iSjuti": {
+    "defaultMessage": "Failed to retract"
   },
   "iTcMqz": {
     "defaultMessage": "Under the moonlight, dreams are about to come true. The Moonlight Dream badge signifies your participation in the Nomad Matters.",
@@ -3356,6 +3398,9 @@
   "oA2Pur": {
     "defaultMessage": "濫發廣告",
     "description": "src/components/Comment/DropdownActions/CommunityWatchRemoveComment.tsx"
+  },
+  "oCQmLu": {
+    "defaultMessage": "Post to wall"
   },
   "oEHAIT": {
     "defaultMessage": "Cancel schedule",

--- a/lang/en.json
+++ b/lang/en.json
@@ -248,6 +248,9 @@
   "1EYCdR": {
     "defaultMessage": "Tags"
   },
+  "1HLo+Y": {
+    "defaultMessage": "Quote wall"
+  },
   "1PORwh": {
     "defaultMessage": "Archived article.",
     "description": "src/views/ArticleDetail/StickyTopBanner/index.tsx"
@@ -413,6 +416,9 @@
   "3cxMQp": {
     "defaultMessage": "Violet"
   },
+  "3jmniZ": {
+    "defaultMessage": "Retract"
+  },
   "3kbIhS": {
     "defaultMessage": "Untitled"
   },
@@ -492,6 +498,9 @@
   },
   "5IS+ui": {
     "defaultMessage": "Support Setting"
+  },
+  "5IlTNw": {
+    "defaultMessage": "Failed to post to the wall"
   },
   "5JN+nl": {
     "defaultMessage": "Check your inbox",
@@ -1028,6 +1037,9 @@
     "defaultMessage": "Comment deleted",
     "description": "src/components/Notice/NoticeComment.tsx/moment"
   },
+  "Cmc/He": {
+    "defaultMessage": "On the wall ✓"
+  },
   "CnPG8j": {
     "defaultMessage": "Featured"
   },
@@ -1050,6 +1062,9 @@
   },
   "D3idYv": {
     "defaultMessage": "Settings"
+  },
+  "D8FJf9": {
+    "defaultMessage": "Wall quota reached for today — come back tomorrow!"
   },
   "D9/QIR": {
     "defaultMessage": "Register ISCN"
@@ -1112,6 +1127,9 @@
   "DrBuEI": {
     "defaultMessage": "Unpin Broadcast",
     "description": "src/components/CircleComment/DropdownActions/PinButton.tsx"
+  },
+  "Ds+7ro": {
+    "defaultMessage": "Full wall →"
   },
   "DtO278": {
     "defaultMessage": "We’ve detected that several of your recent works have been recommended to related channels. They may not appear at the same time"
@@ -1245,6 +1263,9 @@
   },
   "FuYW4i": {
     "defaultMessage": "Subscribe circle and chat together!"
+  },
+  "Fx9x/w": {
+    "defaultMessage": "Full wall / Museum →"
   },
   "FxrSCh": {
     "defaultMessage": "This ID cannot be modified. Are you sure you want to use {id} as your Matters ID?",
@@ -1424,6 +1445,9 @@
   "IW6zQv": {
     "defaultMessage": "Select Time"
   },
+  "IWLb33": {
+    "defaultMessage": "Posted to the quote wall"
+  },
   "IXycMo": {
     "defaultMessage": "Resend"
   },
@@ -1450,6 +1474,9 @@
   },
   "J7hiLV": {
     "defaultMessage": "The author has not bound the LikeCoin wallet yet"
+  },
+  "JBnAOd": {
+    "defaultMessage": "🔀 Shuffle"
   },
   "JCZFqh": {
     "defaultMessage": "Sign up now and start writing the annual questionnaire. Please check the announcement for event details."
@@ -2064,6 +2091,9 @@
   "TF1OhT": {
     "defaultMessage": "This login code has expired, please try to resend"
   },
+  "TIWVxK": {
+    "defaultMessage": "Quote retracted from the wall"
+  },
   "TInwt3": {
     "defaultMessage": "Disable Responses"
   },
@@ -2094,6 +2124,9 @@
   "TgU+Mf": {
     "defaultMessage": "Optimism is a standalone blockchain. If you have USDT on other chains, you need to transfer them to Optimism. See details in the {tutorial}.",
     "description": "src/components/Forms/PaymentForm/SwitchNetwork/index.tsx"
+  },
+  "Thr8QX": {
+    "defaultMessage": "To article ↩"
   },
   "TjWWxF": {
     "defaultMessage": "Broadcast sent",
@@ -2416,6 +2449,9 @@
   "Z7JXlF": {
     "defaultMessage": "Archived for violation.",
     "description": "src/views/ArticleDetail/StickyTopBanner/index.tsx"
+  },
+  "Z82+dw": {
+    "defaultMessage": "Confirm retract"
   },
   "ZAoAcG": {
     "defaultMessage": "Threads, Mastodon, Misskey 這些地方的粉絲也會看到"
@@ -2781,6 +2817,9 @@
   "eov+J2": {
     "defaultMessage": "Custom URL Name"
   },
+  "epZb9X": {
+    "defaultMessage": "View all {count} quotes"
+  },
   "erE5/4": {
     "defaultMessage": "Followed",
     "description": "src/components/Buttons/FollowUser/FollowState.tsx"
@@ -3009,6 +3048,9 @@
   },
   "iSM+et": {
     "defaultMessage": "All rights reserved"
+  },
+  "iSjuti": {
+    "defaultMessage": "Failed to retract"
   },
   "iTcMqz": {
     "defaultMessage": "Under the moonlight, dreams are about to come true. The Moonlight Dream badge signifies your participation in the Nomad Matters.",
@@ -3356,6 +3398,9 @@
   "oA2Pur": {
     "defaultMessage": "濫發廣告",
     "description": "src/components/Comment/DropdownActions/CommunityWatchRemoveComment.tsx"
+  },
+  "oCQmLu": {
+    "defaultMessage": "Post to wall"
   },
   "oEHAIT": {
     "defaultMessage": "Cancel schedule",

--- a/lang/zh-Hans.json
+++ b/lang/zh-Hans.json
@@ -248,6 +248,9 @@
   "1EYCdR": {
     "defaultMessage": "标签"
   },
+  "1HLo+Y": {
+    "defaultMessage": "Quote wall"
+  },
   "1PORwh": {
     "defaultMessage": "仅作者本人可见封存作品，",
     "description": "src/views/ArticleDetail/StickyTopBanner/index.tsx"
@@ -413,6 +416,9 @@
   "3cxMQp": {
     "defaultMessage": "Violet"
   },
+  "3jmniZ": {
+    "defaultMessage": "Retract"
+  },
   "3kbIhS": {
     "defaultMessage": "未命名"
   },
@@ -492,6 +498,9 @@
   },
   "5IS+ui": {
     "defaultMessage": "支持设置"
+  },
+  "5IlTNw": {
+    "defaultMessage": "Failed to post to the wall"
   },
   "5JN+nl": {
     "defaultMessage": "请检查邮件",
@@ -1028,6 +1037,9 @@
     "defaultMessage": "留言已删除",
     "description": "src/components/Notice/NoticeComment.tsx/moment"
   },
+  "Cmc/He": {
+    "defaultMessage": "On the wall ✓"
+  },
   "CnPG8j": {
     "defaultMessage": "精选"
   },
@@ -1050,6 +1062,9 @@
   },
   "D3idYv": {
     "defaultMessage": "设定"
+  },
+  "D8FJf9": {
+    "defaultMessage": "Wall quota reached for today — come back tomorrow!"
   },
   "D9/QIR": {
     "defaultMessage": "注册 ISCN"
@@ -1112,6 +1127,9 @@
   "DrBuEI": {
     "defaultMessage": "取消置顶",
     "description": "src/components/CircleComment/DropdownActions/PinButton.tsx"
+  },
+  "Ds+7ro": {
+    "defaultMessage": "Full wall →"
   },
   "DtO278": {
     "defaultMessage": "检测到近期你的多篇文章被推荐到相关频道，他们有可能不会同时出现"
@@ -1245,6 +1263,9 @@
   },
   "FuYW4i": {
     "defaultMessage": "成为围炉一员，一起谈天说地"
+  },
+  "Fx9x/w": {
+    "defaultMessage": "Full wall / Museum →"
   },
   "FxrSCh": {
     "defaultMessage": "ID 设置后无法修改，确认使用 {id} 作为 Matters ID 吗？",
@@ -1424,6 +1445,9 @@
   "IW6zQv": {
     "defaultMessage": "选择时间"
   },
+  "IWLb33": {
+    "defaultMessage": "Posted to the quote wall"
+  },
   "IXycMo": {
     "defaultMessage": "重新发送"
   },
@@ -1450,6 +1474,9 @@
   },
   "J7hiLV": {
     "defaultMessage": "作者尚未绑定 LikeCoin 钱包"
+  },
+  "JBnAOd": {
+    "defaultMessage": "🔀 Shuffle"
   },
   "JCZFqh": {
     "defaultMessage": "现在报名，即可开始书写年度问卷，活动细则请查看公告"
@@ -2064,6 +2091,9 @@
   "TF1OhT": {
     "defaultMessage": "临时密码已过期，请尝试重新发送"
   },
+  "TIWVxK": {
+    "defaultMessage": "Quote retracted from the wall"
+  },
   "TInwt3": {
     "defaultMessage": "关闭评论"
   },
@@ -2094,6 +2124,9 @@
   "TgU+Mf": {
     "defaultMessage": "Optimism 是独立运行的区块链，若你在其他链上已有 USDT 货币，需要将它们转移到 Optimism 网络才能使用，详情参考 {tutorial}.",
     "description": "src/components/Forms/PaymentForm/SwitchNetwork/index.tsx"
+  },
+  "Thr8QX": {
+    "defaultMessage": "To article ↩"
   },
   "TjWWxF": {
     "defaultMessage": "广播已送出",
@@ -2416,6 +2449,9 @@
   "Z7JXlF": {
     "defaultMessage": "因违反用户协定而被封存，",
     "description": "src/views/ArticleDetail/StickyTopBanner/index.tsx"
+  },
+  "Z82+dw": {
+    "defaultMessage": "Confirm retract"
   },
   "ZAoAcG": {
     "defaultMessage": "Threads, Mastodon, Misskey 這些地方的粉絲也會看到"
@@ -2781,6 +2817,9 @@
   "eov+J2": {
     "defaultMessage": "自定义网址名称"
   },
+  "epZb9X": {
+    "defaultMessage": "View all {count} quotes"
+  },
   "erE5/4": {
     "defaultMessage": "互相关注",
     "description": "src/components/Buttons/FollowUser/FollowState.tsx"
@@ -3009,6 +3048,9 @@
   },
   "iSM+et": {
     "defaultMessage": "作者保留所有权利"
+  },
+  "iSjuti": {
+    "defaultMessage": "Failed to retract"
   },
   "iTcMqz": {
     "defaultMessage": "月色之下，梦想即将实现。月之梦徽章纪念你曾参与「游牧者计划」。",
@@ -3356,6 +3398,9 @@
   "oA2Pur": {
     "defaultMessage": "濫發廣告",
     "description": "src/components/Comment/DropdownActions/CommunityWatchRemoveComment.tsx"
+  },
+  "oCQmLu": {
+    "defaultMessage": "Post to wall"
   },
   "oEHAIT": {
     "defaultMessage": "取消发布",

--- a/lang/zh-Hant.json
+++ b/lang/zh-Hant.json
@@ -248,6 +248,9 @@
   "1EYCdR": {
     "defaultMessage": "標籤"
   },
+  "1HLo+Y": {
+    "defaultMessage": "Quote wall"
+  },
   "1PORwh": {
     "defaultMessage": "僅作者本人可見封存作品，",
     "description": "src/views/ArticleDetail/StickyTopBanner/index.tsx"
@@ -413,6 +416,9 @@
   "3cxMQp": {
     "defaultMessage": "Violet"
   },
+  "3jmniZ": {
+    "defaultMessage": "Retract"
+  },
   "3kbIhS": {
     "defaultMessage": "未命名"
   },
@@ -492,6 +498,9 @@
   },
   "5IS+ui": {
     "defaultMessage": "支持設置"
+  },
+  "5IlTNw": {
+    "defaultMessage": "Failed to post to the wall"
   },
   "5JN+nl": {
     "defaultMessage": "請檢查郵件",
@@ -1028,6 +1037,9 @@
     "defaultMessage": "留言已刪除",
     "description": "src/components/Notice/NoticeComment.tsx/moment"
   },
+  "Cmc/He": {
+    "defaultMessage": "On the wall ✓"
+  },
   "CnPG8j": {
     "defaultMessage": "精選"
   },
@@ -1050,6 +1062,9 @@
   },
   "D3idYv": {
     "defaultMessage": "設定"
+  },
+  "D8FJf9": {
+    "defaultMessage": "Wall quota reached for today — come back tomorrow!"
   },
   "D9/QIR": {
     "defaultMessage": "註冊 ISCN"
@@ -1112,6 +1127,9 @@
   "DrBuEI": {
     "defaultMessage": "取消置頂",
     "description": "src/components/CircleComment/DropdownActions/PinButton.tsx"
+  },
+  "Ds+7ro": {
+    "defaultMessage": "Full wall →"
   },
   "DtO278": {
     "defaultMessage": "檢測到近期你的多篇文章被推薦到相關頻道，它們有可能不會同時出現"
@@ -1245,6 +1263,9 @@
   },
   "FuYW4i": {
     "defaultMessage": "成為圍爐一員，一起談天說地"
+  },
+  "Fx9x/w": {
+    "defaultMessage": "Full wall / Museum →"
   },
   "FxrSCh": {
     "defaultMessage": "ID 設置後無法修改，確認使用 {id} 作為 Matters ID 嗎？",
@@ -1424,6 +1445,9 @@
   "IW6zQv": {
     "defaultMessage": "選擇時間"
   },
+  "IWLb33": {
+    "defaultMessage": "Posted to the quote wall"
+  },
   "IXycMo": {
     "defaultMessage": "重新發送"
   },
@@ -1450,6 +1474,9 @@
   },
   "J7hiLV": {
     "defaultMessage": "作者尚未綁定 LikeCoin 錢包"
+  },
+  "JBnAOd": {
+    "defaultMessage": "🔀 Shuffle"
   },
   "JCZFqh": {
     "defaultMessage": "現在報名，即可開始書寫年度問卷，活動細則可查看公告"
@@ -2064,6 +2091,9 @@
   "TF1OhT": {
     "defaultMessage": "臨時密碼已過期，請嘗試重新發送"
   },
+  "TIWVxK": {
+    "defaultMessage": "Quote retracted from the wall"
+  },
   "TInwt3": {
     "defaultMessage": "關閉評論"
   },
@@ -2094,6 +2124,9 @@
   "TgU+Mf": {
     "defaultMessage": "Optimism 是獨立運行的區塊鏈，若你在其他鏈上已有 USDT 貨幣，需要將它們轉移到 Optimism 網絡才能使用，詳情參考 {tutorial}.",
     "description": "src/components/Forms/PaymentForm/SwitchNetwork/index.tsx"
+  },
+  "Thr8QX": {
+    "defaultMessage": "To article ↩"
   },
   "TjWWxF": {
     "defaultMessage": "廣播已送出",
@@ -2416,6 +2449,9 @@
   "Z7JXlF": {
     "defaultMessage": "因違反用戶協定而被封存，",
     "description": "src/views/ArticleDetail/StickyTopBanner/index.tsx"
+  },
+  "Z82+dw": {
+    "defaultMessage": "Confirm retract"
   },
   "ZAoAcG": {
     "defaultMessage": "Threads, Mastodon, Misskey 這些地方的粉絲也會看到"
@@ -2781,6 +2817,9 @@
   "eov+J2": {
     "defaultMessage": "自定義網址名稱"
   },
+  "epZb9X": {
+    "defaultMessage": "View all {count} quotes"
+  },
   "erE5/4": {
     "defaultMessage": "互相追蹤",
     "description": "src/components/Buttons/FollowUser/FollowState.tsx"
@@ -3009,6 +3048,9 @@
   },
   "iSM+et": {
     "defaultMessage": "作者保留所有權利"
+  },
+  "iSjuti": {
+    "defaultMessage": "Failed to retract"
   },
   "iTcMqz": {
     "defaultMessage": "月色之下，夢想即將實現。月之夢徽章紀念你曾參與「遊牧者計畫」。",
@@ -3356,6 +3398,9 @@
   "oA2Pur": {
     "defaultMessage": "濫發廣告",
     "description": "src/components/Comment/DropdownActions/CommunityWatchRemoveComment.tsx"
+  },
+  "oCQmLu": {
+    "defaultMessage": "Post to wall"
   },
   "oEHAIT": {
     "defaultMessage": "取消排程",

--- a/src/common/enums/externalLinks.ts
+++ b/src/common/enums/externalLinks.ts
@@ -14,6 +14,7 @@ export const EXTERNAL_LINKS = {
     isProd
       ? `https://liker.land/${likerId}/civic?utm_source=Matters`
       : `https://rinkeby.liker.land/${likerId}/civic?utm_source=Matters`,
+  SEVEN_DAY_BOOK_QUOTE_WALL: 'https://freewriting.matters.town/memo-wall',
   PLANET: 'https://www.planetable.xyz/',
   ENS_DOCS: 'https://docs.ens.domains/',
   METAMASK: 'https://metamask.io/download/',

--- a/src/common/utils/analytics.ts
+++ b/src/common/utils/analytics.ts
@@ -93,6 +93,7 @@ export interface ClickButtonProp {
     | 'article_content_quote_image'
     | 'quote_image_download'
     | 'quote_image_share'
+    | 'quote_post_to_wall'
     | 'comment_open'
     | 'comment_close'
     | 'comment_placeholder'

--- a/src/components/Forms/CircleCommentForm/index.tsx
+++ b/src/components/Forms/CircleCommentForm/index.tsx
@@ -88,8 +88,7 @@ export const CircleCommentForm: React.FC<CircleCommentFormProps> = ({
   const maxLength =
     type === 'campaignDiscussion' ? MAX_CAMPAIGN_COMMENT_LENGTH : undefined
   const contentLength = stripHtml(content).length
-  const isOverLength =
-    maxLength !== undefined && contentLength > maxLength
+  const isOverLength = maxLength !== undefined && contentLength > maxLength
   const isValid = contentLength > 0 && !isOverLength
 
   const handleSubmit = async (event?: React.FormEvent<HTMLFormElement>) => {

--- a/src/components/GQL/mutations/putQuote.ts
+++ b/src/components/GQL/mutations/putQuote.ts
@@ -1,0 +1,16 @@
+import gql from 'graphql-tag'
+
+export const PUT_QUOTE = gql`
+  mutation PutQuote($input: PutQuoteInput!) {
+    putQuote(input: $input) {
+      id
+      content
+    }
+  }
+`
+
+export const DELETE_QUOTE = gql`
+  mutation DeleteQuote($input: DeleteQuoteInput!) {
+    deleteQuote(input: $input)
+  }
+`

--- a/src/components/QuoteImageDialog/Content.tsx
+++ b/src/components/QuoteImageDialog/Content.tsx
@@ -139,24 +139,25 @@ const QuoteImageDialogContent: React.FC<QuoteImageDialogContentProps> = ({
         message: (
           <FormattedMessage
             defaultMessage="Posted to the quote wall"
-            id="QuoteImage.postedToWall"
+            id="IWLb33"
           />
         ),
       })
     } catch (error) {
-      const code = (error as { graphQLErrors?: { extensions?: { code?: string } }[] })
-        ?.graphQLErrors?.[0]?.extensions?.code
+      const code = (
+        error as { graphQLErrors?: { extensions?: { code?: string } }[] }
+      )?.graphQLErrors?.[0]?.extensions?.code
       toast.error({
         message:
           code === ERROR_CODES.ACTION_LIMIT_EXCEEDED ? (
             <FormattedMessage
               defaultMessage="Wall quota reached for today — come back tomorrow!"
-              id="QuoteImage.wallQuota"
+              id="D8FJf9"
             />
           ) : (
             <FormattedMessage
               defaultMessage="Failed to post to the wall"
-              id="QuoteImage.wallFailed"
+              id="5IlTNw"
             />
           ),
       })
@@ -284,9 +285,15 @@ const QuoteImageDialogContent: React.FC<QuoteImageDialogContentProps> = ({
               <Dialog.RoundedButton
                 text={
                   posted ? (
-                    <FormattedMessage defaultMessage="On the wall ✓" id="QuoteImage.onWall" />
+                    <FormattedMessage
+                      defaultMessage="On the wall ✓"
+                      id="Cmc/He"
+                    />
                   ) : (
-                    <FormattedMessage defaultMessage="Post to wall" id="QuoteImage.postToWall" />
+                    <FormattedMessage
+                      defaultMessage="Post to wall"
+                      id="oCQmLu"
+                    />
                   )
                 }
                 color="green"
@@ -313,9 +320,15 @@ const QuoteImageDialogContent: React.FC<QuoteImageDialogContentProps> = ({
               <Dialog.TextButton
                 text={
                   posted ? (
-                    <FormattedMessage defaultMessage="On the wall ✓" id="QuoteImage.onWall" />
+                    <FormattedMessage
+                      defaultMessage="On the wall ✓"
+                      id="Cmc/He"
+                    />
                   ) : (
-                    <FormattedMessage defaultMessage="Post to wall" id="QuoteImage.postToWall" />
+                    <FormattedMessage
+                      defaultMessage="Post to wall"
+                      id="oCQmLu"
+                    />
                   )
                 }
                 color="green"

--- a/src/components/QuoteImageDialog/Content.tsx
+++ b/src/components/QuoteImageDialog/Content.tsx
@@ -3,8 +3,11 @@ import QRCode from 'qrcode'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { defineMessages, FormattedMessage, useIntl } from 'react-intl'
 
+import { ERROR_CODES } from '~/common/enums'
 import { analytics, isMobile } from '~/common/utils'
-import { Dialog } from '~/components'
+import { Dialog, toast, useMutation } from '~/components'
+import { PUT_QUOTE } from '~/components/GQL/mutations/putQuote'
+import { PutQuoteMutation } from '~/gql/graphql'
 
 import { QuoteCard } from './Card'
 import { clampQuote, MAX_QUOTE_LEN, QUOTE_SIZES, QUOTE_STYLES } from './presets'
@@ -41,6 +44,10 @@ export type QuoteImageDialogContentProps = {
   /** 文章連結，用於產生 QR Code */
   shareLink: string
   isSevenDayBook: boolean
+  /** 文章 id；與 canPostToWall 一起提供時顯示「上牆」按鈕 */
+  articleId?: string
+  /** 文章屬於活動（campaign）才可上牆；伺服器端會再驗證 */
+  canPostToWall?: boolean
 }
 
 const QuoteImageDialogContent: React.FC<QuoteImageDialogContentProps> = ({
@@ -50,6 +57,8 @@ const QuoteImageDialogContent: React.FC<QuoteImageDialogContentProps> = ({
   title,
   shareLink,
   isSevenDayBook,
+  articleId,
+  canPostToWall,
 }) => {
   const intl = useIntl()
   const cardRef = useRef<HTMLDivElement>(null)
@@ -57,6 +66,9 @@ const QuoteImageDialogContent: React.FC<QuoteImageDialogContentProps> = ({
   const [styleId, setStyleId] = useState('pine')
   const [sizeId, setSizeId] = useState('portrait')
   const [qrDataUrl, setQrDataUrl] = useState('')
+  const [putQuote] = useMutation<PutQuoteMutation>(PUT_QUOTE)
+  const [isPosting, setPosting] = useState(false)
+  const [posted, setPosted] = useState(false)
 
   const style = QUOTE_STYLES.find((s) => s.id === styleId) || QUOTE_STYLES[0]
   const size = QUOTE_SIZES.find((s) => s.id === sizeId) || QUOTE_SIZES[1]
@@ -101,6 +113,56 @@ const QuoteImageDialogContent: React.FC<QuoteImageDialogContentProps> = ({
     a.href = url
     a.download = `matters-quote-${style.id}-${size.id}.jpg`
     a.click()
+  }
+
+  const onPostToWall = async () => {
+    if (!articleId || isPosting || posted) return
+    setPosting(true)
+    analytics.trackEvent('click_button', {
+      type: 'quote_post_to_wall',
+      pageType: 'article_detail',
+    })
+
+    // wall stores plain text (no trailing ellipsis — the server verifies the
+    // quote is an excerpt of the article)
+    const wallText = (quote || '')
+      .trim()
+      .replace(/\s+/g, ' ')
+      .slice(0, MAX_QUOTE_LEN)
+
+    try {
+      await putQuote({
+        variables: { input: { articleId, content: wallText } },
+      })
+      setPosted(true)
+      toast.info({
+        message: (
+          <FormattedMessage
+            defaultMessage="Posted to the quote wall"
+            id="QuoteImage.postedToWall"
+          />
+        ),
+      })
+    } catch (error) {
+      const code = (error as { graphQLErrors?: { extensions?: { code?: string } }[] })
+        ?.graphQLErrors?.[0]?.extensions?.code
+      toast.error({
+        message:
+          code === ERROR_CODES.ACTION_LIMIT_EXCEEDED ? (
+            <FormattedMessage
+              defaultMessage="Wall quota reached for today — come back tomorrow!"
+              id="QuoteImage.wallQuota"
+            />
+          ) : (
+            <FormattedMessage
+              defaultMessage="Failed to post to the wall"
+              id="QuoteImage.wallFailed"
+            />
+          ),
+      })
+    } finally {
+      setPosting(false)
+    }
   }
 
   const onShare = async () => {
@@ -218,6 +280,21 @@ const QuoteImageDialogContent: React.FC<QuoteImageDialogContentProps> = ({
       <Dialog.Footer
         btns={
           <>
+            {articleId && canPostToWall && (
+              <Dialog.RoundedButton
+                text={
+                  posted ? (
+                    <FormattedMessage defaultMessage="On the wall ✓" id="QuoteImage.onWall" />
+                  ) : (
+                    <FormattedMessage defaultMessage="Post to wall" id="QuoteImage.postToWall" />
+                  )
+                }
+                color="green"
+                loading={isPosting}
+                disabled={isPosting || posted}
+                onClick={onPostToWall}
+              />
+            )}
             <Dialog.RoundedButton
               text={<FormattedMessage defaultMessage="Download" id="5q3qC0" />}
               color="green"
@@ -232,6 +309,21 @@ const QuoteImageDialogContent: React.FC<QuoteImageDialogContentProps> = ({
         }
         smUpBtns={
           <>
+            {articleId && canPostToWall && (
+              <Dialog.TextButton
+                text={
+                  posted ? (
+                    <FormattedMessage defaultMessage="On the wall ✓" id="QuoteImage.onWall" />
+                  ) : (
+                    <FormattedMessage defaultMessage="Post to wall" id="QuoteImage.postToWall" />
+                  )
+                }
+                color="green"
+                loading={isPosting}
+                disabled={isPosting || posted}
+                onClick={onPostToWall}
+              />
+            )}
             <Dialog.TextButton
               text={<FormattedMessage defaultMessage="Download" id="5q3qC0" />}
               color="green"

--- a/src/components/TextSelectionPopover/index.tsx
+++ b/src/components/TextSelectionPopover/index.tsx
@@ -233,6 +233,9 @@ export const TextSelectionPopover = ({
       title={article?.title || ''}
       shareLink={typeof window !== 'undefined' ? window.location.href : ''}
       isSevenDayBook={isSevenDayBookArticle(article)}
+      articleId={article?.id}
+      // 只有活動文章可上牆（伺服器會再驗證）
+      canPostToWall={!!article?.campaigns?.length}
     >
       {({ openDialog }) => (
         <button

--- a/src/views/CampaignDetail/QuoteWall/Dialog.tsx
+++ b/src/views/CampaignDetail/QuoteWall/Dialog.tsx
@@ -1,0 +1,125 @@
+import { useContext } from 'react'
+import { FormattedMessage } from 'react-intl'
+
+import IconTimes from '@/public/static/icons/24px/times.svg'
+import { EXTERNAL_LINKS } from '~/common/enums'
+import {
+  Dialog,
+  Icon,
+  SpinnerBlock,
+  useDialogSwitch,
+  usePublicQuery,
+  ViewerContext,
+} from '~/components'
+import { CampaignQuotesQuery } from '~/gql/graphql'
+
+import { CAMPAIGN_QUOTES } from './gql'
+import QuoteCard from './QuoteCard'
+import styles from './styles.module.css'
+
+type QuotesConnection = NonNullable<
+  Extract<
+    NonNullable<CampaignQuotesQuery['campaign']>,
+    { __typename: 'WritingChallenge' }
+  >['quotes']
+>
+type Quote = NonNullable<QuotesConnection['edges']>[0]['node']
+
+const WALL_TAKE = 30
+
+interface QuoteWallDialogProps {
+  shortHash: string
+  totalCount: number
+  children: ({ openDialog }: { openDialog: () => void }) => React.ReactNode
+}
+
+const BaseQuoteWallDialog = ({
+  shortHash,
+  totalCount,
+  children,
+}: QuoteWallDialogProps) => {
+  const viewer = useContext(ViewerContext)
+  const { show, openDialog, closeDialog } = useDialogSwitch(true)
+
+  const { data, loading, refetch } = usePublicQuery<CampaignQuotesQuery>(
+    CAMPAIGN_QUOTES,
+    { variables: { shortHash, first: WALL_TAKE, random: true } },
+    { publicQuery: !viewer.isAuthed }
+  )
+
+  const campaign =
+    data?.campaign?.__typename === 'WritingChallenge'
+      ? data.campaign
+      : undefined
+  const quotes: Quote[] = (campaign?.quotes?.edges || []).map(({ node }) => node)
+
+  // "shuffle" = refetch a fresh random sample
+  const shuffle = () => refetch({ shortHash, first: WALL_TAKE, random: true })
+
+  return (
+    <>
+      {children({ openDialog })}
+
+      <Dialog isOpen={show} onDismiss={closeDialog}>
+        <Dialog.Header
+          title={
+            <>
+              <FormattedMessage defaultMessage="Quote wall" id="QuoteWall.title" />{' '}
+              {totalCount > 0 && (
+                <span className={styles.count}>{totalCount}</span>
+              )}
+            </>
+          }
+          titleLeft
+          rightBtn={
+            <button onClick={closeDialog}>
+              <Icon icon={IconTimes} size={24} />
+            </button>
+          }
+        />
+
+        <Dialog.Content>
+          <div className={styles.dialogTop}>
+            <button className={styles.shuffle} onClick={shuffle}>
+              <FormattedMessage defaultMessage="🔀 Shuffle" id="QuoteWall.shuffle" />
+            </button>
+            <a
+              className={styles.museum}
+              href={EXTERNAL_LINKS.SEVEN_DAY_BOOK_QUOTE_WALL}
+              target="_blank"
+              rel="noreferrer"
+            >
+              <FormattedMessage
+                defaultMessage="Full wall / Museum →"
+                id="QuoteWall.museum"
+              />
+            </a>
+          </div>
+
+          {loading && <SpinnerBlock />}
+
+          {!loading && quotes.length > 0 && (
+            <div className={styles.wall}>
+              {quotes.map((quote, i) => (
+                <QuoteCard
+                  key={quote.id}
+                  quote={quote}
+                  index={i}
+                  afterRetract={shuffle}
+                />
+              ))}
+            </div>
+          )}
+        </Dialog.Content>
+      </Dialog>
+    </>
+  )
+}
+
+const QuoteWallDialog = (props: QuoteWallDialogProps) => (
+  <Dialog.Lazy mounted={<BaseQuoteWallDialog {...props} />}>
+    {({ openDialog }) => <>{props.children({ openDialog })}</>}
+  </Dialog.Lazy>
+)
+
+export default QuoteWallDialog

--- a/src/views/CampaignDetail/QuoteWall/Dialog.tsx
+++ b/src/views/CampaignDetail/QuoteWall/Dialog.tsx
@@ -18,10 +18,7 @@ import QuoteCard from './QuoteCard'
 import styles from './styles.module.css'
 
 type QuotesConnection = NonNullable<
-  Extract<
-    NonNullable<CampaignQuotesQuery['campaign']>,
-    { __typename: 'WritingChallenge' }
-  >['quotes']
+  NonNullable<CampaignQuotesQuery['campaign']>['quotes']
 >
 type Quote = NonNullable<QuotesConnection['edges']>[0]['node']
 
@@ -51,7 +48,9 @@ const BaseQuoteWallDialog = ({
     data?.campaign?.__typename === 'WritingChallenge'
       ? data.campaign
       : undefined
-  const quotes: Quote[] = (campaign?.quotes?.edges || []).map(({ node }) => node)
+  const quotes: Quote[] = (campaign?.quotes?.edges || []).map(
+    ({ node }) => node
+  )
 
   // "shuffle" = refetch a fresh random sample
   const shuffle = () => refetch({ shortHash, first: WALL_TAKE, random: true })
@@ -64,7 +63,7 @@ const BaseQuoteWallDialog = ({
         <Dialog.Header
           title={
             <>
-              <FormattedMessage defaultMessage="Quote wall" id="QuoteWall.title" />{' '}
+              <FormattedMessage defaultMessage="Quote wall" id="1HLo+Y" />{' '}
               {totalCount > 0 && (
                 <span className={styles.count}>{totalCount}</span>
               )}
@@ -81,7 +80,7 @@ const BaseQuoteWallDialog = ({
         <Dialog.Content>
           <div className={styles.dialogTop}>
             <button className={styles.shuffle} onClick={shuffle}>
-              <FormattedMessage defaultMessage="🔀 Shuffle" id="QuoteWall.shuffle" />
+              <FormattedMessage defaultMessage="🔀 Shuffle" id="JBnAOd" />
             </button>
             <a
               className={styles.museum}
@@ -91,7 +90,7 @@ const BaseQuoteWallDialog = ({
             >
               <FormattedMessage
                 defaultMessage="Full wall / Museum →"
-                id="QuoteWall.museum"
+                id="Fx9x/w"
               />
             </a>
           </div>

--- a/src/views/CampaignDetail/QuoteWall/QuoteCard.tsx
+++ b/src/views/CampaignDetail/QuoteWall/QuoteCard.tsx
@@ -37,7 +37,7 @@ const QuoteCard = ({ quote, index = 0, afterRetract }: QuoteCardProps) => {
         message: (
           <FormattedMessage
             defaultMessage="Quote retracted from the wall"
-            id="QuoteWall.retracted"
+            id="TIWVxK"
           />
         ),
       })
@@ -45,7 +45,7 @@ const QuoteCard = ({ quote, index = 0, afterRetract }: QuoteCardProps) => {
     } catch {
       toast.error({
         message: (
-          <FormattedMessage defaultMessage="Failed to retract" id="QuoteWall.retractFailed" />
+          <FormattedMessage defaultMessage="Failed to retract" id="iSjuti" />
         ),
       })
     }
@@ -67,7 +67,7 @@ const QuoteCard = ({ quote, index = 0, afterRetract }: QuoteCardProps) => {
           {quote.article.title ? `《${quote.article.title}》` : ''}
         </span>
         <Link {...path} className={styles.back}>
-          <FormattedMessage defaultMessage="To article ↩" id="QuoteWall.toArticle" />
+          <FormattedMessage defaultMessage="To article ↩" id="Thr8QX" />
         </Link>
       </figcaption>
 
@@ -78,7 +78,7 @@ const QuoteCard = ({ quote, index = 0, afterRetract }: QuoteCardProps) => {
               <FormattedMessage defaultMessage="Cancel" id="47FYwb" />
             </Button>
             <Button textColor="red" onClick={onRetract}>
-              <FormattedMessage defaultMessage="Confirm retract" id="QuoteWall.confirmRetract" />
+              <FormattedMessage defaultMessage="Confirm retract" id="Z82+dw" />
             </Button>
           </span>
         ) : (
@@ -87,7 +87,7 @@ const QuoteCard = ({ quote, index = 0, afterRetract }: QuoteCardProps) => {
             spacing={[0, 0]}
             onClick={() => setConfirming(true)}
           >
-            <FormattedMessage defaultMessage="Retract" id="QuoteWall.retract" />
+            <FormattedMessage defaultMessage="Retract" id="3jmniZ" />
           </Button>
         ))}
     </figure>

--- a/src/views/CampaignDetail/QuoteWall/QuoteCard.tsx
+++ b/src/views/CampaignDetail/QuoteWall/QuoteCard.tsx
@@ -1,0 +1,97 @@
+import Link from 'next/link'
+import { useContext, useState } from 'react'
+import { FormattedMessage } from 'react-intl'
+
+import { toPath } from '~/common/utils'
+import { Button, toast, useMutation, ViewerContext } from '~/components'
+import { DELETE_QUOTE } from '~/components/GQL/mutations/putQuote'
+import { DeleteQuoteMutation, QuoteWallQuoteFragment } from '~/gql/graphql'
+
+import styles from './styles.module.css'
+
+interface QuoteCardProps {
+  quote: QuoteWallQuoteFragment
+  // index drives the rotation / background variety on the wall
+  index?: number
+  afterRetract?: () => void
+}
+
+const QuoteCard = ({ quote, index = 0, afterRetract }: QuoteCardProps) => {
+  const viewer = useContext(ViewerContext)
+  const [deleteQuote] = useMutation<DeleteQuoteMutation>(DELETE_QUOTE)
+  const [confirming, setConfirming] = useState(false)
+  const [retracted, setRetracted] = useState(false)
+
+  // the poster, or the source article's author (the words are theirs), may retract
+  const canRetract =
+    !!viewer.id &&
+    (viewer.id === quote.poster.id || viewer.id === quote.article.author.id)
+
+  const path = toPath({ page: 'articleDetail', article: quote.article })
+
+  const onRetract = async () => {
+    try {
+      await deleteQuote({ variables: { input: { id: quote.id } } })
+      setRetracted(true)
+      toast.info({
+        message: (
+          <FormattedMessage
+            defaultMessage="Quote retracted from the wall"
+            id="QuoteWall.retracted"
+          />
+        ),
+      })
+      afterRetract?.()
+    } catch {
+      toast.error({
+        message: (
+          <FormattedMessage defaultMessage="Failed to retract" id="QuoteWall.retractFailed" />
+        ),
+      })
+    }
+  }
+
+  if (retracted) {
+    return null
+  }
+
+  return (
+    <figure className={styles.card} data-variant={index % 4}>
+      <Link {...path} className={styles.quoteLink}>
+        <blockquote className={styles.quote}>{quote.content}</blockquote>
+      </Link>
+
+      <figcaption className={styles.meta}>
+        <span className={styles.author}>
+          — {quote.article.author.userName}
+          {quote.article.title ? `《${quote.article.title}》` : ''}
+        </span>
+        <Link {...path} className={styles.back}>
+          <FormattedMessage defaultMessage="To article ↩" id="QuoteWall.toArticle" />
+        </Link>
+      </figcaption>
+
+      {canRetract &&
+        (confirming ? (
+          <span className={styles.retractRow}>
+            <Button textColor="grey" onClick={() => setConfirming(false)}>
+              <FormattedMessage defaultMessage="Cancel" id="47FYwb" />
+            </Button>
+            <Button textColor="red" onClick={onRetract}>
+              <FormattedMessage defaultMessage="Confirm retract" id="QuoteWall.confirmRetract" />
+            </Button>
+          </span>
+        ) : (
+          <Button
+            textColor="grey"
+            spacing={[0, 0]}
+            onClick={() => setConfirming(true)}
+          >
+            <FormattedMessage defaultMessage="Retract" id="QuoteWall.retract" />
+          </Button>
+        ))}
+    </figure>
+  )
+}
+
+export default QuoteCard

--- a/src/views/CampaignDetail/QuoteWall/gql.ts
+++ b/src/views/CampaignDetail/QuoteWall/gql.ts
@@ -1,0 +1,47 @@
+import gql from 'graphql-tag'
+
+// public: anyone can read a campaign's quote wall.
+// `random: true` returns a random sample — the "shuffle" button refetches.
+export const CAMPAIGN_QUOTES = gql`
+  query CampaignQuotes(
+    $shortHash: String!
+    $first: Int = 12
+    $random: Boolean
+  ) {
+    campaign(input: { shortHash: $shortHash }) {
+      id
+      ... on WritingChallenge {
+        id
+        quoteCount
+        quotes(input: { first: $first, random: $random }) {
+          totalCount
+          edges {
+            node {
+              ...QuoteWallQuote
+            }
+          }
+        }
+      }
+    }
+  }
+
+  fragment QuoteWallQuote on Quote {
+    id
+    content
+    createdAt
+    poster {
+      id
+      userName
+      displayName
+    }
+    article {
+      id
+      title
+      shortHash
+      author {
+        id
+        userName
+      }
+    }
+  }
+`

--- a/src/views/CampaignDetail/QuoteWall/gql.ts
+++ b/src/views/CampaignDetail/QuoteWall/gql.ts
@@ -5,7 +5,7 @@ import gql from 'graphql-tag'
 export const CAMPAIGN_QUOTES = gql`
   query CampaignQuotes(
     $shortHash: String!
-    $first: Int = 12
+    $first: first_Int_min_0_max_50 = 12
     $random: Boolean
   ) {
     campaign(input: { shortHash: $shortHash }) {

--- a/src/views/CampaignDetail/QuoteWall/index.tsx
+++ b/src/views/CampaignDetail/QuoteWall/index.tsx
@@ -11,10 +11,7 @@ import QuoteCard from './QuoteCard'
 import styles from './styles.module.css'
 
 type QuotesConnection = NonNullable<
-  Extract<
-    NonNullable<CampaignQuotesQuery['campaign']>,
-    { __typename: 'WritingChallenge' }
-  >['quotes']
+  NonNullable<CampaignQuotesQuery['campaign']>['quotes']
 >
 type Quote = NonNullable<QuotesConnection['edges']>[0]['node']
 
@@ -63,8 +60,7 @@ const QuoteWall = ({ shortHash, entry = 'module' }: QuoteWallProps) => {
             aria-haspopup="dialog"
           >
             <span>
-              ✨{' '}
-              <FormattedMessage defaultMessage="Quote wall" id="QuoteWall.title" />
+              ✨ <FormattedMessage defaultMessage="Quote wall" id="1HLo+Y" />
               <span className={styles.count}>{totalCount}</span>
             </span>
             <span className={styles.chevron}>›</span>
@@ -78,8 +74,7 @@ const QuoteWall = ({ shortHash, entry = 'module' }: QuoteWallProps) => {
     <section className={styles.quoteWall}>
       <header className={styles.header}>
         <h2 className={styles.title}>
-          ✨{' '}
-          <FormattedMessage defaultMessage="Quote wall" id="QuoteWall.title" />
+          ✨ <FormattedMessage defaultMessage="Quote wall" id="1HLo+Y" />
         </h2>
         <a
           className={styles.museum}
@@ -87,7 +82,7 @@ const QuoteWall = ({ shortHash, entry = 'module' }: QuoteWallProps) => {
           target="_blank"
           rel="noreferrer"
         >
-          <FormattedMessage defaultMessage="Full wall →" id="QuoteWall.fullWall" />
+          <FormattedMessage defaultMessage="Full wall →" id="Ds+7ro" />
         </a>
       </header>
 
@@ -110,7 +105,7 @@ const QuoteWall = ({ shortHash, entry = 'module' }: QuoteWallProps) => {
               <TextIcon size={14} weight="medium">
                 <FormattedMessage
                   defaultMessage="View all {count} quotes"
-                  id="QuoteWall.viewAll"
+                  id="epZb9X"
                   values={{ count: totalCount }}
                 />
               </TextIcon>

--- a/src/views/CampaignDetail/QuoteWall/index.tsx
+++ b/src/views/CampaignDetail/QuoteWall/index.tsx
@@ -1,0 +1,125 @@
+import { useContext } from 'react'
+import { FormattedMessage } from 'react-intl'
+
+import { EXTERNAL_LINKS } from '~/common/enums'
+import { Button, TextIcon, usePublicQuery, ViewerContext } from '~/components'
+import { CampaignQuotesQuery } from '~/gql/graphql'
+
+import QuoteWallDialog from './Dialog'
+import { CAMPAIGN_QUOTES } from './gql'
+import QuoteCard from './QuoteCard'
+import styles from './styles.module.css'
+
+type QuotesConnection = NonNullable<
+  Extract<
+    NonNullable<CampaignQuotesQuery['campaign']>,
+    { __typename: 'WritingChallenge' }
+  >['quotes']
+>
+type Quote = NonNullable<QuotesConnection['edges']>[0]['node']
+
+// how many quotes to preview in the compact module
+const PREVIEW_COUNT = 3
+
+interface QuoteWallProps {
+  shortHash: string
+  // 'module': compact wall (desktop right aside). 'chip': one-line entry
+  // (mobile main column) that opens the full wall dialog.
+  entry?: 'module' | 'chip'
+}
+
+const QuoteWall = ({ shortHash, entry = 'module' }: QuoteWallProps) => {
+  const viewer = useContext(ViewerContext)
+
+  const { data } = usePublicQuery<CampaignQuotesQuery>(
+    CAMPAIGN_QUOTES,
+    { variables: { shortHash, first: PREVIEW_COUNT, random: true } },
+    { publicQuery: !viewer.isAuthed }
+  )
+
+  const campaign =
+    data?.campaign?.__typename === 'WritingChallenge'
+      ? data.campaign
+      : undefined
+  const totalCount = campaign?.quoteCount ?? 0
+  const quotes: Quote[] = (campaign?.quotes?.edges || [])
+    .map(({ node }) => node)
+    .slice(0, PREVIEW_COUNT)
+
+  // nothing on the wall yet → hide the module entirely
+  if (totalCount <= 0) {
+    return null
+  }
+
+  // mobile: one-line entry that opens the full wall dialog
+  if (entry === 'chip') {
+    return (
+      <QuoteWallDialog shortHash={shortHash} totalCount={totalCount}>
+        {({ openDialog }) => (
+          <button
+            type="button"
+            className={styles.chip}
+            onClick={openDialog}
+            aria-haspopup="dialog"
+          >
+            <span>
+              ✨{' '}
+              <FormattedMessage defaultMessage="Quote wall" id="QuoteWall.title" />
+              <span className={styles.count}>{totalCount}</span>
+            </span>
+            <span className={styles.chevron}>›</span>
+          </button>
+        )}
+      </QuoteWallDialog>
+    )
+  }
+
+  return (
+    <section className={styles.quoteWall}>
+      <header className={styles.header}>
+        <h2 className={styles.title}>
+          ✨{' '}
+          <FormattedMessage defaultMessage="Quote wall" id="QuoteWall.title" />
+        </h2>
+        <a
+          className={styles.museum}
+          href={EXTERNAL_LINKS.SEVEN_DAY_BOOK_QUOTE_WALL}
+          target="_blank"
+          rel="noreferrer"
+        >
+          <FormattedMessage defaultMessage="Full wall →" id="QuoteWall.fullWall" />
+        </a>
+      </header>
+
+      <div className={styles.previewWall}>
+        {quotes.map((quote, i) => (
+          <QuoteCard key={quote.id} quote={quote} index={i} />
+        ))}
+      </div>
+
+      {totalCount > quotes.length && (
+        <QuoteWallDialog shortHash={shortHash} totalCount={totalCount}>
+          {({ openDialog }) => (
+            <Button
+              spacing={[8, 0]}
+              textColor="green"
+              textActiveColor="greenDark"
+              onClick={openDialog}
+              aria-haspopup="dialog"
+            >
+              <TextIcon size={14} weight="medium">
+                <FormattedMessage
+                  defaultMessage="View all {count} quotes"
+                  id="QuoteWall.viewAll"
+                  values={{ count: totalCount }}
+                />
+              </TextIcon>
+            </Button>
+          )}
+        </QuoteWallDialog>
+      )}
+    </section>
+  )
+}
+
+export default QuoteWall

--- a/src/views/CampaignDetail/QuoteWall/styles.module.css
+++ b/src/views/CampaignDetail/QuoteWall/styles.module.css
@@ -1,0 +1,136 @@
+.quoteWall {
+  padding: var(--sp16) 0;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--sp12);
+}
+
+.title {
+  font-size: var(--text16);
+  font-weight: var(--font-medium);
+}
+
+.count {
+  margin-left: var(--sp4);
+  font-weight: var(--font-normal);
+  color: var(--color-grey);
+}
+
+.museum {
+  font-size: var(--text12);
+  font-weight: var(--font-medium);
+  color: var(--color-matters-green);
+}
+
+/* compact preview: a vertical stack of memo cards */
+.previewWall {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp8);
+  margin-bottom: var(--sp8);
+}
+
+/* full wall (dialog): two-column masonry-ish grid */
+.wall {
+  column-count: 2;
+  column-gap: var(--sp12);
+}
+
+.dialogTop {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--sp16);
+}
+
+.shuffle {
+  font-size: var(--text14);
+  font-weight: var(--font-medium);
+  color: var(--color-matters-green);
+}
+
+/* sticky-note card */
+.card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp4);
+  padding: var(--sp12);
+  margin: 0 0 var(--sp12);
+  break-inside: avoid;
+  background: var(--color-yellow-lighter);
+  border-radius: var(--sp8);
+  box-shadow: 0 1px 3px rgb(0 0 0 / 8%);
+}
+
+.card[data-variant='1'] {
+  background: var(--color-green-lighter);
+}
+
+.card[data-variant='2'] {
+  background: var(--color-red-lighter);
+}
+
+.card[data-variant='3'] {
+  background: var(--color-grey-lighter);
+}
+
+.quoteLink {
+  color: inherit;
+}
+
+.quote {
+  margin: 0;
+  /* safety net: cap display at 3 lines even within the 80-char limit */
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+  overflow: hidden;
+  font-size: var(--text14);
+  line-height: 1.5;
+  color: var(--color-grey-darkest);
+}
+
+.meta {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp4);
+}
+
+.author {
+  font-size: var(--text12);
+  color: var(--color-grey-dark);
+}
+
+.back {
+  font-size: var(--text12);
+  color: var(--color-matters-green);
+}
+
+.retractRow {
+  display: flex;
+  gap: var(--sp8);
+}
+
+/* mobile one-line entry */
+.chip {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: var(--sp12) var(--sp16);
+  font-size: var(--text14);
+  font-weight: var(--font-medium);
+  color: var(--color-warn-yellow);
+  cursor: pointer;
+  background: var(--color-top-up-yellow);
+  border: 1px solid var(--color-warn-yellow);
+  border-radius: var(--sp8);
+}
+
+.chevron {
+  color: var(--color-grey);
+}

--- a/src/views/CampaignDetail/QuoteWall/styles.module.css
+++ b/src/views/CampaignDetail/QuoteWall/styles.module.css
@@ -60,10 +60,10 @@
   gap: var(--sp4);
   padding: var(--sp12);
   margin: 0 0 var(--sp12);
-  break-inside: avoid;
   background: var(--color-yellow-lighter);
   border-radius: var(--sp8);
   box-shadow: 0 1px 3px rgb(0 0 0 / 8%);
+  break-inside: avoid;
 }
 
 .card[data-variant='1'] {
@@ -83,15 +83,15 @@
 }
 
 .quote {
-  margin: 0;
   /* safety net: cap display at 3 lines even within the 80-char limit */
   display: -webkit-box;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 3;
+  margin: 0;
   overflow: hidden;
+  -webkit-line-clamp: 3;
   font-size: var(--text14);
   line-height: 1.5;
   color: var(--color-grey-darkest);
+  -webkit-box-orient: vertical;
 }
 
 .meta {

--- a/src/views/CampaignDetail/index.tsx
+++ b/src/views/CampaignDetail/index.tsx
@@ -33,6 +33,11 @@ const DynamicDiscussion = dynamic(() => import('./Discussion'), {
   ssr: false,
 })
 
+const DynamicQuoteWall = dynamic(() => import('./QuoteWall'), {
+  loading: () => <SpinnerBlock />,
+  ssr: false,
+})
+
 const DynamicSideParticipants = dynamic(() => import('./SideParticipants'), {
   loading: () => <SpinnerBlock />,
   ssr: false,
@@ -104,12 +109,16 @@ const CampaignDetail = () => {
         <>
           {campaign.showOther && <DynamicOtherCampaigns id={campaign.id} />}
           <DynamicSideParticipants campaign={campaign} />
-          {/* desktop: discussion sits in the right aside, below the avatars */}
+          {/* desktop: quote wall + discussion sit in the right aside, below
+              the avatars (quote wall first — it's the lighter "trailer") */}
           {isMdUp && (
-            <DynamicDiscussion
-              campaignId={campaign.id}
-              shortHash={campaign.shortHash}
-            />
+            <>
+              <DynamicQuoteWall shortHash={campaign.shortHash} />
+              <DynamicDiscussion
+                campaignId={campaign.id}
+                shortHash={campaign.shortHash}
+              />
+            </>
           )}
           {campaign.showAd && <Billboard />}
         </>
@@ -140,15 +149,18 @@ const CampaignDetail = () => {
 
       <InfoHeader campaign={campaign} />
 
-      {/* mobile: the aside is hidden, so the discussion shrinks to a one-line
-          entry under the header (still on the first screen); tapping it opens
-          the full discussion dialog */}
+      {/* mobile: the aside is hidden, so the quote wall + discussion shrink to
+          one-line entries under the header (still on the first screen);
+          tapping either opens its full dialog */}
       {!isMdUp && (
-        <DynamicDiscussion
-          campaignId={campaign.id}
-          shortHash={campaign.shortHash}
-          entry="chip"
-        />
+        <>
+          <DynamicQuoteWall shortHash={campaign.shortHash} entry="chip" />
+          <DynamicDiscussion
+            campaignId={campaign.id}
+            shortHash={campaign.shortHash}
+            entry="chip"
+          />
+        </>
       )}
 
       <ArticleFeeds campaign={campaign} />

--- a/src/views/Me/Settings/Misc/FederationSetting.tsx
+++ b/src/views/Me/Settings/Misc/FederationSetting.tsx
@@ -103,10 +103,7 @@ const FederationSetting = () => {
   return (
     <TableView.Cell
       title={
-        <FormattedMessage
-          defaultMessage="Fediverse 聯邦發佈"
-          id="YC2b3b"
-        />
+        <FormattedMessage defaultMessage="Fediverse 聯邦發佈" id="YC2b3b" />
       }
       subtitle={
         <FormattedMessage
@@ -118,10 +115,7 @@ const FederationSetting = () => {
         <Switch
           name="fediverse-federation-setting"
           label={
-            <FormattedMessage
-              defaultMessage="Fediverse 聯邦發佈"
-              id="YC2b3b"
-            />
+            <FormattedMessage defaultMessage="Fediverse 聯邦發佈" id="YC2b3b" />
           }
           checked={enabled}
           loading={loading || saving}

--- a/tests/helpers/utils.ts
+++ b/tests/helpers/utils.ts
@@ -3,7 +3,11 @@ import { Page } from '@playwright/test'
 export const pageGoto = async (
   page: Page,
   path: string,
-  waitUntil: 'load' | 'domcontentloaded' | 'networkidle' | 'commit' = 'networkidle'
+  waitUntil:
+    | 'load'
+    | 'domcontentloaded'
+    | 'networkidle'
+    | 'commit' = 'networkidle'
 ) => await page.goto(path, { waitUntil })
 
 export const sleep = async (ms: number) => {


### PR DESCRIPTION
Upstream CI mirror of #5966（原 PR 來自 fork yingshinlee，fork 觸發的 CI 拿不到 secrets、build required check 不會跑）。

此 PR 從 thematters/matters-web 內部分支開啟，讓 CI 能在帶 secrets 的 context 跑、codegen 抓 server.matters.icu 的新 schema（campaign discussion / quote wall 後端已於今日部署上 staging）。

內容與 #5966 相同。Co-Authored-By: Claude Fable 5