### PR TITLE
chore(bump): bump the version for v6.11.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matters-web",
-  "version": "6.11.1",
+  "version": "6.11.2",
   "description": "codebase of Matters' website",
   "author": "Matters <hi@matters.town>",
   "engines": {


### PR DESCRIPTION
版號 6.11.1 → 6.11.2，作為 release [#5974](https://github.com/thematters/matters-web/pull/5974) 的前置。

此 release 緊急修正線上圍爐入口被重新打開（#5972），並一併修好被 schema drift 弄壞的 master build。merge 進 develop 後，#5974 即帶上正確版號。

🤖 Generated with [Claude Code](https://claude.com/claude-code)