### PR TITLE
feat(quote): gate post-to-wall on campaign enableQuoteWall

### DIFF
--- a/src/components/QuoteImageDialog/gql.ts
+++ b/src/components/QuoteImageDialog/gql.ts
@@ -25,6 +25,8 @@ export const fragments = {
           shortHash
           ... on WritingChallenge {
             id
+            # 是否開放金句牆（後端 per-campaign 旗標，控管「上牆」）
+            enableQuoteWall
             nameZhHant: name(input: { language: zh_hant })
             nameZhHans: name(input: { language: zh_hans })
             nameEn: name(input: { language: en })
@@ -51,4 +53,18 @@ export const isSevenDayBookArticle = (
     const names = [campaign.nameZhHant, campaign.nameZhHans]
     return names.some((n) => !!n && n.includes('七日書'))
   })
+}
+
+/**
+ * 判斷文章能否「上牆」：所屬活動需開啟金句牆（後端 `enableQuoteWall` 旗標）。
+ * 取代舊的「任何活動文章皆可上牆」，改由 per-campaign 旗標控管（資料驅動）。
+ */
+export const canPostQuoteToWall = (
+  article?: QuoteImageArticleFragment | null
+): boolean => {
+  if (!article?.campaigns?.length) return false
+  return article.campaigns.some(
+    ({ campaign }) =>
+      campaign?.__typename === 'WritingChallenge' && !!campaign.enableQuoteWall
+  )
 }

--- a/src/components/QuoteImageDialog/index.tsx
+++ b/src/components/QuoteImageDialog/index.tsx
@@ -35,4 +35,4 @@ export const QuoteImageDialog = (props: QuoteImageDialogProps) => {
   )
 }
 
-export { fragments, isSevenDayBookArticle } from './gql'
+export { canPostQuoteToWall, fragments, isSevenDayBookArticle } from './gql'

--- a/src/components/TextSelectionPopover/index.tsx
+++ b/src/components/TextSelectionPopover/index.tsx
@@ -8,6 +8,7 @@ import { OPEN_COMMENT_LIST_DRAWER } from '~/common/enums'
 import { isElementInViewport } from '~/common/utils'
 import { analytics } from '~/common/utils'
 import {
+  canPostQuoteToWall,
   Icon,
   isSevenDayBookArticle,
   QuoteImageDialog,
@@ -234,8 +235,8 @@ export const TextSelectionPopover = ({
       shareLink={typeof window !== 'undefined' ? window.location.href : ''}
       isSevenDayBook={isSevenDayBookArticle(article)}
       articleId={article?.id}
-      // 只有活動文章可上牆（伺服器會再驗證）
-      canPostToWall={!!article?.campaigns?.length}
+      // 只有「開啟金句牆」的活動文章可上牆（後端 enableQuoteWall；伺服器會再驗證）
+      canPostToWall={canPostQuoteToWall(article)}
     >
       {({ openDialog }) => (
         <button


### PR DESCRIPTION
上牆鈕改由活動的 `enableQuoteWall` 旗標控管（取代「任何活動文章皆可上牆」）。新增 `canPostQuoteToWall`、fragment 查 enableQuoteWall。七日書 logo 仍用名稱判定（不變）。

依賴 server#4857（已 merge 上 ICU）。本機 tsc/eslint 綠。base=develop→ICU。