### PR TITLE
feat(campaign): discussion polish — open to all + likes, button/layout/dialog refinements

### DIFF
--- a/lang/zh-Hans.json
+++ b/lang/zh-Hans.json
@@ -85,7 +85,7 @@
     "defaultMessage": "绑定"
   },
   "/0OJlF": {
-    "defaultMessage": "No discussion yet",
+    "defaultMessage": "还没有人留言",
     "description": "src/views/CampaignDetail/Discussion"
   },
   "/5OvMK": {
@@ -249,7 +249,7 @@
     "defaultMessage": "标签"
   },
   "1HLo+Y": {
-    "defaultMessage": "Quote wall"
+    "defaultMessage": "金句墙"
   },
   "1PORwh": {
     "defaultMessage": "仅作者本人可见封存作品，",
@@ -297,7 +297,7 @@
     "defaultMessage": "你无权进行此操作"
   },
   "2/u1aP": {
-    "defaultMessage": "Discussion",
+    "defaultMessage": "讨论区",
     "description": "src/views/CampaignDetail/Discussion"
   },
   "202PEj": {
@@ -417,7 +417,7 @@
     "defaultMessage": "Violet"
   },
   "3jmniZ": {
-    "defaultMessage": "Retract"
+    "defaultMessage": "撤下"
   },
   "3kbIhS": {
     "defaultMessage": "未命名"
@@ -1129,7 +1129,7 @@
     "description": "src/components/CircleComment/DropdownActions/PinButton.tsx"
   },
   "Ds+7ro": {
-    "defaultMessage": "Full wall →"
+    "defaultMessage": "看全部 →"
   },
   "DtO278": {
     "defaultMessage": "检测到近期你的多篇文章被推荐到相关频道，他们有可能不会同时出现"
@@ -1265,7 +1265,7 @@
     "defaultMessage": "成为围炉一员，一起谈天说地"
   },
   "Fx9x/w": {
-    "defaultMessage": "Full wall / Museum →"
+    "defaultMessage": "完整金句墙／博物馆 →"
   },
   "FxrSCh": {
     "defaultMessage": "ID 设置后无法修改，确认使用 {id} 作为 Matters ID 吗？",
@@ -1476,7 +1476,7 @@
     "defaultMessage": "作者尚未绑定 LikeCoin 钱包"
   },
   "JBnAOd": {
-    "defaultMessage": "🔀 Shuffle"
+    "defaultMessage": "🔀 换一批"
   },
   "JCZFqh": {
     "defaultMessage": "现在报名，即可开始书写年度问卷，活动细则请查看公告"
@@ -2092,7 +2092,7 @@
     "defaultMessage": "临时密码已过期，请尝试重新发送"
   },
   "TIWVxK": {
-    "defaultMessage": "Quote retracted from the wall"
+    "defaultMessage": "已从金句墙撤下"
   },
   "TInwt3": {
     "defaultMessage": "关闭评论"
@@ -2126,7 +2126,7 @@
     "description": "src/components/Forms/PaymentForm/SwitchNetwork/index.tsx"
   },
   "Thr8QX": {
-    "defaultMessage": "To article ↩"
+    "defaultMessage": "回原文 ↩"
   },
   "TjWWxF": {
     "defaultMessage": "广播已送出",
@@ -2251,7 +2251,7 @@
     "description": "src/components/Forms/CreateCircleForm/Init.tsx"
   },
   "VyV+WO": {
-    "defaultMessage": "Only participants can join the discussion.",
+    "defaultMessage": "登录后即可参与讨论",
     "description": "src/views/CampaignDetail/Discussion"
   },
   "VzzYJk": {
@@ -2451,7 +2451,7 @@
     "description": "src/views/ArticleDetail/StickyTopBanner/index.tsx"
   },
   "Z82+dw": {
-    "defaultMessage": "Confirm retract"
+    "defaultMessage": "确认撤下"
   },
   "ZAoAcG": {
     "defaultMessage": "Threads, Mastodon, Misskey 這些地方的粉絲也會看到"
@@ -2581,7 +2581,7 @@
     "defaultMessage": "输入简单明了的标题"
   },
   "b8LMpq": {
-    "defaultMessage": "View all {count} comments",
+    "defaultMessage": "查看全部 {count} 则留言",
     "description": "src/views/CampaignDetail/Discussion"
   },
   "b8ogKp": {
@@ -2719,7 +2719,7 @@
     "description": "src/views/CampaignDetail/Apply/Button/index.tsx"
   },
   "dHVTYM": {
-    "defaultMessage": "Share your thoughts with other participants",
+    "defaultMessage": "和其他参与者分享想法…",
     "description": "src/views/CampaignDetail/Discussion"
   },
   "dK7Dnj": {
@@ -2818,7 +2818,7 @@
     "defaultMessage": "自定义网址名称"
   },
   "epZb9X": {
-    "defaultMessage": "View all {count} quotes"
+    "defaultMessage": "查看全部 {count} 则金句"
   },
   "erE5/4": {
     "defaultMessage": "互相关注",
@@ -2896,7 +2896,7 @@
     "defaultMessage": "选择日期"
   },
   "fyKoL1": {
-    "defaultMessage": "Comment sent"
+    "defaultMessage": "留言已送出"
   },
   "g//2O2": {
     "defaultMessage": "取消折叠",
@@ -3050,7 +3050,7 @@
     "defaultMessage": "作者保留所有权利"
   },
   "iSjuti": {
-    "defaultMessage": "Failed to retract"
+    "defaultMessage": "撤下失败"
   },
   "iTcMqz": {
     "defaultMessage": "月色之下，梦想即将实现。月之梦徽章纪念你曾参与「游牧者计划」。",

--- a/lang/zh-Hant.json
+++ b/lang/zh-Hant.json
@@ -85,7 +85,7 @@
     "defaultMessage": "綁定"
   },
   "/0OJlF": {
-    "defaultMessage": "No discussion yet",
+    "defaultMessage": "還沒有人留言",
     "description": "src/views/CampaignDetail/Discussion"
   },
   "/5OvMK": {
@@ -249,7 +249,7 @@
     "defaultMessage": "標籤"
   },
   "1HLo+Y": {
-    "defaultMessage": "Quote wall"
+    "defaultMessage": "金句牆"
   },
   "1PORwh": {
     "defaultMessage": "僅作者本人可見封存作品，",
@@ -297,7 +297,7 @@
     "defaultMessage": "你無權進行此操作"
   },
   "2/u1aP": {
-    "defaultMessage": "Discussion",
+    "defaultMessage": "討論區",
     "description": "src/views/CampaignDetail/Discussion"
   },
   "202PEj": {
@@ -417,7 +417,7 @@
     "defaultMessage": "Violet"
   },
   "3jmniZ": {
-    "defaultMessage": "Retract"
+    "defaultMessage": "撤下"
   },
   "3kbIhS": {
     "defaultMessage": "未命名"
@@ -1129,7 +1129,7 @@
     "description": "src/components/CircleComment/DropdownActions/PinButton.tsx"
   },
   "Ds+7ro": {
-    "defaultMessage": "Full wall →"
+    "defaultMessage": "看全部 →"
   },
   "DtO278": {
     "defaultMessage": "檢測到近期你的多篇文章被推薦到相關頻道，它們有可能不會同時出現"
@@ -1265,7 +1265,7 @@
     "defaultMessage": "成為圍爐一員，一起談天說地"
   },
   "Fx9x/w": {
-    "defaultMessage": "Full wall / Museum →"
+    "defaultMessage": "完整金句牆／博物館 →"
   },
   "FxrSCh": {
     "defaultMessage": "ID 設置後無法修改，確認使用 {id} 作為 Matters ID 嗎？",
@@ -1476,7 +1476,7 @@
     "defaultMessage": "作者尚未綁定 LikeCoin 錢包"
   },
   "JBnAOd": {
-    "defaultMessage": "🔀 Shuffle"
+    "defaultMessage": "🔀 換一批"
   },
   "JCZFqh": {
     "defaultMessage": "現在報名，即可開始書寫年度問卷，活動細則可查看公告"
@@ -2092,7 +2092,7 @@
     "defaultMessage": "臨時密碼已過期，請嘗試重新發送"
   },
   "TIWVxK": {
-    "defaultMessage": "Quote retracted from the wall"
+    "defaultMessage": "已從金句牆撤下"
   },
   "TInwt3": {
     "defaultMessage": "關閉評論"
@@ -2126,7 +2126,7 @@
     "description": "src/components/Forms/PaymentForm/SwitchNetwork/index.tsx"
   },
   "Thr8QX": {
-    "defaultMessage": "To article ↩"
+    "defaultMessage": "回原文 ↩"
   },
   "TjWWxF": {
     "defaultMessage": "廣播已送出",
@@ -2251,7 +2251,7 @@
     "description": "src/components/Forms/CreateCircleForm/Init.tsx"
   },
   "VyV+WO": {
-    "defaultMessage": "Only participants can join the discussion.",
+    "defaultMessage": "登入後即可參與討論",
     "description": "src/views/CampaignDetail/Discussion"
   },
   "VzzYJk": {
@@ -2451,7 +2451,7 @@
     "description": "src/views/ArticleDetail/StickyTopBanner/index.tsx"
   },
   "Z82+dw": {
-    "defaultMessage": "Confirm retract"
+    "defaultMessage": "確認撤下"
   },
   "ZAoAcG": {
     "defaultMessage": "Threads, Mastodon, Misskey 這些地方的粉絲也會看到"
@@ -2581,7 +2581,7 @@
     "defaultMessage": "輸入簡單明瞭的標題"
   },
   "b8LMpq": {
-    "defaultMessage": "View all {count} comments",
+    "defaultMessage": "查看全部 {count} 則留言",
     "description": "src/views/CampaignDetail/Discussion"
   },
   "b8ogKp": {
@@ -2719,7 +2719,7 @@
     "description": "src/views/CampaignDetail/Apply/Button/index.tsx"
   },
   "dHVTYM": {
-    "defaultMessage": "Share your thoughts with other participants",
+    "defaultMessage": "和其他參與者分享想法…",
     "description": "src/views/CampaignDetail/Discussion"
   },
   "dK7Dnj": {
@@ -2818,7 +2818,7 @@
     "defaultMessage": "自定義網址名稱"
   },
   "epZb9X": {
-    "defaultMessage": "View all {count} quotes"
+    "defaultMessage": "查看全部 {count} 則金句"
   },
   "erE5/4": {
     "defaultMessage": "互相追蹤",
@@ -2896,7 +2896,7 @@
     "defaultMessage": "選擇日期"
   },
   "fyKoL1": {
-    "defaultMessage": "Comment sent"
+    "defaultMessage": "留言已送出"
   },
   "g//2O2": {
     "defaultMessage": "取消闔上",
@@ -3050,7 +3050,7 @@
     "defaultMessage": "作者保留所有權利"
   },
   "iSjuti": {
-    "defaultMessage": "Failed to retract"
+    "defaultMessage": "撤下失敗"
   },
   "iTcMqz": {
     "defaultMessage": "月色之下，夢想即將實現。月之夢徽章紀念你曾參與「遊牧者計畫」。",

--- a/src/components/CircleComment/Content/index.tsx
+++ b/src/components/CircleComment/Content/index.tsx
@@ -106,6 +106,9 @@ export const CircleCommentContent = ({
           isRichShow={isRichShow}
           bgColor={bgColor}
           textIndent={textIndent}
+          // match the "展開" button font to the comment text (14px for campaign
+          // discussion); leave other comment types untouched
+          size={isCampaignDiscussion ? size : undefined}
         >
           <section
             className={`${contentClasses} u-content-comment`}

--- a/src/components/CircleComment/Content/index.tsx
+++ b/src/components/CircleComment/Content/index.tsx
@@ -63,9 +63,11 @@ export const CircleCommentContent = ({
   const { content, state } = comment
   const isBlocked = comment.author?.isBlocked
 
-  // campaign discussion: collapse long comments after fewer lines (tunable),
-  // since they are capped at 240 chars and would never hit the default of 10
-  const expandLimit = type === 'campaignDiscussion' ? 4 : limit
+  // campaign discussion: collapse each comment to 2 lines (then 展開/收回),
+  // and use the plain (non-rich) expand path so the collapse button shows
+  const isCampaignDiscussion = type === 'campaignDiscussion'
+  const expandLimit = isCampaignDiscussion ? 2 : limit
+  const effectiveIsRichShow = isCampaignDiscussion ? false : isRichShow
 
   const contentClasses = classNames({
     [styles.content]: true,
@@ -101,7 +103,7 @@ export const CircleCommentContent = ({
         <Expandable
           content={content}
           limit={expandLimit}
-          isRichShow={isRichShow}
+          isRichShow={effectiveIsRichShow}
           bgColor={bgColor}
           textIndent={textIndent}
         >

--- a/src/components/CircleComment/Content/index.tsx
+++ b/src/components/CircleComment/Content/index.tsx
@@ -63,11 +63,11 @@ export const CircleCommentContent = ({
   const { content, state } = comment
   const isBlocked = comment.author?.isBlocked
 
-  // campaign discussion: collapse each comment to 2 lines (then 展開/收回),
-  // and use the plain (non-rich) expand path so the collapse button shows
+  // campaign discussion: clamp each comment to 2 lines, then expand-only (no
+  // collapse, like article comments) via the rich path — keeps the font
+  // consistent between the clamped and expanded states
   const isCampaignDiscussion = type === 'campaignDiscussion'
   const expandLimit = isCampaignDiscussion ? 2 : limit
-  const effectiveIsRichShow = isCampaignDiscussion ? false : isRichShow
 
   const contentClasses = classNames({
     [styles.content]: true,
@@ -103,7 +103,7 @@ export const CircleCommentContent = ({
         <Expandable
           content={content}
           limit={expandLimit}
-          isRichShow={effectiveIsRichShow}
+          isRichShow={isRichShow}
           bgColor={bgColor}
           textIndent={textIndent}
         >

--- a/src/components/CircleComment/Feed/index.tsx
+++ b/src/components/CircleComment/Feed/index.tsx
@@ -97,7 +97,7 @@ const BaseCommentFeed = ({
           <CircleCommentContent
             comment={comment}
             type={type}
-            size={15}
+            size={type === 'campaignDiscussion' ? 14 : 15}
             limit={17}
           />
         </Media>
@@ -105,7 +105,7 @@ const BaseCommentFeed = ({
           <CircleCommentContent
             comment={comment}
             type={type}
-            size={15}
+            size={type === 'campaignDiscussion' ? 14 : 15}
             limit={13}
           />
         </Media>

--- a/src/components/CircleComment/FooterActions/UpvoteButton/index.tsx
+++ b/src/components/CircleComment/FooterActions/UpvoteButton/index.tsx
@@ -1,10 +1,18 @@
 import gql from 'graphql-tag'
 import { useIntl } from 'react-intl'
 
+import IconLike from '@/public/static/icons/24px/like.svg'
+import IconLikeFill from '@/public/static/icons/24px/like-fill.svg'
 import IconVoteUp from '@/public/static/icons/24px/vote-up.svg'
 import IconVoteUpFill from '@/public/static/icons/24px/vote-up-fill.svg'
 import { numAbbr } from '~/common/utils'
-import { Button, Icon, TextIcon, useMutation } from '~/components'
+import {
+  Button,
+  CircleCommentFormType,
+  Icon,
+  TextIcon,
+  useMutation,
+} from '~/components'
 import {
   UNVOTE_COMMENT,
   VOTE_COMMENT,
@@ -20,6 +28,7 @@ import {
 interface UpvoteButtonProps {
   comment: CircleCommentUpvoteCommentPublicFragment &
     Partial<CircleCommentUpvoteCommentPrivateFragment>
+  type?: CircleCommentFormType
   onClick?: () => void
   disabled?: boolean
   inCard: boolean
@@ -45,11 +54,15 @@ const fragments = {
 
 const UpvoteButton = ({
   comment,
+  type,
   onClick,
   disabled,
   inCard,
 }: UpvoteButtonProps) => {
   const intl = useIntl()
+
+  // campaign discussion uses a heart (like) instead of the circle up-vote arrow
+  const isLike = type === 'campaignDiscussion'
 
   const [unvote] = useMutation<UnvoteCommentMutation>(UNVOTE_COMMENT, {
     variables: { id: comment.id },
@@ -95,8 +108,13 @@ const UpvoteButton = ({
         })}
       >
         <TextIcon
-          icon={<Icon icon={IconVoteUpFill} />}
-          color="green"
+          icon={
+            <Icon
+              icon={isLike ? IconLikeFill : IconVoteUpFill}
+              color={isLike ? 'redLight' : undefined}
+            />
+          }
+          color={isLike ? 'black' : 'green'}
           weight="medium"
         >
           {comment.upvotes > 0 ? numAbbr(comment.upvotes) : undefined}
@@ -123,7 +141,7 @@ const UpvoteButton = ({
       })}
     >
       <TextIcon
-        icon={<Icon icon={IconVoteUp} color="grey" />}
+        icon={<Icon icon={isLike ? IconLike : IconVoteUp} color="grey" />}
         color="grey"
         weight="medium"
       >

--- a/src/components/CircleComment/FooterActions/index.tsx
+++ b/src/components/CircleComment/FooterActions/index.tsx
@@ -148,7 +148,7 @@ const BaseFooterActions = ({
           />
         )}
 
-        {hasUpvote && <UpvoteButton {...buttonProps} />}
+        {hasUpvote && <UpvoteButton type={type} {...buttonProps} />}
 
         {hasDownvote && <DownvoteButton {...buttonProps} />}
       </section>

--- a/src/components/Forms/CircleCommentForm/index.tsx
+++ b/src/components/Forms/CircleCommentForm/index.tsx
@@ -43,6 +43,8 @@ export interface CircleCommentFormProps {
   submitCallback?: () => void
 
   placeholder?: string
+  // render the submit footer inside the editor box (campaign discussion look)
+  inlineFooter?: boolean
 }
 
 export const CircleCommentForm: React.FC<CircleCommentFormProps> = ({
@@ -57,6 +59,7 @@ export const CircleCommentForm: React.FC<CircleCommentFormProps> = ({
   submitCallback,
 
   placeholder,
+  inlineFooter = false,
 }) => {
   const viewer = useContext(ViewerContext)
   const intl = useIntl()
@@ -150,6 +153,38 @@ export const CircleCommentForm: React.FC<CircleCommentFormProps> = ({
     handleSubmit()
   })
 
+  const footer = (
+    <footer className={inlineFooter ? styles.inlineFooter : styles.footer}>
+      {maxLength !== undefined && (
+        <span
+          className={styles.counter}
+          data-over={isOverLength ? 'true' : undefined}
+        >
+          {contentLength} / {maxLength}
+        </span>
+      )}
+      <Button
+        type="submit"
+        form={formStorageKey}
+        size={[null, '2rem']}
+        spacing={[0, 16]}
+        bgColor="green"
+        disabled={isSubmitting || !isValid}
+      >
+        <TextIcon
+          color="white"
+          size={15}
+          weight="medium"
+          icon={isSubmitting && <Spinner size={14} />}
+        >
+          {isSubmitting ? null : (
+            <Translate zh_hant="送出" zh_hans="送出" en="Send" />
+          )}
+        </TextIcon>
+      </Button>
+    </footer>
+  )
+
   return (
     <form
       className={styles.form}
@@ -161,7 +196,9 @@ export const CircleCommentForm: React.FC<CircleCommentFormProps> = ({
         description: 'src/components/Forms/CommentForm/index.tsx',
       })}
     >
-      <section className={styles.content}>
+      <section
+        className={`${styles.content} ${inlineFooter ? styles.contentBoxed : ''}`}
+      >
         <CommentEditor
           content={content}
           update={onUpdate}
@@ -171,37 +208,10 @@ export const CircleCommentForm: React.FC<CircleCommentFormProps> = ({
             setEditor(editor)
           }}
         />
+        {inlineFooter && footer}
       </section>
 
-      <footer className={styles.footer}>
-        {maxLength !== undefined && (
-          <span
-            className={styles.counter}
-            data-over={isOverLength ? 'true' : undefined}
-          >
-            {contentLength} / {maxLength}
-          </span>
-        )}
-        <Button
-          type="submit"
-          form={formStorageKey}
-          size={[null, '2rem']}
-          spacing={[0, 16]}
-          bgColor="green"
-          disabled={isSubmitting || !isValid}
-        >
-          <TextIcon
-            color="white"
-            size={15}
-            weight="medium"
-            icon={isSubmitting && <Spinner size={14} />}
-          >
-            {isSubmitting ? null : (
-              <Translate zh_hant="送出" zh_hans="送出" en="Send" />
-            )}
-          </TextIcon>
-        </Button>
-      </footer>
+      {!inlineFooter && footer}
     </form>
   )
 }

--- a/src/components/Forms/CircleCommentForm/styles.module.css
+++ b/src/components/Forms/CircleCommentForm/styles.module.css
@@ -16,6 +16,20 @@
   justify-content: flex-end;
 }
 
+/* campaign-discussion variant: the footer (counter + submit) sits inside the
+   editor box, bottom-right */
+.contentBoxed {
+  margin-bottom: 0;
+}
+
+.inlineFooter {
+  display: flex;
+  gap: var(--sp8);
+  align-items: center;
+  justify-content: flex-end;
+  margin-top: var(--sp8);
+}
+
 .counter {
   font-size: var(--text12);
   color: var(--color-grey);

--- a/src/views/CampaignDetail/Discussion/Dialog.tsx
+++ b/src/views/CampaignDetail/Discussion/Dialog.tsx
@@ -116,6 +116,7 @@ const BaseDiscussionDialog = ({
             <CircleCommentForm
               campaignId={campaignId}
               type="campaignDiscussion"
+              inlineFooter
               placeholder={intl.formatMessage({
                 defaultMessage: 'Share your thoughts with other participants',
                 id: 'dHVTYM',

--- a/src/views/CampaignDetail/Discussion/Dialog.tsx
+++ b/src/views/CampaignDetail/Discussion/Dialog.tsx
@@ -89,7 +89,7 @@ const BaseDiscussionDialog = ({
     <>
       {children({ openDialog })}
 
-      <Dialog isOpen={show} onDismiss={closeDialog}>
+      <Dialog isOpen={show} onDismiss={closeDialog} fixedWidth={false}>
         <Dialog.Header
           title={
             <>
@@ -111,55 +111,57 @@ const BaseDiscussionDialog = ({
           }
         />
 
-        <Dialog.Content>
-          {canComment && (
-            <CircleCommentForm
-              campaignId={campaignId}
-              type="campaignDiscussion"
-              inlineFooter
-              placeholder={intl.formatMessage({
-                defaultMessage: 'Share your thoughts with other participants',
-                id: 'dHVTYM',
-                description: 'src/views/CampaignDetail/Discussion',
-              })}
-              submitCallback={submitCallback}
-            />
-          )}
+        <Dialog.Content noSpacing>
+          <section className={styles.dialogBody}>
+            {canComment && (
+              <CircleCommentForm
+                campaignId={campaignId}
+                type="campaignDiscussion"
+                inlineFooter
+                placeholder={intl.formatMessage({
+                  defaultMessage: 'Share your thoughts with other participants',
+                  id: 'dHVTYM',
+                  description: 'src/views/CampaignDetail/Discussion',
+                })}
+                submitCallback={submitCallback}
+              />
+            )}
 
-          {loading && <SpinnerBlock />}
+            {loading && <SpinnerBlock />}
 
-          {!loading && comments.length <= 0 && (
-            <EmptyComment
-              description={intl.formatMessage({
-                defaultMessage: 'No discussion yet',
-                id: '/0OJlF',
-                description: 'src/views/CampaignDetail/Discussion',
-              })}
-            />
-          )}
+            {!loading && comments.length <= 0 && (
+              <EmptyComment
+                description={intl.formatMessage({
+                  defaultMessage: 'No discussion yet',
+                  id: '/0OJlF',
+                  description: 'src/views/CampaignDetail/Discussion',
+                })}
+              />
+            )}
 
-          {!loading && comments.length > 0 && (
-            <InfiniteScroll
-              hasNextPage={!!pageInfo?.hasNextPage}
-              loadMore={loadMore}
-              eof
-            >
-              <List spacing={['xloose', 0]}>
-                {comments.map((comment) => (
-                  <List.Item key={comment.id}>
-                    <CircleThreadComment
-                      comment={comment}
-                      type="campaignDiscussion"
-                      hasLink
-                      hasUpvote
-                      hasDownvote={false}
-                      hasPin={false}
-                    />
-                  </List.Item>
-                ))}
-              </List>
-            </InfiniteScroll>
-          )}
+            {!loading && comments.length > 0 && (
+              <InfiniteScroll
+                hasNextPage={!!pageInfo?.hasNextPage}
+                loadMore={loadMore}
+                eof
+              >
+                <List spacing={['xloose', 0]}>
+                  {comments.map((comment) => (
+                    <List.Item key={comment.id}>
+                      <CircleThreadComment
+                        comment={comment}
+                        type="campaignDiscussion"
+                        hasLink
+                        hasUpvote
+                        hasDownvote={false}
+                        hasPin={false}
+                      />
+                    </List.Item>
+                  ))}
+                </List>
+              </InfiniteScroll>
+            )}
+          </section>
         </Dialog.Content>
       </Dialog>
     </>

--- a/src/views/CampaignDetail/Discussion/Dialog.tsx
+++ b/src/views/CampaignDetail/Discussion/Dialog.tsx
@@ -150,7 +150,7 @@ const BaseDiscussionDialog = ({
                       comment={comment}
                       type="campaignDiscussion"
                       hasLink
-                      hasUpvote={false}
+                      hasUpvote
                       hasDownvote={false}
                       hasPin={false}
                     />

--- a/src/views/CampaignDetail/Discussion/index.tsx
+++ b/src/views/CampaignDetail/Discussion/index.tsx
@@ -80,25 +80,27 @@ const CampaignDiscussion = ({
         afterSubmit={refetch}
       >
         {({ openDialog }) => (
-          <button
-            type="button"
-            className={styles.chip}
+          // mirror the Apply button's Secondary (outlined green pill) so the
+          // discussion entry sits one clear level below it
+          <Button
+            borderColor="green"
+            textColor="green"
+            borderWidth="sm"
+            size={['100%', '3rem']}
             onClick={openDialog}
             aria-haspopup="dialog"
           >
-            <span>
-              💬{' '}
+            <TextIcon size={16} weight="normal">
               <FormattedMessage
                 defaultMessage="Discussion"
                 id="2/u1aP"
                 description="src/views/CampaignDetail/Discussion"
               />
               {totalCount > 0 && (
-                <span className={styles.count}>{totalCount}</span>
+                <span className={styles.count}> {totalCount}</span>
               )}
-            </span>
-            <span className={styles.chevron}>›</span>
-          </button>
+            </TextIcon>
+          </Button>
         )}
       </DiscussionDialog>
     )

--- a/src/views/CampaignDetail/Discussion/index.tsx
+++ b/src/views/CampaignDetail/Discussion/index.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useState } from 'react'
+import { useContext } from 'react'
 import { FormattedMessage, useIntl } from 'react-intl'
 
 import { filterComments } from '~/common/utils'
@@ -11,13 +11,10 @@ import {
   usePublicQuery,
   ViewerContext,
 } from '~/components'
-import {
-  CampaignDiscussionCommentsQuery,
-  CampaignDiscussionViewerQuery,
-} from '~/gql/graphql'
+import { CampaignDiscussionCommentsQuery } from '~/gql/graphql'
 
 import DiscussionDialog from './Dialog'
-import { CAMPAIGN_DISCUSSION_COMMENTS, CAMPAIGN_DISCUSSION_VIEWER } from './gql'
+import { CAMPAIGN_DISCUSSION_COMMENTS } from './gql'
 import styles from './styles.module.css'
 
 type DiscussionConnection = NonNullable<
@@ -45,7 +42,7 @@ const CampaignDiscussion = ({
   const viewer = useContext(ViewerContext)
   const intl = useIntl()
 
-  const { data, refetch, client } =
+  const { data, refetch } =
     usePublicQuery<CampaignDiscussionCommentsQuery>(
       CAMPAIGN_DISCUSSION_COMMENTS,
       { variables: { shortHash, first: PREVIEW_COUNT } },
@@ -61,31 +58,9 @@ const CampaignDiscussion = ({
     (campaign?.discussion?.edges || []).map(({ node }) => node)
   ).slice(0, PREVIEW_COUNT)
 
-  // viewer's participation decides whether they may post
-  const [canComment, setCanComment] = useState(false)
-  useEffect(() => {
-    if (!viewer.isAuthed) {
-      setCanComment(false)
-      return
-    }
-    ;(async () => {
-      try {
-        const { data: viewerData } =
-          await client.query<CampaignDiscussionViewerQuery>({
-            query: CAMPAIGN_DISCUSSION_VIEWER,
-            fetchPolicy: 'network-only',
-            variables: { shortHash },
-          })
-        const c =
-          viewerData?.campaign?.__typename === 'WritingChallenge'
-            ? viewerData.campaign
-            : undefined
-        setCanComment(c?.application?.state === 'succeeded')
-      } catch {
-        setCanComment(false)
-      }
-    })()
-  }, [viewer.id])
+  // the discussion is open to every logged-in user (relaxed from
+  // participant-only); the server enforces the same rule
+  const canComment = viewer.isAuthed
 
   const submitCallback = () => {
     toast.info({
@@ -171,7 +146,7 @@ const CampaignDiscussion = ({
                 comment={comment}
                 type="campaignDiscussion"
                 hasLink
-                hasUpvote={false}
+                hasUpvote
                 hasDownvote={false}
                 hasPin={false}
               />

--- a/src/views/CampaignDetail/Discussion/index.tsx
+++ b/src/views/CampaignDetail/Discussion/index.tsx
@@ -83,6 +83,7 @@ const CampaignDiscussion = ({
           // mirror the Apply button's Secondary (outlined green pill) so the
           // discussion entry sits one clear level below it
           <Button
+            className={styles.chipEntry}
             borderColor="green"
             textColor="green"
             borderWidth="sm"
@@ -97,7 +98,7 @@ const CampaignDiscussion = ({
                 description="src/views/CampaignDetail/Discussion"
               />
               {totalCount > 0 && (
-                <span className={styles.count}> {totalCount}</span>
+                <span className={styles.count}>{totalCount}</span>
               )}
             </TextIcon>
           </Button>

--- a/src/views/CampaignDetail/Discussion/index.tsx
+++ b/src/views/CampaignDetail/Discussion/index.tsx
@@ -121,6 +121,7 @@ const CampaignDiscussion = ({
         <CircleCommentForm
           campaignId={campaignId}
           type="campaignDiscussion"
+          inlineFooter
           placeholder={intl.formatMessage({
             defaultMessage: 'Share your thoughts with other participants',
             id: 'dHVTYM',

--- a/src/views/CampaignDetail/Discussion/styles.module.css
+++ b/src/views/CampaignDetail/Discussion/styles.module.css
@@ -36,12 +36,18 @@
   gap: var(--sp16);
 
   /* cap the height so a busy discussion scrolls instead of pushing the
-     participants list further down the rail */
+     participants list further down the rail; scroll without visible bars */
   max-height: 20rem;
   padding: 0;
   margin: var(--sp12) 0;
-  overflow-y: auto;
+  overflow: hidden auto;
   list-style: none;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
 }
 
 /* mobile one-line entry */

--- a/src/views/CampaignDetail/Discussion/styles.module.css
+++ b/src/views/CampaignDetail/Discussion/styles.module.css
@@ -26,6 +26,19 @@
   margin-top: var(--sp12);
 }
 
+/* full discussion dialog body: widen the panel from the default `small`
+   (375px) to the design-system dialog `medium` (480px) so avatars + threaded
+   comments aren't cramped; ≤sm it's still a full-width bottom sheet */
+.dialogBody {
+  padding: var(--sp16);
+
+  @media (--sm-up) {
+    width: 30rem; /* 480px (incl. padding) — DS dialog `medium` */
+    max-width: calc(100vw - var(--sp32)); /* keep a 16px gutter at 463–480px */
+    padding: 0 var(--sp20);
+  }
+}
+
 .hint {
   padding: var(--sp12);
   margin-bottom: var(--sp12);

--- a/src/views/CampaignDetail/Discussion/styles.module.css
+++ b/src/views/CampaignDetail/Discussion/styles.module.css
@@ -34,8 +34,13 @@
   display: flex;
   flex-direction: column;
   gap: var(--sp16);
+
+  /* cap the height so a busy discussion scrolls instead of pushing the
+     participants list further down the rail */
+  max-height: 20rem;
   padding: 0;
   margin: var(--sp12) 0;
+  overflow-y: auto;
   list-style: none;
 }
 

--- a/src/views/CampaignDetail/Discussion/styles.module.css
+++ b/src/views/CampaignDetail/Discussion/styles.module.css
@@ -10,7 +10,8 @@
 }
 
 .title {
-  font-size: var(--text16);
+  /* match the "參與者" (SideParticipants) section title — same rail level */
+  font-size: var(--text20);
   font-weight: var(--font-medium);
 }
 

--- a/src/views/CampaignDetail/Discussion/styles.module.css
+++ b/src/views/CampaignDetail/Discussion/styles.module.css
@@ -50,23 +50,3 @@
     display: none;
   }
 }
-
-/* mobile one-line entry */
-.chip {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  width: 100%;
-  padding: var(--sp12) var(--sp16);
-  font-size: var(--text14);
-  font-weight: var(--font-medium);
-  color: var(--color-matters-green);
-  cursor: pointer;
-  background: var(--color-green-lighter);
-  border: 1px solid var(--color-line-matters-green-light);
-  border-radius: var(--sp8);
-}
-
-.chevron {
-  color: var(--color-grey);
-}

--- a/src/views/CampaignDetail/Discussion/styles.module.css
+++ b/src/views/CampaignDetail/Discussion/styles.module.css
@@ -21,6 +21,11 @@
   color: var(--color-grey);
 }
 
+/* mobile one-line entry button: keep it from crowding the apply button above */
+.chipEntry {
+  margin-top: var(--sp12);
+}
+
 .hint {
   padding: var(--sp12);
   margin-bottom: var(--sp12);

--- a/src/views/CampaignDetail/InfoHeader/styles.module.css
+++ b/src/views/CampaignDetail/InfoHeader/styles.module.css
@@ -39,7 +39,13 @@
 
   flex-wrap: wrap;
   row-gap: var(--sp8);
-  margin-top: var(--sp24);
+
+  /* tighter gap under the (half-height) cover on mobile; roomier on desktop */
+  margin-top: var(--sp12);
+
+  @media (--md-up) {
+    margin-top: var(--sp24);
+  }
 
   & .name {
     font-size: var(--text18);

--- a/src/views/CampaignDetail/SideParticipants/styles.module.css
+++ b/src/views/CampaignDetail/SideParticipants/styles.module.css
@@ -1,4 +1,9 @@
 .participants {
+  /* breathing room below the dashed rule that separates this section from the
+     discussion module above it (the rule's top gap comes from the discussion
+     module's own padding) */
+  margin-top: var(--sp16);
+
   & .header {
     @mixin flex-center-space-between;
 

--- a/src/views/CampaignDetail/SideParticipants/styles.module.css
+++ b/src/views/CampaignDetail/SideParticipants/styles.module.css
@@ -1,8 +1,12 @@
 .participants {
-  /* breathing room below the dashed rule that separates this section from the
-     discussion module above it (the rule's top gap comes from the discussion
-     module's own padding) */
-  margin-top: var(--sp16);
+  /* dashed top rule marking the seam from the discussion module above; uses
+     the same colour/style as the article-feed list separators (#ddd dashed)
+     so the two rules match. top gap comes from the discussion module's own
+     padding-bottom; padding-top gives the gap below the rule */
+  @mixin border-top-grey-light;
+
+  padding-top: var(--sp16);
+  border-top-style: dashed;
 
   & .header {
     @mixin flex-center-space-between;

--- a/src/views/CampaignDetail/index.tsx
+++ b/src/views/CampaignDetail/index.tsx
@@ -6,6 +6,7 @@ import { toPath } from '~/common/utils'
 import {
   EmptyLayout,
   Head,
+  HorizontalRule,
   LanguageContext,
   Layout,
   SpinnerBlock,
@@ -111,10 +112,14 @@ const CampaignDetail = () => {
           {/* Option A: discussion sits on top of the right aside, participants
               below it (quote wall moved to the centre column as a band) */}
           {isMdUp && (
-            <DynamicDiscussion
-              campaignId={campaign.id}
-              shortHash={campaign.shortHash}
-            />
+            <>
+              <DynamicDiscussion
+                campaignId={campaign.id}
+                shortHash={campaign.shortHash}
+              />
+              {/* dashed rule to mark the seam between the two aside sections */}
+              <HorizontalRule />
+            </>
           )}
           <DynamicSideParticipants campaign={campaign} />
           {campaign.showAd && <Billboard />}

--- a/src/views/CampaignDetail/index.tsx
+++ b/src/views/CampaignDetail/index.tsx
@@ -6,7 +6,6 @@ import { toPath } from '~/common/utils'
 import {
   EmptyLayout,
   Head,
-  HorizontalRule,
   LanguageContext,
   Layout,
   SpinnerBlock,
@@ -112,15 +111,13 @@ const CampaignDetail = () => {
           {/* Option A: discussion sits on top of the right aside, participants
               below it (quote wall moved to the centre column as a band) */}
           {isMdUp && (
-            <>
-              <DynamicDiscussion
-                campaignId={campaign.id}
-                shortHash={campaign.shortHash}
-              />
-              {/* dashed rule to mark the seam between the two aside sections */}
-              <HorizontalRule />
-            </>
+            <DynamicDiscussion
+              campaignId={campaign.id}
+              shortHash={campaign.shortHash}
+            />
           )}
+          {/* SideParticipants draws its own dashed top rule (matching the
+              article feed) to mark the seam from the discussion above */}
           <DynamicSideParticipants campaign={campaign} />
           {campaign.showAd && <Billboard />}
         </>

--- a/src/views/CampaignDetail/index.tsx
+++ b/src/views/CampaignDetail/index.tsx
@@ -146,18 +146,16 @@ const CampaignDetail = () => {
 
       <InfoHeader campaign={campaign} />
 
-      {/* mobile: the aside is hidden, so discussion + participants shrink to
-          one-line chips under the header (discussion on top, matching the
-          desktop aside order); tapping either opens its dialog/drawer */}
+      {/* mobile: the aside is hidden, so the discussion shrinks to a one-line
+          entry button under the header; tapping it opens the full dialog.
+          (participants already show as an avatar row inside InfoHeader, so we
+          don't repeat them here) */}
       {!isMdUp && (
-        <>
-          <DynamicDiscussion
-            campaignId={campaign.id}
-            shortHash={campaign.shortHash}
-            entry="chip"
-          />
-          <DynamicSideParticipants campaign={campaign} entry="chip" />
-        </>
+        <DynamicDiscussion
+          campaignId={campaign.id}
+          shortHash={campaign.shortHash}
+          entry="chip"
+        />
       )}
 
       {/* Option A: the quote wall is a pull-quote band in the centre column,


### PR DESCRIPTION
活動討論區整備上線（搭配 server#4859「開放登入者留言」已上 ICU）。base = `develop`。

## 功能
- 開放**任何登入者**留言（`canComment = viewer.isAuthed`，前後端一致）＋ 留言**點讚**（`hasUpvote`，圖示用既有留言區的**愛心** `IconLike/IconLikeFill`，非三角形）
- 每則留言 **2 行收合**，比照文章留言區「展開後不再收回」（expand-only）；留言列表 `max-height` 捲動、隱藏捲軸，不擠壓下方參與者

## UI / 排版打磨
- **討論區入口鈕（手機）**：改成 Secondary 外框綠膠囊，與報名鈕（`Apply/Button`）外框狀態用同組 props；移除 💬 與 `›`
- **討論區彈窗加寬**：`small`(375px) → design-system dialog **`medium`(480px)**，`≤sm` 仍為全寬底部抽屜
- **手機版頭部**：移除重複的參與者 chip（InfoHeader 已有 avatar 列）、縮小封面→標題間距、補上按鈕間距
- **右欄區塊分隔**：討論區模組與參與者之間加 dashed 分隔線，顏色／樣式對齊文章列表分隔線（同 `border-top-grey-light` = `#ddd` dashed）
- 討論區標題字級對齊「參與者」（text20）；「展開」字級對齊留言內文；送出鈕移進輸入框內（`CircleCommentForm` 新增 `inlineFooter` 變體，圍爐眾聊不受影響）

## i18n
- 補上討論區／金句牆的繁簡中翻譯（原本 fallback 成英文）；`lang/*.json` 進版，`compiled-lang` 由 build 時 `npm run i18n` 生成

## 依賴
- server **#4859**（putComment 放寬為登入者皆可留言）已 merge 並上 ICU

## 測試狀態
- ✅ CI：`build`、`unit`、Vercel 皆 pass；本機 `tsc --noEmit` 綠
- ✅ i18n 已在 Vercel preview 上實測為中文
- ⚠️ 討論區在本機 `next dev` **不 render**（`ssr:false` + fresnel 的 dev 怪癖，與本 PR 無關），請一律在此 PR 的 **Vercel preview** 上驗收