### PR TITLE
feat(campaign): show the quote wall band even when empty (post-a-quote prompt)

### DIFF
--- a/lang/zh-Hans.json
+++ b/lang/zh-Hans.json
@@ -3159,9 +3159,6 @@
   "kHMa3H": {
     "defaultMessage": "密码不一致"
   },
-  "kQ2vH9": {
-    "defaultMessage": "在文章里选一段你喜欢的话，做成金句卡片贴上墙吧 ✍️"
-  },
   "kS3vTS": {
     "defaultMessage": "Liker ID",
     "description": "src/views/Me/Settings/Misc/LikerID.tsx"
@@ -3316,6 +3313,9 @@
   "mbHf/6": {
     "defaultMessage": "已结束",
     "description": "src/views/CampaignDetail/Apply/Button/index.tsx"
+  },
+  "md2Ml3": {
+    "defaultMessage": "在文章里选一段你喜欢的话，做成金句卡片贴上墙吧 ✍️"
   },
   "me1nR+": {
     "defaultMessage": "复制地址"

--- a/lang/zh-Hans.json
+++ b/lang/zh-Hans.json
@@ -493,6 +493,9 @@
     "defaultMessage": "确认要解绑 {type} 吗？",
     "description": "src/components/Dialogs/RemoveSocialLoginDialog/Content.tsx"
   },
+  "5FUiH2": {
+    "defaultMessage": "活动期间，大家挑出的金句会出现在这里。"
+  },
   "5IGdjy": {
     "defaultMessage": "目前尚无标签，立即添加提高作品曝光度！"
   },

--- a/lang/zh-Hans.json
+++ b/lang/zh-Hans.json
@@ -3159,6 +3159,9 @@
   "kHMa3H": {
     "defaultMessage": "密码不一致"
   },
+  "kQ2vH9": {
+    "defaultMessage": "在文章里选一段你喜欢的话，做成金句卡片贴上墙吧 ✍️"
+  },
   "kS3vTS": {
     "defaultMessage": "Liker ID",
     "description": "src/views/Me/Settings/Misc/LikerID.tsx"

--- a/lang/zh-Hant.json
+++ b/lang/zh-Hant.json
@@ -493,6 +493,9 @@
     "defaultMessage": "確認要解綁 {type} 嗎？",
     "description": "src/components/Dialogs/RemoveSocialLoginDialog/Content.tsx"
   },
+  "5FUiH2": {
+    "defaultMessage": "活動期間，大家挑出的金句會出現在這裡。"
+  },
   "5IGdjy": {
     "defaultMessage": "目前尚無標籤，立即添加提高作品曝光度！"
   },

--- a/lang/zh-Hant.json
+++ b/lang/zh-Hant.json
@@ -3159,6 +3159,9 @@
   "kHMa3H": {
     "defaultMessage": "密碼不一致"
   },
+  "kQ2vH9": {
+    "defaultMessage": "在文章裡選一段你喜歡的話，做成金句卡片貼上牆吧 ✍️"
+  },
   "kS3vTS": {
     "defaultMessage": "Liker ID",
     "description": "src/views/Me/Settings/Misc/LikerID.tsx"

--- a/lang/zh-Hant.json
+++ b/lang/zh-Hant.json
@@ -3159,9 +3159,6 @@
   "kHMa3H": {
     "defaultMessage": "密碼不一致"
   },
-  "kQ2vH9": {
-    "defaultMessage": "在文章裡選一段你喜歡的話，做成金句卡片貼上牆吧 ✍️"
-  },
   "kS3vTS": {
     "defaultMessage": "Liker ID",
     "description": "src/views/Me/Settings/Misc/LikerID.tsx"
@@ -3316,6 +3313,9 @@
   "mbHf/6": {
     "defaultMessage": "已結束",
     "description": "src/views/CampaignDetail/Apply/Button/index.tsx"
+  },
+  "md2Ml3": {
+    "defaultMessage": "在文章裡選一段你喜歡的話，做成金句卡片貼上牆吧 ✍️"
   },
   "me1nR+": {
     "defaultMessage": "複製地址"

--- a/src/views/CampaignDetail/Discussion/styles.module.css
+++ b/src/views/CampaignDetail/Discussion/styles.module.css
@@ -1,5 +1,7 @@
 .discussion {
-  padding: var(--sp16) 0;
+  /* no top padding: the aside already gives the first module a top margin, so
+     dropping it lines the "討論區" title up with the cover top in the main column */
+  padding: 0 0 var(--sp16);
 }
 
 .header {

--- a/src/views/CampaignDetail/QuoteWall/gql.ts
+++ b/src/views/CampaignDetail/QuoteWall/gql.ts
@@ -13,6 +13,7 @@ export const CAMPAIGN_QUOTES = gql`
       ... on WritingChallenge {
         id
         quoteCount
+        enableQuoteWall
         quotes(input: { first: $first, random: $random }) {
           totalCount
           edges {

--- a/src/views/CampaignDetail/QuoteWall/index.tsx
+++ b/src/views/CampaignDetail/QuoteWall/index.tsx
@@ -117,7 +117,7 @@ const QuoteWall = ({ shortHash, entry = 'module' }: QuoteWallProps) => {
           <p className={styles.empty}>
             <FormattedMessage
               defaultMessage="Pick a line you love from an article and put it on the wall ✍️"
-              id="kQ2vH9"
+              id="md2Ml3"
               description="src/views/CampaignDetail/QuoteWall band empty-state prompt"
             />
           </p>

--- a/src/views/CampaignDetail/QuoteWall/index.tsx
+++ b/src/views/CampaignDetail/QuoteWall/index.tsx
@@ -40,12 +40,16 @@ const QuoteWall = ({ shortHash, entry = 'module' }: QuoteWallProps) => {
       ? data.campaign
       : undefined
   const totalCount = campaign?.quoteCount ?? 0
+  const enableQuoteWall = campaign?.enableQuoteWall ?? false
   const quotes: Quote[] = (campaign?.quotes?.edges || [])
     .map(({ node }) => node)
     .slice(0, PREVIEW_COUNT)
 
-  // nothing on the wall yet → hide the module entirely
-  if (totalCount <= 0) {
+  // the centre-column band keeps showing even when the wall is still empty (as
+  // a prompt to post the first quote), as long as the campaign has the wall
+  // enabled; the legacy module/chip entries still hide when empty
+  const showEmptyBand = entry === 'band' && enableQuoteWall
+  if (totalCount <= 0 && !showEmptyBand) {
     return null
   }
 
@@ -103,11 +107,21 @@ const QuoteWall = ({ shortHash, entry = 'module' }: QuoteWallProps) => {
           )}
         </header>
 
-        <div className={styles.bandRow}>
-          {quotes.map((quote, i) => (
-            <QuoteCard key={quote.id} quote={quote} index={i} />
-          ))}
-        </div>
+        {quotes.length > 0 ? (
+          <div className={styles.bandRow}>
+            {quotes.map((quote, i) => (
+              <QuoteCard key={quote.id} quote={quote} index={i} />
+            ))}
+          </div>
+        ) : (
+          <p className={styles.empty}>
+            <FormattedMessage
+              defaultMessage="Pick a line you love from an article and put it on the wall ✍️"
+              id="kQ2vH9"
+              description="src/views/CampaignDetail/QuoteWall band empty-state prompt"
+            />
+          </p>
+        )}
       </section>
     )
   }

--- a/src/views/CampaignDetail/QuoteWall/index.tsx
+++ b/src/views/CampaignDetail/QuoteWall/index.tsx
@@ -114,13 +114,24 @@ const QuoteWall = ({ shortHash, entry = 'module' }: QuoteWallProps) => {
             ))}
           </div>
         ) : (
-          <p className={styles.empty}>
-            <FormattedMessage
-              defaultMessage="Pick a line you love from an article and put it on the wall ✍️"
-              id="md2Ml3"
-              description="src/views/CampaignDetail/QuoteWall band empty-state prompt"
-            />
-          </p>
+          // "invitation card": same shape as a real quote card (left green
+          // rule) so the wall keeps its card feel without showing a fake quote
+          <div className={styles.inviteCard}>
+            <p className={styles.inviteText}>
+              <span className={styles.spark}>✦</span>
+              <FormattedMessage
+                defaultMessage="During the event, the quotes people pick will appear here."
+                id="5FUiH2"
+                description="src/views/CampaignDetail/QuoteWall band empty-state, line 1"
+              />
+              <br />
+              <FormattedMessage
+                defaultMessage="Pick a line you love from an article and put it on the wall ✍️"
+                id="md2Ml3"
+                description="src/views/CampaignDetail/QuoteWall band empty-state prompt"
+              />
+            </p>
+          </div>
         )}
       </section>
     )

--- a/src/views/CampaignDetail/QuoteWall/styles.module.css
+++ b/src/views/CampaignDetail/QuoteWall/styles.module.css
@@ -148,8 +148,9 @@
 /* empty band: an "invitation card" shaped like a real quote card (left green
    rule), so the wall keeps its card feel without showing any fake quote */
 .inviteCard {
-  max-width: 22rem;
-  padding: var(--sp12) var(--sp16);
+  /* full width, matching the article list / centre column (not a half-width
+     card) */
+  padding: var(--sp16);
   margin: var(--sp4) 0 var(--sp8);
   background: var(--color-green-lighter);
   border-left: 2px solid var(--color-matters-green);

--- a/src/views/CampaignDetail/QuoteWall/styles.module.css
+++ b/src/views/CampaignDetail/QuoteWall/styles.module.css
@@ -144,3 +144,11 @@
   flex: 0 0 14.375rem; /* 230px */
   margin: 0;
 }
+
+/* shown in the band when the wall is enabled but has no quotes yet */
+.empty {
+  padding: var(--sp12) 0 var(--sp16);
+  font-size: var(--text14);
+  line-height: 1.6;
+  color: var(--color-grey-dark);
+}

--- a/src/views/CampaignDetail/QuoteWall/styles.module.css
+++ b/src/views/CampaignDetail/QuoteWall/styles.module.css
@@ -145,10 +145,25 @@
   margin: 0;
 }
 
-/* shown in the band when the wall is enabled but has no quotes yet */
-.empty {
-  padding: var(--sp12) 0 var(--sp16);
+/* empty band: an "invitation card" shaped like a real quote card (left green
+   rule), so the wall keeps its card feel without showing any fake quote */
+.inviteCard {
+  max-width: 22rem;
+  padding: var(--sp12) var(--sp16);
+  margin: var(--sp4) 0 var(--sp8);
+  background: var(--color-green-lighter);
+  border-left: 2px solid var(--color-matters-green);
+  border-radius: 0 var(--sp8) var(--sp8) 0;
+}
+
+.inviteText {
+  margin: 0;
   font-size: var(--text14);
-  line-height: 1.6;
-  color: var(--color-grey-dark);
+  line-height: 1.65;
+  color: var(--color-grey-darker);
+}
+
+.spark {
+  margin-right: var(--sp4);
+  color: var(--color-matters-green);
 }


### PR DESCRIPTION
活動剛開始、還沒有任何金句時，活動頁的金句牆**完全不顯示**（`QuoteWall` 在 `totalCount<=0` 時 return null）。本 PR 讓**中欄的金句牆 band 即使空的也預設顯示**，當作「號召大家去選金句上牆」的提示。base = `develop`。

## 改動
- `QuoteWall/index.tsx`：`band` 版型在 `enableQuoteWall=true` 時，即使 `totalCount=0` 也照常渲染；空時顯示一句邀請文案（不是金句卡片）。**只在活動有開啟金句牆時顯示空牆**（gate 在 `enableQuoteWall`）；legacy 的 `module`/`chip` 維持「空就藏」。
- `QuoteWall/gql.ts`：查詢多帶 `enableQuoteWall` 以供 gate。
- 文案（i18n id `kQ2vH9`）：繁「在文章裡選一段你喜歡的話，做成金句卡片貼上牆吧 ✍️」／簡對應。
- `.empty` 樣式。

## 測試狀態
- ✅ 本機 `gen:type`（ICU schema 有 `enableQuoteWall`）＋ `tsc --noEmit` 綠
- ⚠️ QuoteWall 僅在 production build render → 請在 **Vercel preview** 上驗：找一個**還沒有任何金句**的活動頁，確認金句牆 band 出現、顯示邀請文案；再找一個**有金句**的，確認照常顯示卡片。