### PR TITLE
feat(campaign): 活動頁方案 A 版面（討論在上、金句牆橫帶、手機參與者 chip）

### DIFF
--- a/src/views/CampaignDetail/QuoteWall/index.tsx
+++ b/src/views/CampaignDetail/QuoteWall/index.tsx
@@ -20,9 +20,10 @@ const PREVIEW_COUNT = 3
 
 interface QuoteWallProps {
   shortHash: string
-  // 'module': compact wall (desktop right aside). 'chip': one-line entry
-  // (mobile main column) that opens the full wall dialog.
-  entry?: 'module' | 'chip'
+  // 'band': horizontal pull-quote band in the centre column (Option A, every
+  // viewport). 'module': compact wall (legacy desktop right aside). 'chip':
+  // one-line entry (legacy mobile) that opens the full wall dialog.
+  entry?: 'module' | 'chip' | 'band'
 }
 
 const QuoteWall = ({ shortHash, entry = 'module' }: QuoteWallProps) => {
@@ -60,7 +61,7 @@ const QuoteWall = ({ shortHash, entry = 'module' }: QuoteWallProps) => {
             aria-haspopup="dialog"
           >
             <span>
-              ✨ <FormattedMessage defaultMessage="Quote wall" id="1HLo+Y" />
+              <FormattedMessage defaultMessage="Quote wall" id="1HLo+Y" />
               <span className={styles.count}>{totalCount}</span>
             </span>
             <span className={styles.chevron}>›</span>
@@ -70,11 +71,52 @@ const QuoteWall = ({ shortHash, entry = 'module' }: QuoteWallProps) => {
     )
   }
 
+  // centre-column pull-quote band (Option A): a horizontal, scrollable strip
+  // between the campaign header and the article feed, on every viewport
+  if (entry === 'band') {
+    return (
+      <section className={styles.band}>
+        <header className={styles.header}>
+          <h2 className={styles.title}>
+            <FormattedMessage defaultMessage="Quote wall" id="1HLo+Y" />
+          </h2>
+          {totalCount > quotes.length && (
+            <QuoteWallDialog shortHash={shortHash} totalCount={totalCount}>
+              {({ openDialog }) => (
+                <Button
+                  spacing={[4, 0]}
+                  textColor="green"
+                  textActiveColor="greenDark"
+                  onClick={openDialog}
+                  aria-haspopup="dialog"
+                >
+                  <TextIcon size={14} weight="medium">
+                    <FormattedMessage
+                      defaultMessage="View all {count} quotes"
+                      id="epZb9X"
+                      values={{ count: totalCount }}
+                    />
+                  </TextIcon>
+                </Button>
+              )}
+            </QuoteWallDialog>
+          )}
+        </header>
+
+        <div className={styles.bandRow}>
+          {quotes.map((quote, i) => (
+            <QuoteCard key={quote.id} quote={quote} index={i} />
+          ))}
+        </div>
+      </section>
+    )
+  }
+
   return (
     <section className={styles.quoteWall}>
       <header className={styles.header}>
         <h2 className={styles.title}>
-          ✨ <FormattedMessage defaultMessage="Quote wall" id="1HLo+Y" />
+          <FormattedMessage defaultMessage="Quote wall" id="1HLo+Y" />
         </h2>
         <a
           className={styles.museum}

--- a/src/views/CampaignDetail/QuoteWall/styles.module.css
+++ b/src/views/CampaignDetail/QuoteWall/styles.module.css
@@ -53,29 +53,16 @@
   color: var(--color-matters-green);
 }
 
-/* sticky-note card */
+/* pull-quote card: a left green rule, no fill (Option A — uniform, not the
+   old random sticky-note colours) */
 .card {
   display: flex;
   flex-direction: column;
   gap: var(--sp4);
-  padding: var(--sp12);
+  padding-left: var(--sp16);
   margin: 0 0 var(--sp12);
-  background: var(--color-yellow-lighter);
-  border-radius: var(--sp8);
-  box-shadow: 0 1px 3px rgb(0 0 0 / 8%);
+  border-left: 2px solid var(--color-matters-green);
   break-inside: avoid;
-}
-
-.card[data-variant='1'] {
-  background: var(--color-green-lighter);
-}
-
-.card[data-variant='2'] {
-  background: var(--color-red-lighter);
-}
-
-.card[data-variant='3'] {
-  background: var(--color-grey-lighter);
 }
 
 .quoteLink {
@@ -88,8 +75,8 @@
   margin: 0;
   overflow: hidden;
   -webkit-line-clamp: 3;
-  font-size: var(--text14);
-  line-height: 1.5;
+  font-size: var(--text16);
+  line-height: 1.6;
   color: var(--color-grey-darkest);
   -webkit-box-orient: vertical;
 }
@@ -133,4 +120,27 @@
 
 .chevron {
   color: var(--color-grey);
+}
+
+/* centre-column pull-quote band (Option A) */
+.band {
+  padding: var(--sp24) 0 var(--sp8);
+}
+
+.bandRow {
+  display: flex;
+  gap: var(--sp24);
+  padding-bottom: var(--sp4);
+  overflow-x: auto;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.bandRow::-webkit-scrollbar {
+  display: none;
+}
+
+.bandRow > .card {
+  flex: 0 0 14.375rem; /* 230px */
+  margin: 0;
 }

--- a/src/views/CampaignDetail/SideParticipants/index.tsx
+++ b/src/views/CampaignDetail/SideParticipants/index.tsx
@@ -33,6 +33,9 @@ const DynamicParticipantsDrawer = dynamic(
 type SideParticipantsProps = {
   campaign: SideParticipantsCampaignPublicFragment &
     Partial<SideParticipantsCampaignPrivateFragment>
+  // 'module': avatar wall in the desktop right aside. 'chip': one-line entry
+  // (mobile main column) that opens the participants drawer.
+  entry?: 'module' | 'chip'
 }
 
 const Participant = ({
@@ -68,7 +71,10 @@ const Participant = ({
   )
 }
 
-const SideParticipants = ({ campaign }: SideParticipantsProps) => {
+const SideParticipants = ({
+  campaign,
+  entry = 'module',
+}: SideParticipantsProps) => {
   const viewer = useContext(ViewerContext)
   const edges = campaign.sideParticipants.edges
   const totalCount = campaign.sideParticipants.totalCount
@@ -116,6 +122,38 @@ const SideParticipants = ({ campaign }: SideParticipantsProps) => {
 
   if (filteredEdges.length <= 0) {
     return null
+  }
+
+  // mobile: one-line entry that opens the participants drawer
+  if (entry === 'chip') {
+    return (
+      <>
+        <button
+          type="button"
+          className={styles.chip}
+          onClick={toggleDrawer}
+          aria-haspopup="dialog"
+        >
+          <span className={styles.chipLeft}>
+            <span className={styles.stack}>
+              {filteredEdges.slice(0, 3).map(({ node, cursor }) => (
+                <Avatar key={cursor} user={node} size={24} />
+              ))}
+            </span>
+            <span>
+              <FormattedMessage defaultMessage="Participants" id="zx0myy" />
+              <span className={styles.chipCount}>{totalCount}</span>
+            </span>
+          </span>
+          <span className={styles.chevron}>›</span>
+        </button>
+        <DynamicParticipantsDrawer
+          isOpen={openDrawer}
+          onClose={toggleDrawer}
+          totalParticipants={totalCount}
+        />
+      </>
+    )
   }
 
   return (

--- a/src/views/CampaignDetail/SideParticipants/styles.module.css
+++ b/src/views/CampaignDetail/SideParticipants/styles.module.css
@@ -20,3 +20,44 @@
   gap: var(--sp16);
   margin-top: var(--sp16);
 }
+
+/* mobile one-line entry */
+.chip {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: var(--sp12) var(--sp16);
+  margin-top: var(--sp8);
+  font-size: var(--text14);
+  font-weight: var(--font-medium);
+  color: var(--color-black);
+  cursor: pointer;
+  background: var(--color-white);
+  border: 1px solid var(--color-grey-light);
+  border-radius: var(--sp8);
+}
+
+.chipLeft {
+  display: flex;
+  gap: var(--sp8);
+  align-items: center;
+}
+
+.stack {
+  display: flex;
+}
+
+.stack > * + * {
+  margin-left: calc(var(--sp6) * -1);
+}
+
+.chipCount {
+  margin-left: var(--sp4);
+  font-weight: var(--font-normal);
+  color: var(--color-grey);
+}
+
+.chevron {
+  color: var(--color-grey);
+}

--- a/src/views/CampaignDetail/index.tsx
+++ b/src/views/CampaignDetail/index.tsx
@@ -108,18 +108,15 @@ const CampaignDetail = () => {
       aside={
         <>
           {campaign.showOther && <DynamicOtherCampaigns id={campaign.id} />}
-          <DynamicSideParticipants campaign={campaign} />
-          {/* desktop: quote wall + discussion sit in the right aside, below
-              the avatars (quote wall first — it's the lighter "trailer") */}
+          {/* Option A: discussion sits on top of the right aside, participants
+              below it (quote wall moved to the centre column as a band) */}
           {isMdUp && (
-            <>
-              <DynamicQuoteWall shortHash={campaign.shortHash} />
-              <DynamicDiscussion
-                campaignId={campaign.id}
-                shortHash={campaign.shortHash}
-              />
-            </>
+            <DynamicDiscussion
+              campaignId={campaign.id}
+              shortHash={campaign.shortHash}
+            />
           )}
+          <DynamicSideParticipants campaign={campaign} />
           {campaign.showAd && <Billboard />}
         </>
       }
@@ -149,19 +146,23 @@ const CampaignDetail = () => {
 
       <InfoHeader campaign={campaign} />
 
-      {/* mobile: the aside is hidden, so the quote wall + discussion shrink to
-          one-line entries under the header (still on the first screen);
-          tapping either opens its full dialog */}
+      {/* mobile: the aside is hidden, so discussion + participants shrink to
+          one-line chips under the header (discussion on top, matching the
+          desktop aside order); tapping either opens its dialog/drawer */}
       {!isMdUp && (
         <>
-          <DynamicQuoteWall shortHash={campaign.shortHash} entry="chip" />
           <DynamicDiscussion
             campaignId={campaign.id}
             shortHash={campaign.shortHash}
             entry="chip"
           />
+          <DynamicSideParticipants campaign={campaign} entry="chip" />
         </>
       )}
+
+      {/* Option A: the quote wall is a pull-quote band in the centre column,
+          shown on every viewport, between the header and the article feed */}
+      <DynamicQuoteWall shortHash={campaign.shortHash} entry="band" />
 
       <ArticleFeeds campaign={campaign} />
     </Layout.Main>


### PR DESCRIPTION
右欄改討論在上／參與者在下；金句牆移到中欄 pull-quote 橫帶（桌機＋手機）；金句卡統一 pull-quote；手機新增參與者 chip 開 Drawer。留言框維持 CircleCommentForm。型別／eslint／stylelint／build 皆綠；待 ICU 真人驗收。