### PR TITLE
Align CI and Docker runtime with Node 24

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,12 +26,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '24'
           cache: 'npm'
 
       - name: Setup rclone
@@ -52,7 +52,7 @@ jobs:
         id: node_modules_cache
         with:
           path: node_modules
-          key: ${{ runner.os }}-v18-npm-v4-${{ hashFiles('package-lock.json') }}
+          key: ${{ runner.os }}-v24-npm-v4-${{ hashFiles('package-lock.json') }}
 
       - name: Cache Next.js
         uses: actions/cache@v4

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '24'
           cache: 'npm'
 
       - name: Cache NPM dependencies
@@ -28,7 +28,7 @@ jobs:
         id: node_modules_cache
         with:
           path: node_modules
-          key: ${{ runner.os }}-v18-npm-v4-${{ hashFiles('package-lock.json') }}
+          key: ${{ runner.os }}-v24-npm-v4-${{ hashFiles('package-lock.json') }}
 
       - name: Install Dependencies
         if: steps.node_modules_cache.outputs.cache-hit != 'true'

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -7,12 +7,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '24'
           cache: 'npm'
 
       - name: Cache NPM dependencies
@@ -20,7 +20,7 @@ jobs:
         id: node_modules_cache
         with:
           path: node_modules
-          key: ${{ runner.os }}-v18-npm-v4-${{ hashFiles('package-lock.json') }}
+          key: ${{ runner.os }}-v24-npm-v4-${{ hashFiles('package-lock.json') }}
 
       - name: Cache Next.js
         uses: actions/cache@v4

--- a/.github/workflows/test_e2e.yml
+++ b/.github/workflows/test_e2e.yml
@@ -42,12 +42,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '24'
           cache: 'npm'
 
       - name: Create check run for PR
@@ -65,7 +65,7 @@ jobs:
         id: node_modules_cache
         with:
           path: node_modules
-          key: ${{ runner.os }}-v18-npm-v4-${{ hashFiles('package-lock.json') }}
+          key: ${{ runner.os }}-v24-npm-v4-${{ hashFiles('package-lock.json') }}
 
       - name: Install Dependencies
         if: steps.node_modules_cache.outputs.cache-hit != 'true'

--- a/.github/workflows/test_unit.yml
+++ b/.github/workflows/test_unit.yml
@@ -8,12 +8,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '24'
           cache: 'npm'
 
       - name: Cache NPM dependencies
@@ -21,7 +21,7 @@ jobs:
         id: node_modules_cache
         with:
           path: node_modules
-          key: ${{ runner.os }}-v18-npm-v4-${{ hashFiles('package-lock.json') }}
+          key: ${{ runner.os }}-v24-npm-v4-${{ hashFiles('package-lock.json') }}
 
       - name: Install Dependencies
         if: steps.node_modules_cache.outputs.cache-hit != 'true'

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18
+FROM node:24
 
 # install os level packages
 RUN apt-get update && apt-get -y install \


### PR DESCRIPTION
## Summary
- move CI workflows from Node 18 to Node 24
- update node_modules cache keys from v18 to v24
- update checkout actions to v4 in the touched workflows
- align the Docker base image with Node 24

## Validation
- Node 24 npm ci passed
- Node 24 gen:type passed against develop schema
- Node 24 i18n + unit tests passed, 133 files and 449 tests
- Node 24 develop build passed with existing PWA, bundle size, and Browserslist warnings
- pre-commit i18n, lint:ts, and lint:css passed

## Rollback
- revert this PR to restore workflow and Docker runtime to Node 18
- no application code or dependency versions are changed

## Notes
- npm 11 warns that the project .npmrc unsafe-perm config will stop working in a future npm major
- @matters/matters-editor still declares a Node 18-only engine range, so npm reports EBADENGINE under Node 24, but install completes