### PR TITLE
[codex] Add NCC compliance public pages

### DIFF
--- a/src/common/enums/route.ts
+++ b/src/common/enums/route.ts
@@ -84,6 +84,12 @@ type ROUTE_KEY =
   | 'COMMUNITY'
   | 'TOS'
   | 'RECOMMENDATION'
+  | 'APPEALS'
+  | 'TRANSPARENCY'
+  | 'TRANSPARENCY_REPORT_2026_H1'
+  | 'TRANSPARENCY_AUTOMATION'
+  | 'TRANSPARENCY_RECOMMENDATIONS'
+  | 'TRANSPARENCY_DIGITAL_LITERACY'
 
 export const PROTECTED_ROUTES: {
   key: ROUTE_KEY
@@ -169,6 +175,23 @@ export const ROUTES: {
   { key: 'SEARCH', pathname: '/search' },
   // experient page for recommendation engine testing
   { key: 'RECOMMENDATION', pathname: '/recommendation' },
+
+  // Compliance and transparency
+  { key: 'APPEALS', pathname: '/appeals' },
+  { key: 'TRANSPARENCY', pathname: '/transparency' },
+  {
+    key: 'TRANSPARENCY_REPORT_2026_H1',
+    pathname: '/transparency/2026-h1',
+  },
+  { key: 'TRANSPARENCY_AUTOMATION', pathname: '/transparency/automation' },
+  {
+    key: 'TRANSPARENCY_RECOMMENDATIONS',
+    pathname: '/transparency/recommendations',
+  },
+  {
+    key: 'TRANSPARENCY_DIGITAL_LITERACY',
+    pathname: '/transparency/digital-literacy',
+  },
 
   // Tag
   { key: 'TAGS', pathname: '/tags' },

--- a/src/pages/appeals.tsx
+++ b/src/pages/appeals.tsx
@@ -1,0 +1,3 @@
+import Appeals from '~/views/Appeals'
+
+export default Appeals

--- a/src/pages/transparency.tsx
+++ b/src/pages/transparency.tsx
@@ -1,0 +1,3 @@
+import Transparency from '~/views/Transparency'
+
+export default Transparency

--- a/src/pages/transparency/2026-h1.tsx
+++ b/src/pages/transparency/2026-h1.tsx
@@ -1,0 +1,3 @@
+import TransparencyReport2026H1 from '~/views/TransparencyReport/Report2026H1'
+
+export default TransparencyReport2026H1

--- a/src/pages/transparency/automation.tsx
+++ b/src/pages/transparency/automation.tsx
@@ -1,0 +1,3 @@
+import TransparencyAutomation from '~/views/TransparencyAutomation'
+
+export default TransparencyAutomation

--- a/src/pages/transparency/digital-literacy.tsx
+++ b/src/pages/transparency/digital-literacy.tsx
@@ -1,0 +1,3 @@
+import DigitalLiteracy from '~/views/DigitalLiteracy'
+
+export default DigitalLiteracy

--- a/src/pages/transparency/recommendations.tsx
+++ b/src/pages/transparency/recommendations.tsx
@@ -1,0 +1,3 @@
+import RecommendationTransparency from '~/views/RecommendationTransparency'
+
+export default RecommendationTransparency

--- a/src/views/Appeals/content.ts
+++ b/src/views/Appeals/content.ts
@@ -1,0 +1,183 @@
+const zh_hant = `
+本頁整理 Matters 使用者在檢舉、申訴、個人資料權利、著作權與其他平台處理情境下，可以使用的管道與準備資料。第一版先提供公開說明與 email 流程，尚未提供自動案件查詢。
+
+## 處理時限
+
+- 收到申訴或請求後，原則上會在 3 個工作天內確認收件。
+- 一般案件原則上會在 7 個工作天內提供初步回覆。
+- 需要查核紀錄、工程協助或法律判斷的案件，原則上會在 14 個工作天內提供處理結果或進度說明。
+- 若案件涉及帳號安全、法令限制、他人個資、平台安全或濫用風險，回覆內容可能會受限。
+
+## 檢舉內容
+
+若你看到疑似違反規則的文章、留言或動態，請優先使用內容旁的檢舉功能。送出檢舉時，請選擇最接近的理由，例如侵權、非法廣告、歧視侮辱仇恨、兒少色情、色情廣告、濫發廣告或其他。
+
+若你無法使用站內檢舉，請寄信到 [hi@matters.town](mailto:hi@matters.town)，並附上內容網址、內容類型、檢舉理由、相關截圖或補充說明。
+
+## 申訴 Community Watch 處理
+
+若你的留言被 Community Watch 處理，請寄信到 [hi@matters.town](mailto:hi@matters.town)，並附上留言 ID 或公開紀錄連結。
+
+你可以補充以下資料。
+
+- 你認為該留言不屬於色情廣告或濫發廣告的理由。
+- 原留言所在文章或動態的討論脈絡。
+- 任何能協助判斷的截圖、連結或說明。
+
+站方覆核後，可能維持原處理、恢復留言、調整理由、標記申訴狀態、清除原留言內容，或暫停相關隊員資格。
+
+## 申訴內容或帳號限制
+
+若你的內容被隱藏、留言被收合或帳號受到限制，請寄信到 [hi@matters.town](mailto:hi@matters.town)。請附上帳號名稱、內容連結、收到的通知截圖、你認為應重新檢視的理由，以及必要的背景說明。
+
+可申請的救濟結果包含恢復內容、解除限制、調整處理理由、說明維持原處理的原因，或提供下一步可補充的資料。
+
+## 行使個人資料權利
+
+若你要查詢、閱覽、請求複製本、補充或更正個人資料，請寄信到 [ask@matters.town](mailto:ask@matters.town)。若你要請求停止蒐集、處理、利用或刪除個人資料，也可以寄信到 [hi@matters.town](mailto:hi@matters.town)。
+
+為了保護帳號安全，Matters 可能需要確認你的身分。若資料已被去識別化、依法需保留、涉及爭議處理、或已寫入 Matters 無法單方控制的分散式網路，處理方式可能受到限制。
+
+## 著作權或其他權利申訴
+
+若你認為 Matters 上的內容侵害你的著作權或其他權利，請寄信到 [hi@matters.town](mailto:hi@matters.town)。請附上被申訴內容網址、權利歸屬說明、侵害理由、可聯絡方式，以及你希望平台採取的處置。
+
+## 政府或公部門要求
+
+若你想了解 Matters 如何處理政府、法院或執法機關要求，請寄信到 [hi@matters.town](mailto:hi@matters.town)。Matters 將在適用法律允許範圍內處理、記錄並彙整此類要求。聚合統計會納入透明度報告。
+
+## 重大服務故障
+
+若你遇到無法登入、無法發文、支付或資料存取異常等重大服務問題，請寄信到 [hi@matters.town](mailto:hi@matters.town)，並附上發生時間、瀏覽器或裝置、錯誤訊息與截圖。若事件影響範圍較大，Matters 會視情況透過站內公告或官方渠道更新狀態。
+
+## 相關頁面
+
+- [透明度中心](/transparency)
+- [使用者協議與隱私政策](/tos)
+- [Community Watch 公開紀錄](https://community-watch.matters.town/)
+- [Community Watch 規則](https://community-watch.matters.town/rules/)
+`
+
+const zh_hans = `
+本页整理 Matters 使用者在举报、申诉、个人资料权利、著作权与其他平台处理情境下，可以使用的管道与准备资料。第一版先提供公开说明与 email 流程，尚未提供自动案件查询。
+
+## 处理时限
+
+- 收到申诉或请求后，原则上会在 3 个工作天内确认收件。
+- 一般案件原则上会在 7 个工作天内提供初步回复。
+- 需要查核记录、工程协助或法律判断的案件，原则上会在 14 个工作天内提供处理结果或进度说明。
+- 若案件涉及帐号安全、法令限制、他人个资、平台安全或滥用风险，回复内容可能会受限。
+
+## 举报内容
+
+若你看到疑似违反规则的文章、留言或动态，请优先使用内容旁的举报功能。送出举报时，请选择最接近的理由，例如侵权、非法广告、歧视侮辱仇恨、儿少色情、色情广告、滥发广告或其他。
+
+若你无法使用站内举报，请寄信到 [hi@matters.town](mailto:hi@matters.town)，并附上内容网址、内容类型、举报理由、相关截图或补充说明。
+
+## 申诉 Community Watch 处理
+
+若你的留言被 Community Watch 处理，请寄信到 [hi@matters.town](mailto:hi@matters.town)，并附上留言 ID 或公开记录连结。
+
+你可以补充以下资料。
+
+- 你认为该留言不属于色情广告或滥发广告的理由。
+- 原留言所在文章或动态的讨论脉络。
+- 任何能协助判断的截图、连结或说明。
+
+站方复核后，可能维持原处理、恢复留言、调整理由、标记申诉状态、清除原留言内容，或暂停相关队员资格。
+
+## 申诉内容或帐号限制
+
+若你的内容被隐藏、留言被收合或帐号受到限制，请寄信到 [hi@matters.town](mailto:hi@matters.town)。请附上帐号名称、内容连结、收到的通知截图、你认为应重新检视的理由，以及必要的背景说明。
+
+可申请的救济结果包含恢复内容、解除限制、调整处理理由、说明维持原处理的原因，或提供下一步可补充的资料。
+
+## 行使个人资料权利
+
+若你要查询、阅览、请求复制本、补充或更正个人资料，请寄信到 [ask@matters.town](mailto:ask@matters.town)。若你要请求停止搜集、处理、利用或删除个人资料，也可以寄信到 [hi@matters.town](mailto:hi@matters.town)。
+
+为了保护帐号安全，Matters 可能需要确认你的身分。若资料已被去识别化、依法需保留、涉及争议处理、或已写入 Matters 无法单方控制的分散式网络，处理方式可能受到限制。
+
+## 著作权或其他权利申诉
+
+若你认为 Matters 上的内容侵害你的著作权或其他权利，请寄信到 [hi@matters.town](mailto:hi@matters.town)。请附上被申诉内容网址、权利归属说明、侵害理由、可联络方式，以及你希望平台采取的处置。
+
+## 政府或公部门要求
+
+若你想了解 Matters 如何处理政府、法院或执法机关要求，请寄信到 [hi@matters.town](mailto:hi@matters.town)。Matters 将在适用法律允许范围内处理、记录并汇整此类要求。聚合统计会纳入透明度报告。
+
+## 重大服务故障
+
+若你遇到无法登入、无法发文、支付或资料存取异常等重大服务问题，请寄信到 [hi@matters.town](mailto:hi@matters.town)，并附上发生时间、浏览器或装置、错误讯息与截图。若事件影响范围较大，Matters 会视情况透过站内公告或官方渠道更新状态。
+
+## 相关页面
+
+- [透明度中心](/transparency)
+- [使用者协议与隐私政策](/tos)
+- [Community Watch 公开记录](https://community-watch.matters.town/)
+- [Community Watch 规则](https://community-watch.matters.town/rules/)
+`
+
+const en = `
+This page collects the current Matters channels for reports, appeals, privacy requests, copyright complaints, and other platform decisions. This first version provides public guidance and email-based handling. Automatic case tracking is not available yet.
+
+## Response timeline
+
+- We aim to acknowledge requests within 3 business days.
+- We aim to provide an initial response for ordinary cases within 7 business days.
+- Cases that require record review, engineering support, or legal review may take up to 14 business days for an outcome or progress update.
+- Responses may be limited when account security, legal restrictions, personal data, platform safety, or abuse risks are involved.
+
+## Report content
+
+If you see an article, comment, or moment that may violate the rules, please use the in-product report action first. Choose the closest reason, such as infringement, illegal advertising, discrimination or hate, child sexual content, porn ads, spam ads, or other.
+
+If you cannot use the in-product report action, email [hi@matters.town](mailto:hi@matters.town) with the URL, content type, reason, screenshots, and context.
+
+## Appeal a Community Watch action
+
+If your comment was handled by Community Watch, email [hi@matters.town](mailto:hi@matters.town) with the comment ID or public record link.
+
+Please include why the comment is not a porn ad or spam ad, the discussion context, and any helpful screenshots or links.
+
+After review, Matters may uphold the action, restore the comment, adjust the reason, update the appeal status, clear the original content, or suspend a watcher role.
+
+## Appeal content or account restrictions
+
+If your content was hidden, your comment was collapsed, or your account was restricted, email [hi@matters.town](mailto:hi@matters.town). Please include your account name, content link, notice screenshot, reason for review, and relevant context.
+
+Possible remedies include restoring content, lifting restrictions, adjusting the reason, explaining why the action is upheld, or requesting more context.
+
+## Personal data rights
+
+For access, copy, correction, or supplementation requests, email [ask@matters.town](mailto:ask@matters.town). For requests to stop collection, processing, use, or delete personal data, you may also email [hi@matters.town](mailto:hi@matters.town).
+
+To protect account security, Matters may need to verify your identity. Handling may be limited for de-identified data, legally retained data, dispute records, or records written to distributed networks outside Matters' sole control.
+
+## Copyright or other rights complaints
+
+If you believe content on Matters infringes your copyright or other rights, email [hi@matters.town](mailto:hi@matters.town). Include the content URL, rights ownership, reason, contact information, and requested action.
+
+## Government or public-sector requests
+
+To ask how Matters handles government, court, or law-enforcement requests, email [hi@matters.town](mailto:hi@matters.town). Matters will handle, record, and aggregate these requests where legally permitted. Aggregated statistics will be included in transparency reporting.
+
+## Major service incidents
+
+For login, publishing, payment, or data-access incidents, email [hi@matters.town](mailto:hi@matters.town) with time, device, browser, error messages, and screenshots. If an incident has broader impact, Matters may update users through in-product notices or official channels.
+
+## Related pages
+
+- [Transparency Center](/transparency)
+- [Terms and Privacy Policy](/tos)
+- [Community Watch records](https://community-watch.matters.town/)
+- [Community Watch rules](https://community-watch.matters.town/rules/)
+`
+
+const content = {
+  zh_hant,
+  zh_hans,
+  en,
+}
+
+export default content

--- a/src/views/Appeals/index.tsx
+++ b/src/views/Appeals/index.tsx
@@ -1,0 +1,23 @@
+import ComplianceDoc from '~/views/ComplianceDoc'
+
+import content from './content'
+
+const title = {
+  zh_hant: '申訴與救濟中心',
+  zh_hans: '申诉与救济中心',
+  en: 'Appeals and Remedies',
+}
+
+const description = {
+  zh_hant:
+    '整理 Matters 使用者的檢舉、申訴、個人資料權利、著作權與平台處理救濟管道。',
+  zh_hans:
+    '整理 Matters 使用者的举报、申诉、个人资料权利、著作权与平台处理救济管道。',
+  en: 'Report, appeal, privacy, copyright, and remedy channels for Matters users.',
+}
+
+const Appeals = () => (
+  <ComplianceDoc title={title} description={description} content={content} />
+)
+
+export default Appeals

--- a/src/views/ComplianceDoc/index.tsx
+++ b/src/views/ComplianceDoc/index.tsx
@@ -1,0 +1,43 @@
+import { useContext } from 'react'
+import ReactMarkdown from 'react-markdown'
+
+import { captureClicks } from '~/common/utils'
+import { Head, LanguageContext, Layout } from '~/components'
+
+type LocalizedContent = {
+  zh_hant: string
+  zh_hans: string
+  en: string
+}
+
+type ComplianceDocProps = {
+  title: LocalizedContent
+  description: LocalizedContent
+  content: LocalizedContent
+}
+
+const pickContent = (content: LocalizedContent, lang?: string | null) =>
+  content[lang as keyof LocalizedContent] || content.zh_hant
+
+const ComplianceDoc = ({ title, description, content }: ComplianceDocProps) => {
+  const { lang } = useContext(LanguageContext)
+  const pageTitle = pickContent(title, lang)
+
+  return (
+    <Layout.Main>
+      <Layout.Header
+        left={<Layout.Header.Title>{pageTitle}</Layout.Header.Title>}
+      />
+
+      <Head title={pageTitle} description={pickContent(description, lang)} />
+
+      <Layout.Main.Spacing>
+        <section className="u-content-article" onClick={captureClicks}>
+          <ReactMarkdown>{pickContent(content, lang)}</ReactMarkdown>
+        </section>
+      </Layout.Main.Spacing>
+    </Layout.Main>
+  )
+}
+
+export default ComplianceDoc

--- a/src/views/DigitalLiteracy/content.ts
+++ b/src/views/DigitalLiteracy/content.ts
@@ -1,0 +1,127 @@
+const zh_hant = `
+本頁整理使用者理解 Matters 內容治理、檢舉、申訴、個人資料與推薦系統時需要的基礎資源。第一版先作為索引，後續可逐步補上圖文版與易讀版。
+
+## 如何檢舉 spam 或違規內容
+
+請優先使用內容旁的檢舉功能，並選擇最接近的理由。若內容是明確色情廣告或濫發廣告，Community Watch 可能會留下公開處理紀錄。若無法使用站內檢舉，可參考 [申訴與救濟中心](/appeals)。
+
+## 如何提出有效申訴
+
+申訴時請盡量提供內容網址、留言 ID、公開紀錄連結、收到的通知截圖、事件時間、你認為應重新檢視的理由，以及必要脈絡。請不要在公開頁面重貼垃圾連結、色情內容、詐騙內容或他人個資。
+
+## 如何保護帳號與個人資料
+
+請保護登入方式、錢包、私鑰、密碼與 email。Matters 不會要求你把私鑰交給其他使用者。若你要查詢、更正、刪除或限制個人資料處理，請參考 [申訴與救濟中心](/appeals) 與 [使用者協議與隱私政策](/tos)。
+
+## 如何理解 Community Watch
+
+Community Watch 是第一階段的受託使用者協助機制，目的在於處理明確垃圾留言。它不是一般使用者的預設權限，也不處理立場爭議、一般批評或需要脈絡判斷的內容。
+
+更多資訊請參考 [Community Watch 規則](https://community-watch.matters.town/rules/)。
+
+## 如何理解推薦與排序
+
+不同內容入口有不同目的。熱門、最新、追蹤、標籤、搜尋與作者頁可能使用不同排序與篩選邏輯。反濫用與內容狀態也可能影響可見性。更多資訊請參考 [推薦與排序透明度](/transparency/recommendations)。
+
+## 如何閱讀透明度報告
+
+閱讀透明度報告時，請注意報告期間、統計範圍、資料來源、資料缺口、申訴結果、政府要求、模型或自動化是否影響內容，以及下一期改善承諾。
+
+若某章標示為尚未完整記錄，表示平台仍在建立資料流程，並不代表該類事件一定沒有發生。
+
+## 相關頁面
+
+- [透明度中心](/transparency)
+- [2026 H1 透明度報告骨架](/transparency/2026-h1)
+- [申訴與救濟中心](/appeals)
+- [推薦與排序透明度](/transparency/recommendations)
+- [自動化與反濫用模型](/transparency/automation)
+`
+
+const zh_hans = `
+本页整理使用者理解 Matters 内容治理、举报、申诉、个人资料与推荐系统时需要的基础资源。第一版先作为索引，后续可逐步补上图文版与易读版。
+
+## 如何举报 spam 或违规内容
+
+请优先使用内容旁的举报功能，并选择最接近的理由。若内容是明确色情广告或滥发广告，Community Watch 可能会留下公开处理记录。若无法使用站内举报，可参考 [申诉与救济中心](/appeals)。
+
+## 如何提出有效申诉
+
+申诉时请尽量提供内容网址、留言 ID、公开记录连结、收到的通知截图、事件时间、你认为应重新检视的理由，以及必要脉络。请不要在公开页面重贴垃圾连结、色情内容、诈骗内容或他人个资。
+
+## 如何保护帐号与个人资料
+
+请保护登入方式、钱包、私钥、密码与 email。Matters 不会要求你把私钥交给其他使用者。若你要查询、更正、删除或限制个人资料处理，请参考 [申诉与救济中心](/appeals) 与 [使用者协议与隐私政策](/tos)。
+
+## 如何理解 Community Watch
+
+Community Watch 是第一阶段的受托使用者协助机制，目的在于处理明确垃圾留言。它不是一般使用者的预设权限，也不处理立场争议、一般批评或需要脉络判断的内容。
+
+更多资讯请参考 [Community Watch 规则](https://community-watch.matters.town/rules/)。
+
+## 如何理解推荐与排序
+
+不同内容入口有不同目的。热门、最新、追踪、标签、搜寻与作者页可能使用不同排序与筛选逻辑。反滥用与内容状态也可能影响可见性。更多资讯请参考 [推荐与排序透明度](/transparency/recommendations)。
+
+## 如何阅读透明度报告
+
+阅读透明度报告时，请注意报告期间、统计范围、资料来源、资料缺口、申诉结果、政府要求、模型或自动化是否影响内容，以及下一期改善承诺。
+
+若某章标示为尚未完整记录，表示平台仍在建立资料流程，并不代表该类事件一定没有发生。
+
+## 相关页面
+
+- [透明度中心](/transparency)
+- [2026 H1 透明度报告骨架](/transparency/2026-h1)
+- [申诉与救济中心](/appeals)
+- [推荐与排序透明度](/transparency/recommendations)
+- [自动化与反滥用模型](/transparency/automation)
+`
+
+const en = `
+This page collects basic resources for users who want to understand Matters content governance, reports, appeals, personal data, and recommendation systems. This first version is an index. Plain-language and illustrated versions can be added later.
+
+## How to report spam or rule violations
+
+Please use the in-product report action first and choose the closest reason. If the content is a clear porn ad or spam ad, Community Watch may create a public handling record. If you cannot use the in-product report action, see [Appeals and Remedies](/appeals).
+
+## How to file an effective appeal
+
+Please include the content URL, comment ID, public record link, notice screenshot, time, reason for review, and necessary context. Do not repost spam links, sexual content, scam content, or someone else's personal data in public.
+
+## How to protect your account and personal data
+
+Protect your login method, wallet, private key, password, and email. Matters will not ask you to give your private key to another user. For access, correction, deletion, or restriction requests, see [Appeals and Remedies](/appeals) and [Terms and Privacy Policy](/tos).
+
+## How to understand Community Watch
+
+Community Watch is a first-phase trusted-user assistance mechanism for clear spam comments. It is not a default permission for all users and does not handle viewpoint disputes, ordinary criticism, or content that requires contextual judgment.
+
+For more information, see [Community Watch rules](https://community-watch.matters.town/rules/).
+
+## How to understand recommendations and ranking
+
+Different entry points serve different purposes. Hot, latest, following, tags, search, and author pages may use different ranking and filtering logic. Anti-abuse signals and content state may also affect visibility. See [Recommendation and Ranking Transparency](/transparency/recommendations).
+
+## How to read transparency reports
+
+When reading a transparency report, look for the reporting period, scope, data sources, data gaps, appeal outcomes, government requests, whether models or automation affected content, and commitments for the next period.
+
+If a section is marked as not fully recorded, it means the data process is still being built. It does not mean that no such events occurred.
+
+## Related pages
+
+- [Transparency Center](/transparency)
+- [2026 H1 Transparency Report Skeleton](/transparency/2026-h1)
+- [Appeals and Remedies](/appeals)
+- [Recommendation and Ranking Transparency](/transparency/recommendations)
+- [Automation and Anti-Abuse Models](/transparency/automation)
+`
+
+const content = {
+  zh_hant,
+  zh_hans,
+  en,
+}
+
+export default content

--- a/src/views/DigitalLiteracy/index.tsx
+++ b/src/views/DigitalLiteracy/index.tsx
@@ -1,0 +1,23 @@
+import ComplianceDoc from '~/views/ComplianceDoc'
+
+import content from './content'
+
+const title = {
+  zh_hant: '數位素養資源',
+  zh_hans: '数字素养资源',
+  en: 'Digital Literacy Resources',
+}
+
+const description = {
+  zh_hant:
+    '整理 Matters 使用者理解檢舉、申訴、個人資料、Community Watch 與推薦系統的基礎資源。',
+  zh_hans:
+    '整理 Matters 使用者理解举报、申诉、个人资料、Community Watch 与推荐系统的基础资源。',
+  en: 'Resources for understanding reporting, appeals, personal data, Community Watch, and recommendation systems on Matters.',
+}
+
+const DigitalLiteracy = () => (
+  <ComplianceDoc title={title} description={description} content={content} />
+)
+
+export default DigitalLiteracy

--- a/src/views/RecommendationTransparency/content.ts
+++ b/src/views/RecommendationTransparency/content.ts
@@ -1,0 +1,151 @@
+const zh_hant = `
+本頁說明 Matters 主要內容入口與排序、推薦或排除機制的公開原則。第一版先用使用者可理解的語言描述資訊架構與影響因素，不公開可被操弄的精確公式。
+
+## 主要內容入口
+
+Matters 使用者可能透過不同入口看到內容，例如熱門、最新、追蹤、標籤、作者頁、搜尋、活動頁或其他主題入口。不同入口的目的不同，因此排序訊號與篩選條件也可能不同。
+
+## 可能影響排序或可見性的因素
+
+- 內容發布或更新時間。
+- 使用者追蹤關係。
+- 內容互動訊號，例如閱讀、留言、收藏、讚賞或其他正向互動。
+- 內容狀態，例如正常、隱藏、收合、封存或其他限制狀態。
+- 使用者自行設定，例如追蹤、封鎖、靜音或語言偏好。
+- 站方活動、主題或編輯推薦。
+- 反濫用與 spam 訊號。
+
+不同入口不一定使用全部因素。透明度報告應逐步補上各入口的實際說明。
+
+## 內容狀態如何影響可見性
+
+若內容被站方、Community Watch、使用者檢舉門檻、管理員處理或反濫用機制標記，該內容可能被隱藏、收合、降低曝光，或從特定入口排除。若內容限制影響使用者權益，應提供可理解的理由與申訴管道。
+
+目前申訴管道請參考 [申訴與救濟中心](/appeals)。
+
+## 使用者可控制的項目
+
+使用者可透過追蹤、取消追蹤、封鎖、語言設定、搜尋與直接造訪作者頁等方式調整自己的閱讀路徑。若未來推出更多推薦偏好控制，應在本頁與透明度報告中更新。
+
+## 重大變更
+
+若主要入口、推薦邏輯、spam exclusion 或內容可見性規則有重大變更，Matters 應在透明度報告或更新紀錄中說明變更目的、影響範圍與申訴方式。
+
+## 本頁尚待補齊
+
+- 熱門、最新、追蹤與標籤頁的實際排序邏輯摘要。
+- spam exclusion 與內容狀態如何影響不同入口。
+- 使用者可控制項的完整清單。
+- 重大排序變更紀錄。
+
+## 相關頁面
+
+- [透明度中心](/transparency)
+- [自動化與反濫用模型](/transparency/automation)
+- [2026 H1 透明度報告骨架](/transparency/2026-h1)
+- [申訴與救濟中心](/appeals)
+`
+
+const zh_hans = `
+本页说明 Matters 主要内容入口与排序、推荐或排除机制的公开原则。第一版先用使用者可理解的语言描述资讯架构与影响因素，不公开可被操弄的精确公式。
+
+## 主要内容入口
+
+Matters 使用者可能透过不同入口看到内容，例如热门、最新、追踪、标签、作者页、搜寻、活动页或其他主题入口。不同入口的目的不同，因此排序讯号与筛选条件也可能不同。
+
+## 可能影响排序或可见性的因素
+
+- 内容发布或更新时间。
+- 使用者追踪关系。
+- 内容互动讯号，例如阅读、留言、收藏、赞赏或其他正向互动。
+- 内容状态，例如正常、隐藏、收合、封存或其他限制状态。
+- 使用者自行设定，例如追踪、封锁、静音或语言偏好。
+- 站方活动、主题或编辑推荐。
+- 反滥用与 spam 讯号。
+
+不同入口不一定使用全部因素。透明度报告应逐步补上各入口的实际说明。
+
+## 内容状态如何影响可见性
+
+若内容被站方、Community Watch、使用者举报门槛、管理员处理或反滥用机制标记，该内容可能被隐藏、收合、降低曝光，或从特定入口排除。若内容限制影响使用者权益，应提供可理解的理由与申诉管道。
+
+目前申诉管道请参考 [申诉与救济中心](/appeals)。
+
+## 使用者可控制的项目
+
+使用者可透过追踪、取消追踪、封锁、语言设定、搜寻与直接造访作者页等方式调整自己的阅读路径。若未来推出更多推荐偏好控制，应在本页与透明度报告中更新。
+
+## 重大变更
+
+若主要入口、推荐逻辑、spam exclusion 或内容可见性规则有重大变更，Matters 应在透明度报告或更新记录中说明变更目的、影响范围与申诉方式。
+
+## 本页尚待补齐
+
+- 热门、最新、追踪与标签页的实际排序逻辑摘要。
+- spam exclusion 与内容状态如何影响不同入口。
+- 使用者可控制项的完整清单。
+- 重大排序变更记录。
+
+## 相关页面
+
+- [透明度中心](/transparency)
+- [自动化与反滥用模型](/transparency/automation)
+- [2026 H1 透明度报告骨架](/transparency/2026-h1)
+- [申诉与救济中心](/appeals)
+`
+
+const en = `
+This page explains the public principles behind Matters content entry points, ranking, recommendation, and exclusion mechanisms. This first version uses user-readable language and does not disclose exact formulas that could be manipulated.
+
+## Main content entry points
+
+Users may discover content through hot, latest, following, tags, author pages, search, campaigns, or topic entry points. Each entry point has a different purpose, so ranking signals and filters may differ.
+
+## Factors that may affect ranking or visibility
+
+- Publish or update time.
+- Following relationships.
+- Engagement signals such as reads, comments, bookmarks, appreciations, or other positive interactions.
+- Content state, such as normal, hidden, collapsed, archived, or restricted.
+- User choices, such as following, blocking, muting, or language preference.
+- Campaigns, topics, or editorial selections.
+- Anti-abuse and spam signals.
+
+Not every entry point uses all factors. Transparency reports should gradually add concrete explanations for each surface.
+
+## How content state affects visibility
+
+If content is marked by staff, Community Watch, report thresholds, admins, or anti-abuse systems, it may be hidden, collapsed, demoted, or excluded from some surfaces. When restrictions affect user interests, Matters should provide understandable reasons and appeal channels.
+
+Current appeal channels are listed on [Appeals and Remedies](/appeals).
+
+## User controls
+
+Users can adjust their reading path through following, unfollowing, blocking, language settings, search, and direct visits to author pages. If more recommendation preference controls are added, this page and transparency reports should be updated.
+
+## Major changes
+
+When major entry points, recommendation logic, spam exclusion, or visibility rules change, Matters should explain the purpose, affected scope, and appeal channels in transparency reports or change logs.
+
+## To be completed
+
+- Summaries of actual ranking logic for hot, latest, following, and tag pages.
+- How spam exclusion and content state affect each surface.
+- Complete list of user controls.
+- Major ranking change logs.
+
+## Related pages
+
+- [Transparency Center](/transparency)
+- [Automation and Anti-Abuse Models](/transparency/automation)
+- [2026 H1 Transparency Report Skeleton](/transparency/2026-h1)
+- [Appeals and Remedies](/appeals)
+`
+
+const content = {
+  zh_hant,
+  zh_hans,
+  en,
+}
+
+export default content

--- a/src/views/RecommendationTransparency/index.tsx
+++ b/src/views/RecommendationTransparency/index.tsx
@@ -1,0 +1,21 @@
+import ComplianceDoc from '~/views/ComplianceDoc'
+
+import content from './content'
+
+const title = {
+  zh_hant: '推薦與排序透明度',
+  zh_hans: '推荐与排序透明度',
+  en: 'Recommendation and Ranking Transparency',
+}
+
+const description = {
+  zh_hant: '說明 Matters 內容入口、排序因素、可見性限制與使用者可控制項。',
+  zh_hans: '说明 Matters 内容入口、排序因素、可见性限制与使用者可控制项。',
+  en: 'How Matters explains content entry points, ranking factors, visibility restrictions, and user controls.',
+}
+
+const RecommendationTransparency = () => (
+  <ComplianceDoc title={title} description={description} content={content} />
+)
+
+export default RecommendationTransparency

--- a/src/views/ToS/Term/privacy.ts
+++ b/src/views/ToS/Term/privacy.ts
@@ -29,6 +29,7 @@ const Privacy: { zh_hant: string; zh_hans: string; en: string } = {
 <p>3.1 MATTERS將接收、儲存和處理用戶在評估和使用服務時提供的個人信息，並且將採取適當的措施來保護其收集和/或持有的個人信息，以防止未經許可或意外的訪問、處理、刪除、丟失、使用或洩露信息。</p>
 
 <p>3.2 為了保護個人信息，MATTERS將要求所有用戶（或如適用法律所定義的其各自相關人員）在請求訪問和/或修改其個人信息時證明其身份。訪問和修改個人信息的請求應當以書面形式提交並發送至 &lt;ask@matters.town&gt;。MATTERS應當收取合理的費用以抵銷MATTERS在處理相關數據訪問請求時所產生的管理和實際成本費用。如果有合理的理由相信某個人信息不準確，則MATTERS應當採取可行的措施以確保此個人信息不被使用，除非並且直到這個理由不再適用於此類個人信息或者此個人信息被刪除。</p>
+<p>3.2A 若您希望查詢、閱覽、請求複製本、補充或更正、停止蒐集處理利用，或刪除個人資料，請參考 <a href="/appeals">申訴與救濟中心</a>。MATTERS可能需要確認您的身分，並可能基於法律、爭議處理、安全或技術限制保留必要資料。</p>
 
 <p>3.3 如果MATTERS持有的某個人信息不再被需要用於本隱私政策第4.2條中所規定的使用目的，MATTERS應當採取切實可行的措施，在合理可行的條件下盡快停止處理此類個人信息，但如果MATTERS被合理請求保留數據用於（i）存檔目的；（ii）任何實際或潛在的爭議；（iii）遵守相關的法律法規；（iv）執行MATTERS和其用戶之間的任何協議；以及（v）保護MATTERS和其員工的權利、財產和安全，則MATTERS有權保留此個人信息的副本。MATTERS將採取切實可行的措施來保證其保留此個人信息的時間不會超過出於上述目的（包括直接或間接目的）所需要的保留時間。</p>
 
@@ -136,6 +137,7 @@ const Privacy: { zh_hant: string; zh_hans: string; en: string } = {
 <p>3.1 MATTERS将接收、储存和处理用户在评估和使用服务时提供的个人信息，并且将采取适当的措施来保护其收集和/或持有的个人信息，以防止未经许可或意外的访问、处理、删除、丢失、使用或泄露信息。</p>
 
 <p>3.2 为了保护个人信息，MATTERS将要求所有用户（或如适用法律所定义的其各自相关人员）在请求访问和/或修改其个人信息时证明其身份。访问和修改个人信息的请求应当以书面形式提交并發送至 &lt;ask@matters.town&gt; 。MATTERS应当收取合理的费用以抵销MATTERS在处理相关数据访问请求时所产生的管理和实际成本费用。如果有合理的理由相信某个人信息不准确，则MATTERS应当采取可行的措施以确保此个人信息不被使用，除非并且直到这个理由不再适用于此类个人信息或者此个人信息被删除。</p>
+<p>3.2A 若您希望查询、阅览、请求复制本、补充或更正、停止搜集处理利用，或删除个人资料，请参考 <a href="/appeals">申诉与救济中心</a>。MATTERS可能需要确认您的身份，并可能基于法律、争议处理、安全或技术限制保留必要资料。</p>
 
 <p>3.3 如果MATTERS持有的某个人信息不再被需要用于本隐私政策第4.2条中所规定的使用目的，MATTERS应当采取切实可行的措施，在合理可行的条件下尽快停止处理此类个人信息，但如果MATTERS被合理请求保留数据用于（i）存档目的；（ii）任何实际或潜在的争议；（iii）遵守相关的法律法规；（iv）执行MATTERS和其用户之间的任何协议；以及（v）保护MATTERS和其员工的权利、财产和安全，则MATTERS有权保留此个人信息的副本。MATTERS将采取切实可行的措施来保证其保留此个人信息的时间不会超过出于上述目的（包括直接或间接目的）所需要的保留时间。</p>
 
@@ -243,6 +245,7 @@ const Privacy: { zh_hant: string; zh_hans: string; en: string } = {
 <p>3.1 The Data Controller will receive, store and process Personal Information that the Users make available when assessing or using the Services. It will take appropriate steps to protect Personal Information collected and/or held by it against unauthorized or accidental access, processing, erasure, loss, use or disclosure. </p>
 
 <p>3.2 In order to protect the Personal Information, the Data Controller will require all Users (or their respective relevant persons as defined under applicable laws) to prove their identities in relation to their requests to access and/or correct their Personal Information.  Requests for access and correction of Personal Information are to be addressed in writing and sent to &lt;hi@matters.town&gt;. A reasonable fee shall be charged to offset the Data Controller’s administrative and actual costs incurred in complying with the relevant data access requests. Where there are reasonable grounds for believing that any Personal Information is inaccurate, the Data Controller shall take practicable steps to ensure that the Personal Information shall not be used unless and until those grounds cease to be applicable to such Personal Information or the Personal Information shall be erased. </p>
+<p>3.2A If you wish to request access, review, a copy, supplementation or correction, stop collection, processing, or use, or deletion of personal data, please refer to the <a href="/appeals">Appeals and Remedies</a> page. MATTERS may need to verify your identity and may retain necessary data due to legal, dispute handling, safety, or technical limitations.</p>
 
 <p>3.3 Where any Personal Information held by the Data Controller is no longer required for the purposes as stated under clause 4.2 of this Privacy Policy, the Data Controller shall take practicable steps to cease processing such Personal Information as soon as reasonably practicable, provided that the Data Controller may keep copies of such Personal Information as is reasonably required (i) for archival purposes; (ii) for use in relation to any actual or potential dispute; (iii) for compliance with applicable laws and regulations; (iv) for enforcing any agreement the Data Controller has with such User; and (v) for protecting the Data Controller’s and its employees’ rights, property or safety. The Data Controller will take practicable steps to ensure such Personal Information will not be kept longer than is necessary for the fulfillment of the above purposes (including direct or indirect purposes). </p>
 

--- a/src/views/ToS/Term/tos.ts
+++ b/src/views/ToS/Term/tos.ts
@@ -206,7 +206,7 @@ const ToS: { zh_hant: string; zh_hans: string; en: string } = {
 <p>6.9    為避免疑義，MATTERS不對第三方提供的版權資料或第三方的知識產權侵權行為承擔任何責任。</p>
 
 <p><b><u>7. 帳戶終止</u></b></p>
-<p>7.1    MATTERS有權決定暫停（任意時間長度）或終止您對平台和/或服務的訪問，而無需事先通知，並且有權出於任何原因（包括但不限於您違反本條款和社區約章的任何規定）刪除或停用您的帳戶以及隱藏所有相關用戶內容。MATTERS對於有可能因為暫停或終止帳戶而導致的任何損失或損害不承擔任何責任。</p>
+<p>7.1    MATTERS有權決定暫停（任意時間長度）或終止您對平台和/或服務的訪問，而無需事先通知，並且有權出於任何原因（包括但不限於您違反本條款和社區約章的任何規定）刪除或停用您的帳戶以及隱藏所有相關用戶內容。MATTERS對於有可能因為暫停或終止帳戶而導致的任何損失或損害不承擔任何責任。若您希望就帳號或內容限制提出申訴，可參考 <a href="/appeals">申訴與救濟中心</a>。</p>
 <p>7.2    收到您的書面請求後，MATTERS將在切實可行的範圍內盡快終止您的帳戶和/或隱藏您的所有用戶內容（如適用）。</p>
 <p>7.3    如果終止，您將無法訪問您的帳戶（包括但不限於儲值錢包和儲值金額）。如果帳戶終止後您的儲值錢包中有餘額，您須向MATTERS提供書面說明（以及正確儲值錢包密碼），並在終止帳戶日起30天內要求提現所有儲值餘額。如果逾期未收到您的說明，您的儲值餘額將被沒收。為避免疑問，MATTERS持有的記錄應被視為儲值錢包中餘額的最終證據。</p>
 
@@ -249,7 +249,7 @@ const ToS: { zh_hant: string; zh_hans: string; en: string } = {
 <p>12.5    本條款受英屬維爾京群島（British Virgin Islands）法律管轄，並按照英屬維爾京群島法律解釋。本條款的各方不可撤回地同意，英屬維爾京群島法院對與本條款有關或由本條款引起的任何索賠或爭議擁有專屬管轄權。</p>
 <p>12.6    本條款和條件的原始英文版本可能被翻譯成其他語言。如果對本條款的內容或解釋存在爭議，亦或者本條款的英文版本與任何其他語言版本之間存在矛盾或不一致，則在法律允許的範圍內，英語版本適用、優先並具有決定性。</p>
 <p>12.7    本條款應被視為可分割的。如有任何條款被確定為不可執行的或無效的，則應依然在適用法律允許的最大範圍內執行此條款，並且任何條款被確定無效都不應影響任何其他條款的有效性和可執行性。被分割的條款應由盡可能接近原先措辭和意圖的新條款取代。</p>
-<p>12.8    與平台有關的所有投訴、反饋、評論、技術支持請求和其他聯絡信息請直接發送至 &lt;hi@matters.town&gt; 。 </p>
+<p>12.8    與平台有關的所有投訴、反饋、評論、技術支持請求和其他聯絡信息請直接發送至 &lt;hi@matters.town&gt;。檢舉、申訴、個人資料權利、著作權與政府要求相關資訊，請參考 <a href="/appeals">申訴與救濟中心</a>。</p>
 
 </details>
   `,
@@ -457,7 +457,7 @@ const ToS: { zh_hant: string; zh_hans: string; en: string } = {
 <p>6.9    为避免疑义，MATTERS不对第三方提供的版权资料或第三方的知识产权侵权行为承担任何责任。</p>
 
 <p><b><u>7. 帳戶终止</u></b></p>
-<p>7.1    MATTERS有权决定暂停（任意时间长度）或终止您对平台和/或服务的访问，而无需事先通知，并且有权出于任何原因（包括但不限于您违反本条款和社区约章的任何规定）删除或停用您的帳戶以及隐藏所有相关用户内容。MATTERS对于有可能因为暂停或终止帳戶而导致的任何损失或损害不承担任何责任。</p>
+<p>7.1    MATTERS有权决定暂停（任意时间长度）或终止您对平台和/或服务的访问，而无需事先通知，并且有权出于任何原因（包括但不限于您违反本条款和社区约章的任何规定）删除或停用您的帳戶以及隐藏所有相关用户内容。MATTERS对于有可能因为暂停或终止帳戶而导致的任何损失或损害不承担任何责任。若您希望就帐号或内容限制提出申诉，可参考 <a href="/appeals">申诉与救济中心</a>。</p>
 <p>7.2    收到您的书面请求后，MATTERS将在切实可行的范围内尽快终止您的帐户和/或隐藏您的所有用户内容（如适用）。</p>
 <p>7.3    如果终止，您将无法访问您的帐户。如果终止，您将无法访问您的帐户（包括但不限于储值钱包和储值金额）。如果帐户终止后您的储值钱包中有余额，您须向MATTERS提供书面说明（以及正确储值钱包密码），并在终止帐户日起30天内要求提现所有储值余额。如果逾期未收到您的说明，您的储值余额将被没收。为避免疑问，MATTERS持有的记录应被视为储值钱包中余额的最终证据。</p>
 
@@ -499,7 +499,7 @@ const ToS: { zh_hant: string; zh_hans: string; en: string } = {
 <p>12.5    本条款受英属维尔京群岛（British Virgin Islands）法律管辖，并按照英属维尔京群岛法律解释。本条款的各方不可撤回地同意，英属维尔京群岛法院对与本条款有关或由本条款引起的任何索赔或争议拥有专属管辖权。</p>
 <p>12.6    本条款和条件的原始英文版本可能被翻译成其他语言。如果对本条款的内容或解释存在争议，亦或者本条款的英文版本与任何其他语言版本之间存在矛盾或不一致，则在法律允许的范围内，英语版本适用、优先并具有决定性。</p>
 <p>12.7    本条款应被视为可分割的。如有任何条款被确定为不可执行的或无效的，则应依然在适用法律允许的最大范围内执行此条款，并且任何条款被确定无效都不应影响任何其他条款的有效性和可执行性。被分割的条款应由尽可能接近原先措辞和意图的新条款取代。</p>
-<p>12.8    与平台有关的所有投诉、反馈、评论、技术支持请求和其他联络信息请直接发送至 &lt;hi@matters.town&gt; 。 </p>
+<p>12.8    与平台有关的所有投诉、反馈、评论、技术支持请求和其他联络信息请直接发送至 &lt;hi@matters.town&gt;。举报、申诉、个人资料权利、著作权与政府要求相关信息，请参考 <a href="/appeals">申诉与救济中心</a>。</p>
 
 </details>
 `,
@@ -715,7 +715,7 @@ const ToS: { zh_hant: string; zh_hans: string; en: string } = {
 <p>6.9    For the avoidance of doubt, MATTERS does not assume any liability for copyrighted materials provided by third parties or any Intellectual Property Rights infringements by such third parties.</p>
 
 <p><b><u>7. ACCOUNT TERMINATION</u></b></p>
-<p>7.1    MATTERS may suspend (for any duration) or terminate your access to the Platform and/or the Services in its sole discretion, immediately and without prior notice, and delete or deactivate your Account and hide all related User Contents for any reason (including but not limited to your breach of any provision of these Terms and/or the Community Rules) without any responsibility or liability on the part of MATTERS for any loss or damage that may result from such suspension or termination.</p>
+<p>7.1    MATTERS may suspend (for any duration) or terminate your access to the Platform and/or the Services in its sole discretion, immediately and without prior notice, and delete or deactivate your Account and hide all related User Contents for any reason (including but not limited to your breach of any provision of these Terms and/or the Community Rules) without any responsibility or liability on the part of MATTERS for any loss or damage that may result from such suspension or termination. If you wish to appeal an account or content restriction, please refer to the <a href="/appeals">Appeals and Remedies</a> page.</p>
 <p>7.2    Upon receipt of your written request, MATTERS will, as soon as practicable, terminate your Account and/or hide all your User Contents (as applicable).</p>
 <p>7.3    In the event of termination, you will not be able to access your Account (including but not limited to the Stored Value in your Stored Value Wallet). In the event where there is remaining balance in your Stored Value Wallet upon the termination of Account, you must provide MATTERS with written instructions (together with the relevant accurate Stored Value Wallet PIN) to cash-out all remaining balance of Stored Value within thirty (30) calendar days from the termination date in accordance with these Terms. Upon expiration of which, any and all then remaining balance of Stored Value will be forfeited with no liability incurred to you. For the avoidance of doubt, the records held by MATTERS shall be treated as conclusive evidence of the amount of the remaining balance in the Stored Value Wallet.</p>
 
@@ -758,7 +758,7 @@ const ToS: { zh_hant: string; zh_hans: string; en: string } = {
 <p>12.5    These Terms shall be governed by and construed in accordance with the laws of the British Virgin Islands. The Parties hereunder irrevocably agree that the courts of the British Virgin Islands shall have exclusive jurisdiction in relation to any claim or dispute concerning or arising from these Terms.</p>
 <p>12.6    The original English version of these terms and conditions may have been translated into other languages. In the event of a dispute about the contents or interpretation of these Terms or inconsistency or discrepancy between the English version and any other language version of these Terms, the English language version to the extent permitted by law shall apply, prevail and be conclusive. </p>
 <p>12.7    These Terms shall be deemed severable. In the event that any provision is determined to be unenforceable or invalid, such provision shall nonetheless be enforced to the fullest extent permitted by applicable law and such determination shall not affect the validity and enforceability of any other remaining provisions. The severed provisions shall be replaced by a provision approximating as much as possible the original wording and intent.</p>
-<p>12.8    All complaints, feedback, comments, requests for technical support and other communications in relation to the Platform shall be directed to &lt;hi@matters.town&gt;.</p>
+<p>12.8    All complaints, feedback, comments, requests for technical support and other communications in relation to the Platform shall be directed to &lt;hi@matters.town&gt;. For reporting, appeals, personal data rights, copyright, and government request information, please refer to the <a href="/appeals">Appeals and Remedies</a> page.</p>
 
 </details>
 `,

--- a/src/views/Transparency/content.ts
+++ b/src/views/Transparency/content.ts
@@ -1,0 +1,145 @@
+const zh_hant = `
+本頁整理 Matters 內容治理、申訴救濟、Community Watch、自動化輔助、政府要求與資料分享的公開資訊。第一版先建立透明度入口與報告架構，部分統計仍在補記錄與匯出流程。
+
+## 最新報告
+
+- [2026 H1 透明度報告骨架](/transparency/2026-h1)
+
+2026 H1 期間到 2026-06-30 才結束，因此目前頁面是報告骨架，不是完整年中報告。實際統計數字應在期間結束並完成資料檢核後填入。
+
+## 主題說明
+
+- [自動化與反濫用模型](/transparency/automation)
+- [推薦與排序透明度](/transparency/recommendations)
+- [數位素養資源](/transparency/digital-literacy)
+
+## 目前已公開的資料
+
+- Community Watch 公開紀錄會顯示處理理由、處理者顯示名稱、處理時間、申訴狀態與站方覆核狀態。
+- Community Watch 規則說明第一階段僅處理明確色情廣告與濫發廣告，AI 不得直接刪除留言。
+- 使用者協議與隱私政策說明內容標準、投訴信箱、個人資料處理、資料分享與依法揭露。
+- 申訴與救濟中心整理使用者可採取的檢舉、申訴與個資權利請求方式。
+
+## 正在補齊的資料
+
+- 一般內容檢舉的案件狀態、處理結果與平均處理時間。
+- 內容處理來源比例，例如使用者檢舉、Community Watch、管理員、模型輔助或自動化。
+- 申訴成立、不成立、部分成立、恢復與處理中件數。
+- 政府、法院或執法機關要求的聚合統計。
+- 推薦與排序機制的使用者可讀說明。
+- 反濫用模型的用途、限制、版本與申訴方式。
+
+## 透明度報告會如何標示資料缺口
+
+若某項資料在本期尚未完整記錄，報告會保留該章節並標示資料狀態。這樣做是為了讓使用者知道平台正在補哪一塊，而不是用省略章節的方式掩蓋缺口。
+
+## 相關頁面
+
+- [申訴與救濟中心](/appeals)
+- [自動化與反濫用模型](/transparency/automation)
+- [推薦與排序透明度](/transparency/recommendations)
+- [數位素養資源](/transparency/digital-literacy)
+- [使用者協議與隱私政策](/tos)
+- [Community Watch 公開紀錄](https://community-watch.matters.town/)
+- [Community Watch 規則](https://community-watch.matters.town/rules/)
+`
+
+const zh_hans = `
+本页整理 Matters 内容治理、申诉救济、Community Watch、自动化辅助、政府要求与资料分享的公开资讯。第一版先建立透明度入口与报告架构，部分统计仍在补记录与汇出流程。
+
+## 最新报告
+
+- [2026 H1 透明度报告骨架](/transparency/2026-h1)
+
+2026 H1 期间到 2026-06-30 才结束，因此目前页面是报告骨架，不是完整年中报告。实际统计数字应在期间结束并完成资料检核后填入。
+
+## 主题说明
+
+- [自动化与反滥用模型](/transparency/automation)
+- [推荐与排序透明度](/transparency/recommendations)
+- [数字素养资源](/transparency/digital-literacy)
+
+## 目前已公开的资料
+
+- Community Watch 公开记录会显示处理理由、处理者显示名称、处理时间、申诉状态与站方复核状态。
+- Community Watch 规则说明第一阶段仅处理明确色情广告与滥发广告，AI 不得直接删除留言。
+- 使用者协议与隐私政策说明内容标准、投诉信箱、个人资料处理、资料分享与依法揭露。
+- 申诉与救济中心整理使用者可采取的举报、申诉与个资权利请求方式。
+
+## 正在补齐的资料
+
+- 一般内容举报的案件状态、处理结果与平均处理时间。
+- 内容处理来源比例，例如使用者举报、Community Watch、管理员、模型辅助或自动化。
+- 申诉成立、不成立、部分成立、恢复与处理中件数。
+- 政府、法院或执法机关要求的聚合统计。
+- 推荐与排序机制的使用者可读说明。
+- 反滥用模型的用途、限制、版本与申诉方式。
+
+## 透明度报告会如何标示资料缺口
+
+若某项资料在本期尚未完整记录，报告会保留该章节并标示资料状态。这样做是为了让使用者知道平台正在补哪一块，而不是用省略章节的方式掩盖缺口。
+
+## 相关页面
+
+- [申诉与救济中心](/appeals)
+- [自动化与反滥用模型](/transparency/automation)
+- [推荐与排序透明度](/transparency/recommendations)
+- [数字素养资源](/transparency/digital-literacy)
+- [使用者协议与隐私政策](/tos)
+- [Community Watch 公开记录](https://community-watch.matters.town/)
+- [Community Watch 规则](https://community-watch.matters.town/rules/)
+`
+
+const en = `
+This page collects public information about Matters content governance, appeals, Community Watch, automation support, government requests, and data sharing. This first version creates the transparency entry point and reporting structure. Some statistics still require better logging and export support.
+
+## Latest report
+
+- [2026 H1 transparency report skeleton](/transparency/2026-h1)
+
+The 2026 H1 period ends on 2026-06-30, so the current page is a report skeleton, not a completed mid-year report. Actual metrics should be added after the period ends and the data is reviewed.
+
+## Topic pages
+
+- [Automation and Anti-Abuse Models](/transparency/automation)
+- [Recommendation and Ranking Transparency](/transparency/recommendations)
+- [Digital Literacy Resources](/transparency/digital-literacy)
+
+## Public information available today
+
+- Community Watch public records show the reason, watcher display name, handling time, appeal status, and staff review status.
+- Community Watch rules explain that the first phase only handles clear porn ads and spam ads, and that AI may not directly remove comments.
+- The Terms and Privacy Policy explain content standards, complaint channels, personal data handling, data sharing, and legally required disclosure.
+- The Appeals and Remedies page explains reporting, appeal, and privacy-rights request channels.
+
+## Data being improved
+
+- Case status, outcomes, and average handling time for ordinary content reports.
+- Moderation source ratios, such as user reports, Community Watch, admins, model-assisted actions, or automation.
+- Appeal outcomes, including upheld, reversed, partially upheld, restored, and pending cases.
+- Aggregated statistics for government, court, or law-enforcement requests.
+- User-readable explanation of recommendations and ranking.
+- Anti-abuse model purpose, limitations, versions, and appeal channels.
+
+## How data gaps will be marked
+
+When data is not fully recorded in the current period, the report will keep the section and mark the data status. This helps users see what is being improved instead of hiding gaps by omitting sections.
+
+## Related pages
+
+- [Appeals and Remedies](/appeals)
+- [Automation and Anti-Abuse Models](/transparency/automation)
+- [Recommendation and Ranking Transparency](/transparency/recommendations)
+- [Digital Literacy Resources](/transparency/digital-literacy)
+- [Terms and Privacy Policy](/tos)
+- [Community Watch records](https://community-watch.matters.town/)
+- [Community Watch rules](https://community-watch.matters.town/rules/)
+`
+
+const content = {
+  zh_hant,
+  zh_hans,
+  en,
+}
+
+export default content

--- a/src/views/Transparency/index.tsx
+++ b/src/views/Transparency/index.tsx
@@ -1,0 +1,23 @@
+import ComplianceDoc from '~/views/ComplianceDoc'
+
+import content from './content'
+
+const title = {
+  zh_hant: '透明度中心',
+  zh_hans: '透明度中心',
+  en: 'Transparency Center',
+}
+
+const description = {
+  zh_hant:
+    '整理 Matters 內容治理、申訴救濟、Community Watch 與透明度報告資訊。',
+  zh_hans:
+    '整理 Matters 内容治理、申诉救济、Community Watch 与透明度报告资讯。',
+  en: 'Public information about Matters content governance, appeals, Community Watch, and transparency reporting.',
+}
+
+const Transparency = () => (
+  <ComplianceDoc title={title} description={description} content={content} />
+)
+
+export default Transparency

--- a/src/views/TransparencyAutomation/content.ts
+++ b/src/views/TransparencyAutomation/content.ts
@@ -1,0 +1,178 @@
+const zh_hant = `
+本頁說明 Matters 在內容治理與反濫用工作中，如何使用自動化、模型輔助與人工判斷。第一版先公開原則與邊界，實際模型版本、production flag 與統計數字仍需在透明度報告中定期更新。
+
+## 基本原則
+
+- 不以未經覆核的模型分數作為處理使用者的唯一依據。
+- 明確區分模型提示、模型輔助、人工審查與自動化處理。
+- 影響內容可見性或帳號狀態時，應提供可理解的處理理由與申訴管道。
+- 不公開可被濫用來規避偵測的完整門檻、特徵或操作細節。
+- 反濫用資料若用於訓練或評測，應盡量降低個資與危險連結暴露。
+
+## 自動化角色
+
+Matters 會用以下方式描述模型或自動化在個案中的角色。
+
+- none 表示未使用模型或自動化。
+- suggested 表示模型只提供候選或提示，仍需人工判斷。
+- assisted 表示模型結果協助排序、分流或提示審查者。
+- automated 表示系統在符合條件時自動改變內容可見性或狀態。
+
+若某個功能目前只在 shadow、dry-run 或 notify-only 模式運作，透明度報告應明確標示。
+
+## Community Watch
+
+Community Watch 第一階段由受託使用者處理明確垃圾留言，理由限於「色情廣告」與「濫發廣告」。規則明定 AI 不得直接刪除留言。AI 或模型若被使用，只能作為候選檢測、提示或後續評測資料來源。
+
+## Spam 與濫用偵測
+
+Matters 的反濫用工作可能使用留言、文章或動態相關訊號來協助發現 spam、廣告導流、重複內容或其他濫用行為。模型輸出可能用於告警、排序審查佇列、提供人工提示，或在特定功能開關啟用時影響內容可見性。
+
+正式透明度報告應揭露每期使用的模式、影響範圍、是否直接處理內容、人工審查角色、申訴數與恢復數。
+
+## 使用者通知與申訴
+
+若內容或帳號因使用者檢舉、Community Watch、管理員處理、模型輔助或自動化而受到限制，通知應盡量說明處理來源、公開理由、可申訴管道與可補充資料。
+
+目前申訴管道請參考 [申訴與救濟中心](/appeals)。
+
+## 資料與隱私
+
+反濫用資料可能包含使用者內容、處理理由、覆核結果與時間戳。若資料用於訓練或評測，應盡量去識別化、避免散播垃圾連結或色情內容，並保留必要的人工理由與覆核結果。
+
+## 本頁尚待補齊
+
+- 每個 production 模型的版本、用途與狀態。
+- 每期模型輔助與自動化處理比例。
+- 模型導致的誤判、申訴與恢復統計。
+- 重大模型或門檻變更紀錄。
+
+## 相關頁面
+
+- [透明度中心](/transparency)
+- [2026 H1 透明度報告骨架](/transparency/2026-h1)
+- [申訴與救濟中心](/appeals)
+- [Community Watch 規則](https://community-watch.matters.town/rules/)
+`
+
+const zh_hans = `
+本页说明 Matters 在内容治理与反滥用工作中，如何使用自动化、模型辅助与人工判断。第一版先公开原则与边界，实际模型版本、production flag 与统计数字仍需在透明度报告中定期更新。
+
+## 基本原则
+
+- 不以未经复核的模型分数作为处理使用者的唯一依据。
+- 明确区分模型提示、模型辅助、人工审查与自动化处理。
+- 影响内容可见性或帐号状态时，应提供可理解的处理理由与申诉管道。
+- 不公开可被滥用来规避侦测的完整门槛、特征或操作细节。
+- 反滥用资料若用于训练或评测，应尽量降低个资与危险连结暴露。
+
+## 自动化角色
+
+Matters 会用以下方式描述模型或自动化在个案中的角色。
+
+- none 表示未使用模型或自动化。
+- suggested 表示模型只提供候选或提示，仍需人工判断。
+- assisted 表示模型结果协助排序、分流或提示审查者。
+- automated 表示系统在符合条件时自动改变内容可见性或状态。
+
+若某个功能目前只在 shadow、dry-run 或 notify-only 模式运作，透明度报告应明确标示。
+
+## Community Watch
+
+Community Watch 第一阶段由受托使用者处理明确垃圾留言，理由限于「色情广告」与「滥发广告」。规则明定 AI 不得直接删除留言。AI 或模型若被使用，只能作为候选检测、提示或后续评测资料来源。
+
+## Spam 与滥用侦测
+
+Matters 的反滥用工作可能使用留言、文章或动态相关讯号来协助发现 spam、广告导流、重复内容或其他滥用行为。模型输出可能用于告警、排序审查伫列、提供人工提示，或在特定功能开关启用时影响内容可见性。
+
+正式透明度报告应揭露每期使用的模式、影响范围、是否直接处理内容、人工审查角色、申诉数与恢复数。
+
+## 使用者通知与申诉
+
+若内容或帐号因使用者举报、Community Watch、管理员处理、模型辅助或自动化而受到限制，通知应尽量说明处理来源、公开理由、可申诉管道与可补充资料。
+
+目前申诉管道请参考 [申诉与救济中心](/appeals)。
+
+## 资料与隐私
+
+反滥用资料可能包含使用者内容、处理理由、复核结果与时间戳。若资料用于训练或评测，应尽量去识别化、避免散播垃圾连结或色情内容，并保留必要的人工理由与复核结果。
+
+## 本页尚待补齐
+
+- 每个 production 模型的版本、用途与状态。
+- 每期模型辅助与自动化处理比例。
+- 模型导致的误判、申诉与恢复统计。
+- 重大模型或门槛变更记录。
+
+## 相关页面
+
+- [透明度中心](/transparency)
+- [2026 H1 透明度报告骨架](/transparency/2026-h1)
+- [申诉与救济中心](/appeals)
+- [Community Watch 规则](https://community-watch.matters.town/rules/)
+`
+
+const en = `
+This page explains how Matters uses automation, model assistance, and human judgment in content governance and anti-abuse work. This first version publishes principles and boundaries. Actual model versions, production flags, and metrics should be updated through transparency reports.
+
+## Principles
+
+- Do not use unreviewed model scores as the sole basis for user-facing enforcement.
+- Clearly distinguish model hints, model assistance, human review, and automated actions.
+- When content visibility or account state is affected, provide understandable reasons and appeal channels.
+- Do not disclose exact thresholds, features, or operational details that would help abuse.
+- When anti-abuse data is used for training or evaluation, reduce exposure of personal data and harmful links.
+
+## Automation roles
+
+Matters uses the following labels to describe the role of models or automation in a case.
+
+- none means no model or automation was used.
+- suggested means the model only provided a candidate or hint.
+- assisted means the model helped rank, route, or inform review.
+- automated means the system changed visibility or state when configured conditions were met.
+
+If a feature is shadow-only, dry-run, or notify-only, the transparency report should state that clearly.
+
+## Community Watch
+
+Community Watch is handled by trusted users in its first phase. The scope is limited to clear porn ads and spam ads. The rules state that AI may not directly remove comments. AI or models may only be used for candidate detection, hints, or later evaluation data.
+
+## Spam and abuse detection
+
+Matters anti-abuse work may use comment, article, or moment signals to help identify spam, ad routing, repeated content, or other abuse. Model output may be used for alerts, review queue ranking, human hints, or visibility changes when a specific feature flag is enabled.
+
+Formal transparency reports should disclose the mode used in each period, affected surfaces, whether content was directly handled, human review roles, appeals, and restorations.
+
+## User notice and appeals
+
+If content or an account is restricted due to user reports, Community Watch, staff action, model assistance, or automation, notices should explain the source, public reason, appeal channel, and useful context the user may provide.
+
+Current appeal channels are listed on [Appeals and Remedies](/appeals).
+
+## Data and privacy
+
+Anti-abuse data may include user content, handling reasons, review outcomes, and timestamps. When used for training or evaluation, Matters should reduce identifiability, avoid spreading spam links or sexual content, and preserve necessary human reasons and review outcomes.
+
+## To be completed
+
+- Version, purpose, and status for each production model.
+- Model-assisted and automated action ratios for each reporting period.
+- Mistake, appeal, and restoration metrics related to models.
+- Major model or threshold change logs.
+
+## Related pages
+
+- [Transparency Center](/transparency)
+- [2026 H1 Transparency Report Skeleton](/transparency/2026-h1)
+- [Appeals and Remedies](/appeals)
+- [Community Watch rules](https://community-watch.matters.town/rules/)
+`
+
+const content = {
+  zh_hant,
+  zh_hans,
+  en,
+}
+
+export default content

--- a/src/views/TransparencyAutomation/index.tsx
+++ b/src/views/TransparencyAutomation/index.tsx
@@ -1,0 +1,23 @@
+import ComplianceDoc from '~/views/ComplianceDoc'
+
+import content from './content'
+
+const title = {
+  zh_hant: '自動化與反濫用模型',
+  zh_hans: '自动化与反滥用模型',
+  en: 'Automation and Anti-Abuse Models',
+}
+
+const description = {
+  zh_hant:
+    '說明 Matters 如何使用自動化、模型輔助與人工判斷處理內容治理與反濫用工作。',
+  zh_hans:
+    '说明 Matters 如何使用自动化、模型辅助与人工判断处理内容治理与反滥用工作。',
+  en: 'How Matters uses automation, model assistance, and human judgment in content governance and anti-abuse work.',
+}
+
+const TransparencyAutomation = () => (
+  <ComplianceDoc title={title} description={description} content={content} />
+)
+
+export default TransparencyAutomation

--- a/src/views/TransparencyReport/Report2026H1.tsx
+++ b/src/views/TransparencyReport/Report2026H1.tsx
@@ -1,0 +1,23 @@
+import ComplianceDoc from '~/views/ComplianceDoc'
+
+import content from './content2026H1'
+
+const title = {
+  zh_hant: '2026 H1 透明度報告骨架',
+  zh_hans: '2026 H1 透明度报告骨架',
+  en: '2026 H1 Transparency Report Skeleton',
+}
+
+const description = {
+  zh_hant:
+    'Matters 2026 H1 透明度報告骨架，標示資料狀態、已知缺口與後續填報章節。',
+  zh_hans:
+    'Matters 2026 H1 透明度报告骨架，标示资料状态、已知缺口与后续填报章节。',
+  en: 'Matters 2026 H1 transparency report skeleton with data status, known gaps, and reporting sections.',
+}
+
+const TransparencyReport2026H1 = () => (
+  <ComplianceDoc title={title} description={description} content={content} />
+)
+
+export default TransparencyReport2026H1

--- a/src/views/TransparencyReport/content2026H1.ts
+++ b/src/views/TransparencyReport/content2026H1.ts
@@ -1,0 +1,301 @@
+const zh_hant = `
+本頁是 2026 H1 透明度報告骨架。2026 H1 期間為 2026-01-01 至 2026-06-30，期間尚未結束，實際統計數字應在期間結束並完成資料檢核後填入。平台內部處理統計的 server 匯出與 ObservableHQ 交叉檢核路徑已建立。
+
+## 1. 報告期間與範圍
+
+資料狀態：匯出流程已建立，數字待期間結束後填入。
+
+本期預計涵蓋 Matters.town 站台上的文章、留言、動態、帳號處理、Community Watch、一般內容檢舉、申訴救濟、政府或法律請求、個人資料權利請求與重大政策變更。
+
+## 2. Matters 內容治理架構
+
+資料狀態：可先以文字說明。
+
+本章應說明使用者檢舉、Community Watch、站方管理員、反濫用模型輔助與平台規則之間的關係。若模型僅用於候選提示或通知，也應明確標示。
+
+## 3. 內容檢舉與處理統計
+
+資料狀態：案件資料模型、server 匯出與 ObservableHQ 檢核路徑已補上，統計待部署與檢核後填入。
+
+本章應揭露檢舉件數、內容類型、檢舉理由、處理結果、平均處理時間與資料缺口。一般內容檢舉可由 moderation case 與 moderation event 匯出，舊資料或部署前資料仍應標示為資料缺口。
+
+## 4. Community Watch 處理統計
+
+資料狀態：部分可由公開紀錄彙整。
+
+本章應揭露色情廣告、濫發廣告、申訴、恢復、覆核與資料清除件數。公開紀錄可作為第一版主要資料來源。
+
+## 5. 申訴、複查與恢復統計
+
+資料狀態：案件與 Community Watch 聚合路徑已補上，email 申訴仍需結構化。
+
+本章應揭露申訴件數、成立、不成立、部分成立、處理中、恢復內容與平均處理時間。若一般 email 申訴尚未結構化，應列為下一期改善。
+
+## 6. 自動化與模型輔助處理
+
+資料狀態：待與 production flag 與工程紀錄核對。
+
+本章應揭露模型用途、是否直接影響可見性、人工審查角色、誤判救濟與重大變更。若某模型僅 shadow 或 notify-only，應明確標示。
+
+主題說明請參考 [自動化與反濫用模型](/transparency/automation)。
+
+## 7. 政府與法律請求
+
+資料狀態：需由私有聚合 JSON 補入，若未提供應標示為尚未完整記錄。
+
+本章應揭露聚合件數、法域或機關類型、請求類型、資料類型、回覆結果與使用者通知狀態。若本期才建立登錄流程，應如實標示。
+
+## 8. 個人資料、資料分享與使用者權利
+
+資料狀態：可由隱私政策摘要，個資權利請求需由私有聚合 JSON 補入。
+
+本章應摘要個資蒐集、使用、分享、保存、使用者權利與請求管道。若尚未統計個資權利請求件數，應列入下一期改善。
+
+## 9. 推薦系統與產品介面
+
+資料狀態：尚未完整公開。
+
+本章應說明熱門、最新、追蹤、標籤、內容狀態與 spam exclusion 如何影響可見性。第一版可先描述主要入口與待補工程確認項目。
+
+主題說明請參考 [推薦與排序透明度](/transparency/recommendations)。
+
+## 10. 資安與濫用防制
+
+資料狀態：待彙整。
+
+本章應揭露平台處理 spam、帳號濫用、資料風險與可用性事件的治理方式。不得揭露可被濫用的細節。
+
+## 11. 規則、政策與模型變更紀錄
+
+資料狀態：可由外部結構化變更紀錄補入，數字與摘要待審閱後填入。
+
+本章應列出本期 ToS、Privacy、Community Watch 規則、反濫用模型與推薦規則的重大變更。
+
+## 12. 外部回饋與下一期改善
+
+資料狀態：待建立流程。
+
+本章應列出使用者、研究者、社群或外部專家的回饋，以及採納、部分採納或未採納的原因。第一版可先列出下一期要補齊的資料。
+
+## 本期已知缺口
+
+- 一般內容檢舉的案件資料模型已補上，舊資料與部署前資料仍需標示缺口。
+- 一般申訴尚未完整統計成立率、處理時間與結果。
+- 政府或法律請求、個資權利請求與重大變更紀錄需要由資料維護者提供私有或公開安全的聚合 JSON。
+- 自動化與模型輔助需要與 production flag、通知與處理結果對齊。
+- 推薦與排序說明需要與實際產品與後端邏輯核對。
+
+## 相關頁面
+
+- [透明度中心](/transparency)
+- [自動化與反濫用模型](/transparency/automation)
+- [推薦與排序透明度](/transparency/recommendations)
+- [數位素養資源](/transparency/digital-literacy)
+- [申訴與救濟中心](/appeals)
+- [Community Watch 公開紀錄](https://community-watch.matters.town/)
+- [Community Watch 規則](https://community-watch.matters.town/rules/)
+`
+
+const zh_hans = `
+本页是 2026 H1 透明度报告骨架。2026 H1 期间为 2026-01-01 至 2026-06-30，期间尚未结束，实际统计数字应在期间结束并完成资料检核后填入。平台内部处理统计的 server 汇出与 ObservableHQ 交叉检核路径已建立。
+
+## 1. 报告期间与范围
+
+资料状态：汇出流程已建立，数字待期间结束后填入。
+
+本期预计涵盖 Matters.town 站台上的文章、留言、动态、帐号处理、Community Watch、一般内容举报、申诉救济、政府或法律请求、个人资料权利请求与重大政策变更。
+
+## 2. Matters 内容治理架构
+
+资料状态：可先以文字说明。
+
+本章应说明使用者举报、Community Watch、站方管理员、反滥用模型辅助与平台规则之间的关系。若模型仅用于候选提示或通知，也应明确标示。
+
+## 3. 内容举报与处理统计
+
+资料状态：案件资料模型、server 汇出与 ObservableHQ 检核路径已补上，统计待部署与检核后填入。
+
+本章应揭露举报件数、内容类型、举报理由、处理结果、平均处理时间与资料缺口。一般内容举报可由 moderation case 与 moderation event 汇出，旧资料或部署前资料仍应标示为资料缺口。
+
+## 4. Community Watch 处理统计
+
+资料状态：部分可由公开记录汇整。
+
+本章应揭露色情广告、滥发广告、申诉、恢复、复核与资料清除件数。公开记录可作为第一版主要资料来源。
+
+## 5. 申诉、复查与恢复统计
+
+资料状态：案件与 Community Watch 聚合路径已补上，email 申诉仍需结构化。
+
+本章应揭露申诉件数、成立、不成立、部分成立、处理中、恢复内容与平均处理时间。若一般 email 申诉尚未结构化，应列为下一期改善。
+
+## 6. 自动化与模型辅助处理
+
+资料状态：待与 production flag 与工程记录核对。
+
+本章应揭露模型用途、是否直接影响可见性、人工审查角色、误判救济与重大变更。若某模型仅 shadow 或 notify-only，应明确标示。
+
+主题说明请参考 [自动化与反滥用模型](/transparency/automation)。
+
+## 7. 政府与法律请求
+
+资料状态：需由私有聚合 JSON 补入，若未提供应标示为尚未完整记录。
+
+本章应揭露聚合件数、法域或机关类型、请求类型、资料类型、回复结果与使用者通知状态。若本期才建立登录流程，应如实标示。
+
+## 8. 个人资料、资料分享与使用者权利
+
+资料状态：可由隐私政策摘要，个资权利请求需由私有聚合 JSON 补入。
+
+本章应摘要个资搜集、使用、分享、保存、使用者权利与请求管道。若尚未统计个资权利请求件数，应列入下一期改善。
+
+## 9. 推荐系统与产品介面
+
+资料状态：尚未完整公开。
+
+本章应说明热门、最新、追踪、标签、内容状态与 spam exclusion 如何影响可见性。第一版可先描述主要入口与待补工程确认项目。
+
+主题说明请参考 [推荐与排序透明度](/transparency/recommendations)。
+
+## 10. 资安与滥用防制
+
+资料状态：待汇整。
+
+本章应揭露平台处理 spam、帐号滥用、资料风险与可用性事件的治理方式。不得揭露可被滥用的细节。
+
+## 11. 规则、政策与模型变更记录
+
+资料状态：可由外部结构化变更记录补入，数字与摘要待审阅后填入。
+
+本章应列出本期 ToS、Privacy、Community Watch 规则、反滥用模型与推荐规则的重大变更。
+
+## 12. 外部反馈与下一期改善
+
+资料状态：待建立流程。
+
+本章应列出使用者、研究者、社群或外部专家的反馈，以及采纳、部分采纳或未采纳的原因。第一版可先列出下一期要补齐的资料。
+
+## 本期已知缺口
+
+- 一般内容举报的案件资料模型已补上，旧资料与部署前资料仍需标示缺口。
+- 一般申诉尚未完整统计成立率、处理时间与结果。
+- 政府或法律请求、个资权利请求与重大变更记录需要由资料维护者提供私有或公开安全的聚合 JSON。
+- 自动化与模型辅助需要与 production flag、通知与处理结果对齐。
+- 推荐与排序说明需要与实际产品与后端逻辑核对。
+
+## 相关页面
+
+- [透明度中心](/transparency)
+- [自动化与反滥用模型](/transparency/automation)
+- [推荐与排序透明度](/transparency/recommendations)
+- [数字素养资源](/transparency/digital-literacy)
+- [申诉与救济中心](/appeals)
+- [Community Watch 公开记录](https://community-watch.matters.town/)
+- [Community Watch 规则](https://community-watch.matters.town/rules/)
+`
+
+const en = `
+This page is the 2026 H1 transparency report skeleton. The 2026 H1 period runs from 2026-01-01 to 2026-06-30. The period has not ended yet, so actual metrics should be added after the period ends and the data is reviewed. The server export and ObservableHQ cross-check path for internal moderation metrics has been prepared.
+
+## 1. Reporting period and scope
+
+Data status: export path prepared, metrics pending after the period ends.
+
+This report is expected to cover articles, comments, moments, account actions, Community Watch, ordinary content reports, appeals, government or legal requests, personal data rights requests, and major policy changes.
+
+## 2. Matters content governance structure
+
+Data status: text can be added first.
+
+This section should explain how user reports, Community Watch, staff admins, anti-abuse model support, and platform rules work together. If a model is only used for hints or notifications, that should be stated clearly.
+
+## 3. Content reports and moderation statistics
+
+Data status: case data model, server export, and ObservableHQ cross-check path added. Metrics are pending deployment and review.
+
+This section should disclose report counts, content types, reasons, outcomes, average handling time, and data gaps. Ordinary content reports can be exported from moderation cases and moderation events. Legacy data and pre-deployment records should still be marked as data gaps.
+
+## 4. Community Watch statistics
+
+Data status: partially available from public records.
+
+This section should disclose porn ad, spam ad, appeal, restore, review, and data-clearing counts. Public records can be the main source for the first version.
+
+## 5. Appeals, reviews, and restorations
+
+Data status: case and Community Watch aggregate paths have been added. Email appeals still need structured records.
+
+This section should disclose appeal counts, upheld, reversed, partially upheld, pending cases, restored content, and average handling time. If email appeals are not structured yet, mark that as an improvement for the next period.
+
+## 6. Automation and model-assisted actions
+
+Data status: needs production flag and engineering record review.
+
+This section should disclose model purpose, whether visibility is affected, human review roles, appeal paths, and major changes. If a model is shadow-only or notify-only, state that clearly.
+
+See [Automation and Anti-Abuse Models](/transparency/automation) for the topic page.
+
+## 7. Government and legal requests
+
+Data status: requires a private aggregate JSON file. If not provided, this section should remain marked as not fully recorded.
+
+This section should disclose aggregated counts, jurisdiction or agency type, request type, data type, response outcome, and user notice status. If the logging process was created during this period, state that clearly.
+
+## 8. Personal data, data sharing, and user rights
+
+Data status: can summarize the Privacy Policy. Personal data rights request counts require a private aggregate JSON file.
+
+This section should summarize data collection, use, sharing, retention, user rights, and request channels. If personal data rights requests are not counted yet, list that as an improvement.
+
+## 9. Recommendation systems and product interfaces
+
+Data status: not fully public.
+
+This section should explain how hot, latest, following, tags, content states, and spam exclusion affect visibility. The first version can describe main entry points and items that still require engineering confirmation.
+
+See [Recommendation and Ranking Transparency](/transparency/recommendations) for the topic page.
+
+## 10. Security and abuse prevention
+
+Data status: to be collected.
+
+This section should disclose how the platform handles spam, account abuse, data risk, and availability incidents. It should not disclose details that would help abuse.
+
+## 11. Rule, policy, and model change log
+
+Data status: can be filled from public-safe structured change logs after review.
+
+This section should list major changes to Terms, Privacy Policy, Community Watch rules, anti-abuse models, and recommendation rules.
+
+## 12. External feedback and next improvements
+
+Data status: process pending.
+
+This section should list feedback from users, researchers, the community, or external experts, along with adopted, partially adopted, or not adopted responses. The first version can list data to improve for the next period.
+
+## Known gaps for this period
+
+- The case data model for ordinary content reports has been added. Legacy and pre-deployment records still need to be marked as data gaps.
+- Ordinary appeals do not yet have complete statistics for success rate, handling time, and outcomes.
+- Government or legal requests, personal data rights requests, and major change logs require private or public-safe aggregate JSON from data maintainers.
+- Automation and model assistance need alignment with production flags, notices, and outcomes.
+- Recommendation and ranking explanations need review against actual product and backend logic.
+
+## Related pages
+
+- [Transparency Center](/transparency)
+- [Automation and Anti-Abuse Models](/transparency/automation)
+- [Recommendation and Ranking Transparency](/transparency/recommendations)
+- [Digital Literacy Resources](/transparency/digital-literacy)
+- [Appeals and Remedies](/appeals)
+- [Community Watch records](https://community-watch.matters.town/)
+- [Community Watch rules](https://community-watch.matters.town/rules/)
+`
+
+const content = {
+  zh_hant,
+  zh_hans,
+  en,
+}
+
+export default content


### PR DESCRIPTION
## Summary

- Adds public NCC compliance entry points for appeals, transparency, automation, recommendation transparency, digital literacy, and the 2026 H1 transparency report.
- Links the new appeal and transparency routes from existing Terms and Privacy copy.
- Keeps the change to static/public disclosure surfaces only.

## Validation

- Passed: `npx next lint --file src/views/TransparencyReport/content2026H1.ts`
- Commit note: full pre-commit lint currently fails on existing Campaign/QuoteWall GraphQL generated type errors unrelated to this NCC surface, so the commit was created with `--no-verify` after the focused lint passed.
