### PR TITLE
hotfix(circle-sunset): re-hide circle entry reopened on master

### DIFF
--- a/src/views/User/UserProfile/AsideUserProfile/index.tsx
+++ b/src/views/User/UserProfile/AsideUserProfile/index.tsx
@@ -37,7 +37,8 @@ import {
   SeedBadge,
   TraveloggersBadge,
 } from '../Badges'
-import CircleWidget from '../CircleWidget'
+// FEATURE IS SUNSETTING: circle entry on aside user profile is hidden
+// import CircleWidget from '../CircleWidget'
 import DropdownActions from '../DropdownActions'
 import { FollowersDialog } from '../FollowersDialog'
 import { FollowingDialog } from '../FollowingDialog'
@@ -114,7 +115,8 @@ export const AsideUserProfile = () => {
   }
 
   const badges = user.info.badges || []
-  const circles = user.ownCircles || []
+  // FEATURE IS SUNSETTING: circle entry on aside user profile is hidden
+  // const circles = user.ownCircles || []
   const hasSeedBadge = badges.some((b) => b.type === 'seed')
   const hasArchitectBadge = badges.some((b) => b.type === 'architect')
   const hasGoldenMotorBadge = badges.some((b) => b.type === 'golden_motor')
@@ -374,11 +376,12 @@ export const AsideUserProfile = () => {
         )}
       </section>
 
-      {isInUserPage && (
+      {/* FEATURE IS SUNSETTING: circle entry on aside user profile is hidden */}
+      {/* {isInUserPage && (
         <footer className={styles.footer}>
           <CircleWidget circles={circles} isMe={isMe} />
         </footer>
-      )}
+      )} */}
     </section>
   )
 }

--- a/src/views/User/UserProfile/index.tsx
+++ b/src/views/User/UserProfile/index.tsx
@@ -28,7 +28,8 @@ import { UserProfileUserPublicQuery } from '~/gql/graphql'
 import UserTabs from '../UserTabs'
 import { Badges } from './Badges'
 import { BadgesDialog } from './BadgesDialog'
-import CircleWidget from './CircleWidget'
+// FEATURE IS SUNSETTING: circle entry on user profile is hidden
+// import CircleWidget from './CircleWidget'
 import DropdownActions from './DropdownActions'
 import { FollowersDialog } from './FollowersDialog'
 import { FollowingDialog } from './FollowingDialog'
@@ -102,7 +103,8 @@ export const UserProfile = () => {
   }
 
   const badges = user.info.badges || []
-  const circles = user.ownCircles || []
+  // FEATURE IS SUNSETTING: circle entry on user profile is hidden
+  // const circles = user.ownCircles || []
   const hasSeedBadge = badges.some((b) => b.type === 'seed')
   const hasArchitectBadge = badges.some((b) => b.type === 'architect')
   const hasGoldenMotorBadge = badges.some((b) => b.type === 'golden_motor')
@@ -306,12 +308,13 @@ export const UserProfile = () => {
               </p>
             </Expandable>
 
-            <CircleWidget
+            {/* FEATURE IS SUNSETTING: circle entry on user profile is hidden */}
+            {/* <CircleWidget
               circles={circles}
               isMe={isMe}
               hasDescription={false}
               hasFooter={false}
-            />
+            /> */}
           </section>
         </Media>
       </section>


### PR DESCRIPTION
## 🔥 Hotfix
線上 master 上的圍爐（圍爐 / Circle）入口被意外重新打開，CTO 回報。本 PR 直接修進 master 止血。

## 根因
sunset 系列（ed1108cea / 814c776d3）原本關閉個人頁與側欄的 CircleWidget 入口，被 Codex 生成的 commit `4acdd2035`（"Display carbon based badge"）以 sunset 前內容重寫檔案、解除註解而回退。develop 端修復見 #5972；此 hotfix 為對應的 master cherry-pick。

## 修改
`UserProfile/index.tsx` 與 `AsideUserProfile/index.tsx` 圍爐三處重新關閉，保留 CarbonBasedBadge。等同 #5972。

🤖 Generated with [Claude Code](https://claude.com/claude-code)