### PR TITLE
fix(circle-sunset): re-hide circle entry reopened by carbon-badge commit

### DIFF
--- a/src/views/User/UserProfile/AsideUserProfile/index.tsx
+++ b/src/views/User/UserProfile/AsideUserProfile/index.tsx
@@ -37,7 +37,8 @@ import {
   SeedBadge,
   TraveloggersBadge,
 } from '../Badges'
-import CircleWidget from '../CircleWidget'
+// FEATURE IS SUNSETTING: circle entry on aside user profile is hidden
+// import CircleWidget from '../CircleWidget'
 import DropdownActions from '../DropdownActions'
 import { FollowersDialog } from '../FollowersDialog'
 import { FollowingDialog } from '../FollowingDialog'
@@ -114,7 +115,8 @@ export const AsideUserProfile = () => {
   }
 
   const badges = user.info.badges || []
-  const circles = user.ownCircles || []
+  // FEATURE IS SUNSETTING: circle entry on aside user profile is hidden
+  // const circles = user.ownCircles || []
   const hasSeedBadge = badges.some((b) => b.type === 'seed')
   const hasArchitectBadge = badges.some((b) => b.type === 'architect')
   const hasGoldenMotorBadge = badges.some((b) => b.type === 'golden_motor')
@@ -374,11 +376,12 @@ export const AsideUserProfile = () => {
         )}
       </section>
 
-      {isInUserPage && (
+      {/* FEATURE IS SUNSETTING: circle entry on aside user profile is hidden */}
+      {/* {isInUserPage && (
         <footer className={styles.footer}>
           <CircleWidget circles={circles} isMe={isMe} />
         </footer>
-      )}
+      )} */}
     </section>
   )
 }

--- a/src/views/User/UserProfile/index.tsx
+++ b/src/views/User/UserProfile/index.tsx
@@ -28,7 +28,8 @@ import { UserProfileUserPublicQuery } from '~/gql/graphql'
 import UserTabs from '../UserTabs'
 import { Badges } from './Badges'
 import { BadgesDialog } from './BadgesDialog'
-import CircleWidget from './CircleWidget'
+// FEATURE IS SUNSETTING: circle entry on user profile is hidden
+// import CircleWidget from './CircleWidget'
 import DropdownActions from './DropdownActions'
 import { FollowersDialog } from './FollowersDialog'
 import { FollowingDialog } from './FollowingDialog'
@@ -102,7 +103,8 @@ export const UserProfile = () => {
   }
 
   const badges = user.info.badges || []
-  const circles = user.ownCircles || []
+  // FEATURE IS SUNSETTING: circle entry on user profile is hidden
+  // const circles = user.ownCircles || []
   const hasSeedBadge = badges.some((b) => b.type === 'seed')
   const hasArchitectBadge = badges.some((b) => b.type === 'architect')
   const hasGoldenMotorBadge = badges.some((b) => b.type === 'golden_motor')
@@ -306,12 +308,13 @@ export const UserProfile = () => {
               </p>
             </Expandable>
 
-            <CircleWidget
+            {/* FEATURE IS SUNSETTING: circle entry on user profile is hidden */}
+            {/* <CircleWidget
               circles={circles}
               isMe={isMe}
               hasDescription={false}
               hasFooter={false}
-            />
+            /> */}
           </section>
         </Media>
       </section>


### PR DESCRIPTION
## 問題
CTO 回報「圍爐入口又被打開」。排查確認：圍爐 sunset 系列（ed1108cea / 814c776d3）原本用註解關閉個人頁與側欄的 CircleWidget 入口，但被 commit `4acdd2035`（"Display carbon based badge"，Codex 生成，PR #5934/#5935/#5937）以 sunset 前的內容重寫檔案、解除註解，導致入口重新顯示。

## 影響範圍
- `src/views/User/UserProfile/index.tsx`
- `src/views/User/UserProfile/AsideUserProfile/index.tsx`
- ⚠️ **develop 與 master（線上）都受影響**，此 PR 進 develop 後，需 cherry-pick / hotfix 一份進 master。

## 修改
把兩個檔案的圍爐三處（import / `circles` 變數 / `<CircleWidget>` render）重新加回 `// FEATURE IS SUNSETTING` 註解，**保留** `CarbonBasedBadge` 相關新增。`tsc --noEmit` + ESLint + stylelint 通過。

## 全面排查附註
同批 Codex commit（碳基徽章 + personhood）已全面掃過，其餘共用檔（Badges、UserFeatures schema、moments 按讚、community-watch、後端 circle-sunset）皆未受影響——圍爐是唯一回退點。

🤖 Generated with [Claude Code](https://claude.com/claude-code)