### PR TITLE
feat(campaign): redesign campaign quote wall — green-rule pull-quotes, display-only

### DIFF
--- a/lang/default.json
+++ b/lang/default.json
@@ -493,6 +493,10 @@
     "defaultMessage": "Do you want to disconnect from {type}?",
     "description": "src/components/Dialogs/RemoveSocialLoginDialog/Content.tsx"
   },
+  "5FUiH2": {
+    "defaultMessage": "During the event, the quotes people pick will appear here.",
+    "description": "src/views/CampaignDetail/QuoteWall band empty-state, line 1"
+  },
   "5IGdjy": {
     "defaultMessage": "Not using tags yet, add tags now to improve discoverability!"
   },
@@ -2613,6 +2617,9 @@
   "beLe/F": {
     "defaultMessage": "Broadcast"
   },
+  "bv9UzQ": {
+    "defaultMessage": "See all quotes"
+  },
   "c/z318": {
     "defaultMessage": "Incorrect email or password",
     "description": "src/components/Forms/EmailLoginForm/index.tsx"
@@ -3313,6 +3320,10 @@
   "mbHf/6": {
     "defaultMessage": "Ended",
     "description": "src/views/CampaignDetail/Apply/Button/index.tsx"
+  },
+  "md2Ml3": {
+    "defaultMessage": "Pick a line you love from an article and put it on the wall ✍️",
+    "description": "src/views/CampaignDetail/QuoteWall band empty-state prompt"
   },
   "me1nR+": {
     "defaultMessage": "Copy Address"

--- a/lang/default.json
+++ b/lang/default.json
@@ -1191,6 +1191,9 @@
     "defaultMessage": "commented broadcast in {circleName}",
     "description": "src/components/Notice/CircleNotice/CircleNewBroadcastComments.tsx"
   },
+  "EZhPi/": {
+    "defaultMessage": "Manage quotes"
+  },
   "Eb1U+/": {
     "defaultMessage": "Topped up successfully"
   },

--- a/lang/default.json
+++ b/lang/default.json
@@ -416,9 +416,6 @@
   "3cxMQp": {
     "defaultMessage": "Violet"
   },
-  "3jmniZ": {
-    "defaultMessage": "Retract"
-  },
   "3kbIhS": {
     "defaultMessage": "Untitled"
   },
@@ -1190,9 +1187,6 @@
   "EZMrtJ": {
     "defaultMessage": "commented broadcast in {circleName}",
     "description": "src/components/Notice/CircleNotice/CircleNewBroadcastComments.tsx"
-  },
-  "EZhPi/": {
-    "defaultMessage": "Manage quotes"
   },
   "Eb1U+/": {
     "defaultMessage": "Topped up successfully"
@@ -2098,9 +2092,6 @@
   "TF1OhT": {
     "defaultMessage": "This login code has expired, please try to resend"
   },
-  "TIWVxK": {
-    "defaultMessage": "Quote retracted from the wall"
-  },
   "TInwt3": {
     "defaultMessage": "Disable Responses"
   },
@@ -2453,9 +2444,6 @@
   "Z7JXlF": {
     "defaultMessage": "Archived for violation.",
     "description": "src/views/ArticleDetail/StickyTopBanner/index.tsx"
-  },
-  "Z82+dw": {
-    "defaultMessage": "Confirm retract"
   },
   "ZAoAcG": {
     "defaultMessage": "Threads, Mastodon, Misskey 這些地方的粉絲也會看到"
@@ -3055,9 +3043,6 @@
   },
   "iSM+et": {
     "defaultMessage": "All rights reserved"
-  },
-  "iSjuti": {
-    "defaultMessage": "Failed to retract"
   },
   "iTcMqz": {
     "defaultMessage": "Under the moonlight, dreams are about to come true. The Moonlight Dream badge signifies your participation in the Nomad Matters.",

--- a/lang/default.json
+++ b/lang/default.json
@@ -2129,9 +2129,6 @@
     "defaultMessage": "Optimism is a standalone blockchain. If you have USDT on other chains, you need to transfer them to Optimism. See details in the {tutorial}.",
     "description": "src/components/Forms/PaymentForm/SwitchNetwork/index.tsx"
   },
-  "Thr8QX": {
-    "defaultMessage": "To article ↩"
-  },
   "TjWWxF": {
     "defaultMessage": "Broadcast sent",
     "description": "src/views/Circle/Broadcast/Broadcast.tsx"

--- a/lang/en.json
+++ b/lang/en.json
@@ -493,6 +493,10 @@
     "defaultMessage": "Do you want to disconnect from {type}?",
     "description": "src/components/Dialogs/RemoveSocialLoginDialog/Content.tsx"
   },
+  "5FUiH2": {
+    "defaultMessage": "During the event, the quotes people pick will appear here.",
+    "description": "src/views/CampaignDetail/QuoteWall band empty-state, line 1"
+  },
   "5IGdjy": {
     "defaultMessage": "Not using tags yet, add tags now to improve discoverability!"
   },
@@ -2613,6 +2617,9 @@
   "beLe/F": {
     "defaultMessage": "Broadcast"
   },
+  "bv9UzQ": {
+    "defaultMessage": "See all quotes"
+  },
   "c/z318": {
     "defaultMessage": "Incorrect email or password",
     "description": "src/components/Forms/EmailLoginForm/index.tsx"
@@ -3313,6 +3320,10 @@
   "mbHf/6": {
     "defaultMessage": "Ended",
     "description": "src/views/CampaignDetail/Apply/Button/index.tsx"
+  },
+  "md2Ml3": {
+    "defaultMessage": "Pick a line you love from an article and put it on the wall ✍️",
+    "description": "src/views/CampaignDetail/QuoteWall band empty-state prompt"
   },
   "me1nR+": {
     "defaultMessage": "Copy Address"

--- a/lang/en.json
+++ b/lang/en.json
@@ -1191,6 +1191,9 @@
     "defaultMessage": "commented broadcast in {circleName}",
     "description": "src/components/Notice/CircleNotice/CircleNewBroadcastComments.tsx"
   },
+  "EZhPi/": {
+    "defaultMessage": "Manage quotes"
+  },
   "Eb1U+/": {
     "defaultMessage": "Topped up successfully"
   },

--- a/lang/en.json
+++ b/lang/en.json
@@ -416,9 +416,6 @@
   "3cxMQp": {
     "defaultMessage": "Violet"
   },
-  "3jmniZ": {
-    "defaultMessage": "Retract"
-  },
   "3kbIhS": {
     "defaultMessage": "Untitled"
   },
@@ -1190,9 +1187,6 @@
   "EZMrtJ": {
     "defaultMessage": "commented broadcast in {circleName}",
     "description": "src/components/Notice/CircleNotice/CircleNewBroadcastComments.tsx"
-  },
-  "EZhPi/": {
-    "defaultMessage": "Manage quotes"
   },
   "Eb1U+/": {
     "defaultMessage": "Topped up successfully"
@@ -2098,9 +2092,6 @@
   "TF1OhT": {
     "defaultMessage": "This login code has expired, please try to resend"
   },
-  "TIWVxK": {
-    "defaultMessage": "Quote retracted from the wall"
-  },
   "TInwt3": {
     "defaultMessage": "Disable Responses"
   },
@@ -2453,9 +2444,6 @@
   "Z7JXlF": {
     "defaultMessage": "Archived for violation.",
     "description": "src/views/ArticleDetail/StickyTopBanner/index.tsx"
-  },
-  "Z82+dw": {
-    "defaultMessage": "Confirm retract"
   },
   "ZAoAcG": {
     "defaultMessage": "Threads, Mastodon, Misskey 這些地方的粉絲也會看到"
@@ -3055,9 +3043,6 @@
   },
   "iSM+et": {
     "defaultMessage": "All rights reserved"
-  },
-  "iSjuti": {
-    "defaultMessage": "Failed to retract"
   },
   "iTcMqz": {
     "defaultMessage": "Under the moonlight, dreams are about to come true. The Moonlight Dream badge signifies your participation in the Nomad Matters.",

--- a/lang/en.json
+++ b/lang/en.json
@@ -2129,9 +2129,6 @@
     "defaultMessage": "Optimism is a standalone blockchain. If you have USDT on other chains, you need to transfer them to Optimism. See details in the {tutorial}.",
     "description": "src/components/Forms/PaymentForm/SwitchNetwork/index.tsx"
   },
-  "Thr8QX": {
-    "defaultMessage": "To article ↩"
-  },
   "TjWWxF": {
     "defaultMessage": "Broadcast sent",
     "description": "src/views/Circle/Broadcast/Broadcast.tsx"

--- a/lang/zh-Hans.json
+++ b/lang/zh-Hans.json
@@ -1190,6 +1190,9 @@
     "defaultMessage": "在 {circleName} 的广播中留言 ",
     "description": "src/components/Notice/CircleNotice/CircleNewBroadcastComments.tsx"
   },
+  "EZhPi/": {
+    "defaultMessage": "管理金句"
+  },
   "Eb1U+/": {
     "defaultMessage": "储值成功"
   },

--- a/lang/zh-Hans.json
+++ b/lang/zh-Hans.json
@@ -2128,9 +2128,6 @@
     "defaultMessage": "Optimism 是独立运行的区块链，若你在其他链上已有 USDT 货币，需要将它们转移到 Optimism 网络才能使用，详情参考 {tutorial}.",
     "description": "src/components/Forms/PaymentForm/SwitchNetwork/index.tsx"
   },
-  "Thr8QX": {
-    "defaultMessage": "回原文 ↩"
-  },
   "TjWWxF": {
     "defaultMessage": "广播已送出",
     "description": "src/views/Circle/Broadcast/Broadcast.tsx"

--- a/lang/zh-Hans.json
+++ b/lang/zh-Hans.json
@@ -2616,6 +2616,9 @@
   "beLe/F": {
     "defaultMessage": "广播"
   },
+  "bv9UzQ": {
+    "defaultMessage": "查看全部金句"
+  },
   "c/z318": {
     "defaultMessage": "邮箱或密码错误",
     "description": "src/components/Forms/EmailLoginForm/index.tsx"

--- a/lang/zh-Hans.json
+++ b/lang/zh-Hans.json
@@ -416,9 +416,6 @@
   "3cxMQp": {
     "defaultMessage": "Violet"
   },
-  "3jmniZ": {
-    "defaultMessage": "撤下"
-  },
   "3kbIhS": {
     "defaultMessage": "未命名"
   },
@@ -1189,9 +1186,6 @@
   "EZMrtJ": {
     "defaultMessage": "在 {circleName} 的广播中留言 ",
     "description": "src/components/Notice/CircleNotice/CircleNewBroadcastComments.tsx"
-  },
-  "EZhPi/": {
-    "defaultMessage": "管理金句"
   },
   "Eb1U+/": {
     "defaultMessage": "储值成功"
@@ -2097,9 +2091,6 @@
   "TF1OhT": {
     "defaultMessage": "临时密码已过期，请尝试重新发送"
   },
-  "TIWVxK": {
-    "defaultMessage": "已从金句墙撤下"
-  },
   "TInwt3": {
     "defaultMessage": "关闭评论"
   },
@@ -2452,9 +2443,6 @@
   "Z7JXlF": {
     "defaultMessage": "因违反用户协定而被封存，",
     "description": "src/views/ArticleDetail/StickyTopBanner/index.tsx"
-  },
-  "Z82+dw": {
-    "defaultMessage": "确认撤下"
   },
   "ZAoAcG": {
     "defaultMessage": "Threads, Mastodon, Misskey 這些地方的粉絲也會看到"
@@ -3054,9 +3042,6 @@
   },
   "iSM+et": {
     "defaultMessage": "作者保留所有权利"
-  },
-  "iSjuti": {
-    "defaultMessage": "撤下失败"
   },
   "iTcMqz": {
     "defaultMessage": "月色之下，梦想即将实现。月之梦徽章纪念你曾参与「游牧者计划」。",

--- a/lang/zh-Hant.json
+++ b/lang/zh-Hant.json
@@ -1190,6 +1190,9 @@
     "defaultMessage": "在 {circleName} 的廣播中留言 ",
     "description": "src/components/Notice/CircleNotice/CircleNewBroadcastComments.tsx"
   },
+  "EZhPi/": {
+    "defaultMessage": "管理金句"
+  },
   "Eb1U+/": {
     "defaultMessage": "儲值成功"
   },

--- a/lang/zh-Hant.json
+++ b/lang/zh-Hant.json
@@ -2128,9 +2128,6 @@
     "defaultMessage": "Optimism 是獨立運行的區塊鏈，若你在其他鏈上已有 USDT 貨幣，需要將它們轉移到 Optimism 網絡才能使用，詳情參考 {tutorial}.",
     "description": "src/components/Forms/PaymentForm/SwitchNetwork/index.tsx"
   },
-  "Thr8QX": {
-    "defaultMessage": "回原文 ↩"
-  },
   "TjWWxF": {
     "defaultMessage": "廣播已送出",
     "description": "src/views/Circle/Broadcast/Broadcast.tsx"

--- a/lang/zh-Hant.json
+++ b/lang/zh-Hant.json
@@ -2616,6 +2616,9 @@
   "beLe/F": {
     "defaultMessage": "廣播"
   },
+  "bv9UzQ": {
+    "defaultMessage": "查看全部金句"
+  },
   "c/z318": {
     "defaultMessage": "郵件地址或密碼錯誤",
     "description": "src/components/Forms/EmailLoginForm/index.tsx"

--- a/lang/zh-Hant.json
+++ b/lang/zh-Hant.json
@@ -416,9 +416,6 @@
   "3cxMQp": {
     "defaultMessage": "Violet"
   },
-  "3jmniZ": {
-    "defaultMessage": "撤下"
-  },
   "3kbIhS": {
     "defaultMessage": "未命名"
   },
@@ -1189,9 +1186,6 @@
   "EZMrtJ": {
     "defaultMessage": "在 {circleName} 的廣播中留言 ",
     "description": "src/components/Notice/CircleNotice/CircleNewBroadcastComments.tsx"
-  },
-  "EZhPi/": {
-    "defaultMessage": "管理金句"
   },
   "Eb1U+/": {
     "defaultMessage": "儲值成功"
@@ -2097,9 +2091,6 @@
   "TF1OhT": {
     "defaultMessage": "臨時密碼已過期，請嘗試重新發送"
   },
-  "TIWVxK": {
-    "defaultMessage": "已從金句牆撤下"
-  },
   "TInwt3": {
     "defaultMessage": "關閉評論"
   },
@@ -2452,9 +2443,6 @@
   "Z7JXlF": {
     "defaultMessage": "因違反用戶協定而被封存，",
     "description": "src/views/ArticleDetail/StickyTopBanner/index.tsx"
-  },
-  "Z82+dw": {
-    "defaultMessage": "確認撤下"
   },
   "ZAoAcG": {
     "defaultMessage": "Threads, Mastodon, Misskey 這些地方的粉絲也會看到"
@@ -3054,9 +3042,6 @@
   },
   "iSM+et": {
     "defaultMessage": "作者保留所有權利"
-  },
-  "iSjuti": {
-    "defaultMessage": "撤下失敗"
   },
   "iTcMqz": {
     "defaultMessage": "月色之下，夢想即將實現。月之夢徽章紀念你曾參與「遊牧者計畫」。",

--- a/src/views/CampaignDetail/Discussion/styles.module.css
+++ b/src/views/CampaignDetail/Discussion/styles.module.css
@@ -1,7 +1,9 @@
 .discussion {
   /* no top padding: the aside already gives the first module a top margin, so
-     dropping it lines the "討論區" title up with the cover top in the main column */
-  padding: 0 0 var(--sp16);
+     dropping it lines the "討論區" title up with the cover top in the main column.
+     bottom = sp8: with the "view all" button's own 8px, the gap above the dashed
+     rule matches the participants' sp16 padding-top below it */
+  padding: 0 0 var(--sp8);
 }
 
 .header {

--- a/src/views/CampaignDetail/QuoteWall/Dialog.tsx
+++ b/src/views/CampaignDetail/QuoteWall/Dialog.tsx
@@ -100,11 +100,7 @@ const BaseQuoteWallDialog = ({
           {!loading && quotes.length > 0 && (
             <div className={styles.wall}>
               {quotes.map((quote) => (
-                <QuoteCard
-                  key={quote.id}
-                  quote={quote}
-                  afterRetract={shuffle}
-                />
+                <QuoteCard key={quote.id} quote={quote} />
               ))}
             </div>
           )}

--- a/src/views/CampaignDetail/QuoteWall/Dialog.tsx
+++ b/src/views/CampaignDetail/QuoteWall/Dialog.tsx
@@ -99,11 +99,10 @@ const BaseQuoteWallDialog = ({
 
           {!loading && quotes.length > 0 && (
             <div className={styles.wall}>
-              {quotes.map((quote, i) => (
+              {quotes.map((quote) => (
                 <QuoteCard
                   key={quote.id}
                   quote={quote}
-                  index={i}
                   afterRetract={shuffle}
                 />
               ))}

--- a/src/views/CampaignDetail/QuoteWall/QuoteCard.tsx
+++ b/src/views/CampaignDetail/QuoteWall/QuoteCard.tsx
@@ -56,7 +56,8 @@ const QuoteCard = ({ quote, afterRetract }: QuoteCardProps) => {
       <span className={styles.quoteMark} aria-hidden="true">
         ❝
       </span>
-      <Link {...path} className={styles.quoteLink}>
+      {/* stretched link: the whole card navigates to the source article */}
+      <Link {...path} className={styles.cardLink}>
         <blockquote className={styles.quote}>{quote.content}</blockquote>
       </Link>
 
@@ -65,9 +66,6 @@ const QuoteCard = ({ quote, afterRetract }: QuoteCardProps) => {
           — {quote.article.author.userName}
           {quote.article.title ? `《${quote.article.title}》` : ''}
         </span>
-        <Link {...path} className={styles.back}>
-          <FormattedMessage defaultMessage="To article ↩" id="Thr8QX" />
-        </Link>
       </figcaption>
 
       {canRetract && (

--- a/src/views/CampaignDetail/QuoteWall/QuoteCard.tsx
+++ b/src/views/CampaignDetail/QuoteWall/QuoteCard.tsx
@@ -53,9 +53,6 @@ const QuoteCard = ({ quote, afterRetract }: QuoteCardProps) => {
 
   return (
     <figure className={styles.card}>
-      <span className={styles.quoteMark} aria-hidden="true">
-        ❝
-      </span>
       {/* stretched link: the whole card navigates to the source article */}
       <Link {...path} className={styles.cardLink}>
         <blockquote className={styles.quote}>{quote.content}</blockquote>

--- a/src/views/CampaignDetail/QuoteWall/QuoteCard.tsx
+++ b/src/views/CampaignDetail/QuoteWall/QuoteCard.tsx
@@ -1,61 +1,17 @@
 import Link from 'next/link'
-import { useContext, useState } from 'react'
-import { FormattedMessage } from 'react-intl'
 
 import { toPath } from '~/common/utils'
-import { Button, toast, useMutation, ViewerContext } from '~/components'
-import { DELETE_QUOTE } from '~/components/GQL/mutations/putQuote'
-import { DeleteQuoteMutation, QuoteWallQuoteFragment } from '~/gql/graphql'
+import { QuoteWallQuoteFragment } from '~/gql/graphql'
 
 import styles from './styles.module.css'
 
 interface QuoteCardProps {
   quote: QuoteWallQuoteFragment
-  afterRetract?: () => void
 }
 
-const QuoteCard = ({ quote, afterRetract }: QuoteCardProps) => {
-  const viewer = useContext(ViewerContext)
-  const [deleteQuote] = useMutation<DeleteQuoteMutation>(DELETE_QUOTE)
-  const [confirming, setConfirming] = useState(false)
-  const [retracted, setRetracted] = useState(false)
-
-  // retract is staff-only (site admin); posters/authors cannot self-retract
-  const canRetract = !!viewer.isAdmin
-
+// display-only card; quote moderation (retract) lives in the OSS admin console
+const QuoteCard = ({ quote }: QuoteCardProps) => {
   const path = toPath({ page: 'articleDetail', article: quote.article })
-
-  const onRetract = async () => {
-    try {
-      // deleteQuote returns a bare boolean, so Apollo can't evict the quote on
-      // its own; refetch every CampaignQuotes observer (band + dialog) so the
-      // retracted quote and the quoteCount reconcile across the page
-      await deleteQuote({
-        variables: { input: { id: quote.id } },
-        refetchQueries: ['CampaignQuotes'],
-      })
-      setRetracted(true)
-      toast.info({
-        message: (
-          <FormattedMessage
-            defaultMessage="Quote retracted from the wall"
-            id="TIWVxK"
-          />
-        ),
-      })
-      afterRetract?.()
-    } catch {
-      toast.error({
-        message: (
-          <FormattedMessage defaultMessage="Failed to retract" id="iSjuti" />
-        ),
-      })
-    }
-  }
-
-  if (retracted) {
-    return null
-  }
 
   return (
     <figure className={styles.card}>
@@ -70,32 +26,6 @@ const QuoteCard = ({ quote, afterRetract }: QuoteCardProps) => {
           {quote.article.title ? `《${quote.article.title}》` : ''}
         </span>
       </figcaption>
-
-      {canRetract && (
-        <div className={styles.retractRow}>
-          {confirming ? (
-            <>
-              <Button textColor="grey" onClick={() => setConfirming(false)}>
-                <FormattedMessage defaultMessage="Cancel" id="47FYwb" />
-              </Button>
-              <Button textColor="red" onClick={onRetract}>
-                <FormattedMessage
-                  defaultMessage="Confirm retract"
-                  id="Z82+dw"
-                />
-              </Button>
-            </>
-          ) : (
-            <Button
-              textColor="grey"
-              spacing={[0, 0]}
-              onClick={() => setConfirming(true)}
-            >
-              <FormattedMessage defaultMessage="Retract" id="3jmniZ" />
-            </Button>
-          )}
-        </div>
-      )}
     </figure>
   )
 }

--- a/src/views/CampaignDetail/QuoteWall/QuoteCard.tsx
+++ b/src/views/CampaignDetail/QuoteWall/QuoteCard.tsx
@@ -27,7 +27,13 @@ const QuoteCard = ({ quote, afterRetract }: QuoteCardProps) => {
 
   const onRetract = async () => {
     try {
-      await deleteQuote({ variables: { input: { id: quote.id } } })
+      // deleteQuote returns a bare boolean, so Apollo can't evict the quote on
+      // its own; refetch every CampaignQuotes observer (band + dialog) so the
+      // retracted quote and the quoteCount reconcile across the page
+      await deleteQuote({
+        variables: { input: { id: quote.id } },
+        refetchQueries: ['CampaignQuotes'],
+      })
       setRetracted(true)
       toast.info({
         message: (

--- a/src/views/CampaignDetail/QuoteWall/QuoteCard.tsx
+++ b/src/views/CampaignDetail/QuoteWall/QuoteCard.tsx
@@ -11,21 +11,17 @@ import styles from './styles.module.css'
 
 interface QuoteCardProps {
   quote: QuoteWallQuoteFragment
-  // index drives the rotation / background variety on the wall
-  index?: number
   afterRetract?: () => void
 }
 
-const QuoteCard = ({ quote, index = 0, afterRetract }: QuoteCardProps) => {
+const QuoteCard = ({ quote, afterRetract }: QuoteCardProps) => {
   const viewer = useContext(ViewerContext)
   const [deleteQuote] = useMutation<DeleteQuoteMutation>(DELETE_QUOTE)
   const [confirming, setConfirming] = useState(false)
   const [retracted, setRetracted] = useState(false)
 
-  // the poster, or the source article's author (the words are theirs), may retract
-  const canRetract =
-    !!viewer.id &&
-    (viewer.id === quote.poster.id || viewer.id === quote.article.author.id)
+  // retract is staff-only (site admin); posters/authors cannot self-retract
+  const canRetract = !!viewer.isAdmin
 
   const path = toPath({ page: 'articleDetail', article: quote.article })
 
@@ -56,7 +52,10 @@ const QuoteCard = ({ quote, index = 0, afterRetract }: QuoteCardProps) => {
   }
 
   return (
-    <figure className={styles.card} data-variant={index % 4}>
+    <figure className={styles.card}>
+      <span className={styles.quoteMark} aria-hidden="true">
+        ❝
+      </span>
       <Link {...path} className={styles.quoteLink}>
         <blockquote className={styles.quote}>{quote.content}</blockquote>
       </Link>
@@ -71,25 +70,31 @@ const QuoteCard = ({ quote, index = 0, afterRetract }: QuoteCardProps) => {
         </Link>
       </figcaption>
 
-      {canRetract &&
-        (confirming ? (
-          <span className={styles.retractRow}>
-            <Button textColor="grey" onClick={() => setConfirming(false)}>
-              <FormattedMessage defaultMessage="Cancel" id="47FYwb" />
+      {canRetract && (
+        <div className={styles.retractRow}>
+          {confirming ? (
+            <>
+              <Button textColor="grey" onClick={() => setConfirming(false)}>
+                <FormattedMessage defaultMessage="Cancel" id="47FYwb" />
+              </Button>
+              <Button textColor="red" onClick={onRetract}>
+                <FormattedMessage
+                  defaultMessage="Confirm retract"
+                  id="Z82+dw"
+                />
+              </Button>
+            </>
+          ) : (
+            <Button
+              textColor="grey"
+              spacing={[0, 0]}
+              onClick={() => setConfirming(true)}
+            >
+              <FormattedMessage defaultMessage="Retract" id="3jmniZ" />
             </Button>
-            <Button textColor="red" onClick={onRetract}>
-              <FormattedMessage defaultMessage="Confirm retract" id="Z82+dw" />
-            </Button>
-          </span>
-        ) : (
-          <Button
-            textColor="grey"
-            spacing={[0, 0]}
-            onClick={() => setConfirming(true)}
-          >
-            <FormattedMessage defaultMessage="Retract" id="3jmniZ" />
-          </Button>
-        ))}
+          )}
+        </div>
+      )}
     </figure>
   )
 }

--- a/src/views/CampaignDetail/QuoteWall/index.tsx
+++ b/src/views/CampaignDetail/QuoteWall/index.tsx
@@ -120,30 +120,6 @@ const QuoteWall = ({ shortHash, entry = 'module' }: QuoteWallProps) => {
             </p>
           </div>
         )}
-
-        {quotes.length > 0 && totalCount > quotes.length && (
-          <div className={styles.bandViewMore}>
-            <QuoteWallDialog shortHash={shortHash} totalCount={totalCount}>
-              {({ openDialog }) => (
-                <Button
-                  spacing={[4, 0]}
-                  textColor="green"
-                  textActiveColor="greenDark"
-                  onClick={openDialog}
-                  aria-haspopup="dialog"
-                >
-                  <TextIcon size={14} weight="medium">
-                    <FormattedMessage
-                      defaultMessage="View all {count} quotes"
-                      id="epZb9X"
-                      values={{ count: totalCount }}
-                    />
-                  </TextIcon>
-                </Button>
-              )}
-            </QuoteWallDialog>
-          </div>
-        )}
       </section>
     )
   }

--- a/src/views/CampaignDetail/QuoteWall/index.tsx
+++ b/src/views/CampaignDetail/QuoteWall/index.tsx
@@ -84,32 +84,14 @@ const QuoteWall = ({ shortHash, entry = 'module' }: QuoteWallProps) => {
           <h2 className={styles.title}>
             <FormattedMessage defaultMessage="Quote wall" id="1HLo+Y" />
           </h2>
-          <div className={styles.headerActions}>
-            {/* admin-only: opens the in-app wall dialog where each quote shows a
-                retract control (canRetract = viewer.isAdmin) */}
-            {viewer.isAdmin && (
-              <QuoteWallDialog shortHash={shortHash} totalCount={totalCount}>
-                {({ openDialog }) => (
-                  <button
-                    type="button"
-                    className={styles.manageLink}
-                    onClick={openDialog}
-                    aria-haspopup="dialog"
-                  >
-                    <FormattedMessage defaultMessage="Manage quotes" id="EZhPi/" />
-                  </button>
-                )}
-              </QuoteWallDialog>
-            )}
-            <a
-              className={styles.viewAllLink}
-              href={EXTERNAL_LINKS.SEVEN_DAY_BOOK_QUOTE_WALL}
-              target="_blank"
-              rel="noreferrer"
-            >
-              <FormattedMessage defaultMessage="See all quotes" id="bv9UzQ" />
-            </a>
-          </div>
+          <a
+            className={styles.viewAllLink}
+            href={EXTERNAL_LINKS.SEVEN_DAY_BOOK_QUOTE_WALL}
+            target="_blank"
+            rel="noreferrer"
+          >
+            <FormattedMessage defaultMessage="See all quotes" id="bv9UzQ" />
+          </a>
         </header>
 
         {quotes.length > 0 ? (

--- a/src/views/CampaignDetail/QuoteWall/index.tsx
+++ b/src/views/CampaignDetail/QuoteWall/index.tsx
@@ -84,14 +84,32 @@ const QuoteWall = ({ shortHash, entry = 'module' }: QuoteWallProps) => {
           <h2 className={styles.title}>
             <FormattedMessage defaultMessage="Quote wall" id="1HLo+Y" />
           </h2>
-          <a
-            className={styles.viewAllLink}
-            href={EXTERNAL_LINKS.SEVEN_DAY_BOOK_QUOTE_WALL}
-            target="_blank"
-            rel="noreferrer"
-          >
-            <FormattedMessage defaultMessage="See all quotes" id="bv9UzQ" />
-          </a>
+          <div className={styles.headerActions}>
+            {/* admin-only: opens the in-app wall dialog where each quote shows a
+                retract control (canRetract = viewer.isAdmin) */}
+            {viewer.isAdmin && (
+              <QuoteWallDialog shortHash={shortHash} totalCount={totalCount}>
+                {({ openDialog }) => (
+                  <button
+                    type="button"
+                    className={styles.manageLink}
+                    onClick={openDialog}
+                    aria-haspopup="dialog"
+                  >
+                    <FormattedMessage defaultMessage="Manage quotes" id="EZhPi/" />
+                  </button>
+                )}
+              </QuoteWallDialog>
+            )}
+            <a
+              className={styles.viewAllLink}
+              href={EXTERNAL_LINKS.SEVEN_DAY_BOOK_QUOTE_WALL}
+              target="_blank"
+              rel="noreferrer"
+            >
+              <FormattedMessage defaultMessage="See all quotes" id="bv9UzQ" />
+            </a>
+          </div>
         </header>
 
         {quotes.length > 0 ? (

--- a/src/views/CampaignDetail/QuoteWall/index.tsx
+++ b/src/views/CampaignDetail/QuoteWall/index.tsx
@@ -84,33 +84,20 @@ const QuoteWall = ({ shortHash, entry = 'module' }: QuoteWallProps) => {
           <h2 className={styles.title}>
             <FormattedMessage defaultMessage="Quote wall" id="1HLo+Y" />
           </h2>
-          {totalCount > quotes.length && (
-            <QuoteWallDialog shortHash={shortHash} totalCount={totalCount}>
-              {({ openDialog }) => (
-                <Button
-                  spacing={[4, 0]}
-                  textColor="green"
-                  textActiveColor="greenDark"
-                  onClick={openDialog}
-                  aria-haspopup="dialog"
-                >
-                  <TextIcon size={14} weight="medium">
-                    <FormattedMessage
-                      defaultMessage="View all {count} quotes"
-                      id="epZb9X"
-                      values={{ count: totalCount }}
-                    />
-                  </TextIcon>
-                </Button>
-              )}
-            </QuoteWallDialog>
-          )}
+          <a
+            className={styles.viewAllLink}
+            href={EXTERNAL_LINKS.SEVEN_DAY_BOOK_QUOTE_WALL}
+            target="_blank"
+            rel="noreferrer"
+          >
+            <FormattedMessage defaultMessage="See all quotes" id="bv9UzQ" />
+          </a>
         </header>
 
         {quotes.length > 0 ? (
           <div className={styles.bandRow}>
-            {quotes.map((quote, i) => (
-              <QuoteCard key={quote.id} quote={quote} index={i} />
+            {quotes.map((quote) => (
+              <QuoteCard key={quote.id} quote={quote} />
             ))}
           </div>
         ) : (
@@ -131,6 +118,30 @@ const QuoteWall = ({ shortHash, entry = 'module' }: QuoteWallProps) => {
                 description="src/views/CampaignDetail/QuoteWall band empty-state prompt"
               />
             </p>
+          </div>
+        )}
+
+        {quotes.length > 0 && totalCount > quotes.length && (
+          <div className={styles.bandViewMore}>
+            <QuoteWallDialog shortHash={shortHash} totalCount={totalCount}>
+              {({ openDialog }) => (
+                <Button
+                  spacing={[4, 0]}
+                  textColor="green"
+                  textActiveColor="greenDark"
+                  onClick={openDialog}
+                  aria-haspopup="dialog"
+                >
+                  <TextIcon size={14} weight="medium">
+                    <FormattedMessage
+                      defaultMessage="View all {count} quotes"
+                      id="epZb9X"
+                      values={{ count: totalCount }}
+                    />
+                  </TextIcon>
+                </Button>
+              )}
+            </QuoteWallDialog>
           </div>
         )}
       </section>
@@ -154,8 +165,8 @@ const QuoteWall = ({ shortHash, entry = 'module' }: QuoteWallProps) => {
       </header>
 
       <div className={styles.previewWall}>
-        {quotes.map((quote, i) => (
-          <QuoteCard key={quote.id} quote={quote} index={i} />
+        {quotes.map((quote) => (
+          <QuoteCard key={quote.id} quote={quote} />
         ))}
       </div>
 

--- a/src/views/CampaignDetail/QuoteWall/styles.module.css
+++ b/src/views/CampaignDetail/QuoteWall/styles.module.css
@@ -52,6 +52,10 @@
   column-gap: var(--sp12);
 }
 
+.wall > .card {
+  margin-bottom: var(--sp24);
+}
+
 .dialogTop {
   display: flex;
   align-items: center;
@@ -65,26 +69,17 @@
   color: var(--color-matters-green);
 }
 
-/* quote card — refined pull-quote: light card, green quote mark, an author
-   footer split by a thin DS rule. The whole card is a stretched link to the
-   source article (see .cardLink). */
+/* quote card — pull-quote with a green left rule, no fill/box (the original
+   form). Text follows the article-body standard. The whole card is a stretched
+   link to the source article (see .cardLink). */
 .card {
   position: relative;
   display: flex;
   flex-direction: column;
-  padding: var(--sp16);
+  padding-left: var(--sp16);
   margin: 0;
-  background: var(--color-grey-lighter);
-  border: 1px solid var(--color-grey-light);
-  border-radius: 0.625rem;
+  border-left: 2px solid var(--color-matters-green);
   break-inside: avoid;
-}
-
-.quoteMark {
-  font-size: 1.75rem;
-  font-weight: var(--font-semibold);
-  line-height: 1;
-  color: var(--color-matters-green);
 }
 
 /* stretched link: the ::after overlay makes the whole card clickable while the
@@ -102,28 +97,23 @@
 }
 
 .quote {
-  /* match the article feed summary: text14 / 1.375rem / grey-dark */
+  /* match the article body text: 17px / 1.75 / #333, inheriting the body sans */
   display: -webkit-box;
-  margin: var(--sp4) 0 0;
+  margin: 0;
   overflow: hidden;
   -webkit-line-clamp: 3;
-  font-size: var(--text14);
-  line-height: 1.375rem;
-  color: var(--color-grey-dark);
+  font-size: var(--font-size-article-base);
+  line-height: var(--line-height-article-base);
+  color: var(--color-black);
   -webkit-box-orient: vertical;
 }
 
 .meta {
-  display: flex;
-  gap: var(--sp8);
-  align-items: flex-end;
-  padding-top: var(--sp12);
   margin-top: var(--sp12);
-  border-top: 1px solid var(--color-grey-light);
 }
 
 .author {
-  font-size: var(--text12);
+  font-size: var(--text13);
   line-height: 1.5;
   color: var(--color-grey-dark);
 }
@@ -162,16 +152,15 @@
   padding: var(--sp24) 0 var(--sp8);
 }
 
-/* joined strip: the cards share one outer frame; a thin DS rule divides each
-   quote (no gaps, borders connected) */
+/* band: a row of up to 3 pull-quotes (green left rule), gap-separated; on
+   narrow viewports they keep a min width and scroll horizontally */
 .bandRow {
   display: flex;
+  gap: var(--sp24);
+  padding-bottom: var(--sp4);
   overflow-x: auto;
   scrollbar-width: none;
   -ms-overflow-style: none;
-  background: var(--color-grey-lighter);
-  border: 1px solid var(--color-grey-light);
-  border-radius: 0.625rem;
 }
 
 .bandRow::-webkit-scrollbar {
@@ -179,16 +168,11 @@
 }
 
 .bandRow > .card {
-  flex: 0 0 15rem; /* 240px */
+  /* basis 15rem with grow disabled: 3 fill the row (shrink to fit) yet 1-2
+     stay a fixed width, left-aligned, instead of stretching the full column */
+  flex: 0 1 15rem;
+  min-width: 12rem;
   margin: 0;
-  background: transparent;
-  border: none;
-  border-right: 1px solid var(--color-grey-light);
-  border-radius: 0;
-}
-
-.bandRow > .card:last-child {
-  border-right: none;
 }
 
 /* empty band: an invitation card (soft green fill + green accent rule) shown

--- a/src/views/CampaignDetail/QuoteWall/styles.module.css
+++ b/src/views/CampaignDetail/QuoteWall/styles.module.css
@@ -26,14 +26,6 @@
   color: var(--color-matters-green);
 }
 
-/* band header right side: admin manage button + the see-all pill */
-.headerActions {
-  display: flex;
-  flex-shrink: 0;
-  gap: var(--sp8);
-  align-items: center;
-}
-
 /* "see all quotes" pill in the band header → external museum wall */
 .viewAllLink {
   flex-shrink: 0;
@@ -43,19 +35,6 @@
   color: var(--color-matters-green);
   white-space: nowrap;
   border: 1px solid var(--color-matters-green);
-  border-radius: 999px;
-}
-
-/* admin-only manage button → opens the in-app dialog to retract quotes;
-   grey pill to distinguish it from the green see-all pill */
-.manageLink {
-  flex-shrink: 0;
-  padding: 0.1875rem 0.75rem;
-  font-size: var(--text13);
-  font-weight: var(--font-medium);
-  color: var(--color-grey-dark);
-  white-space: nowrap;
-  border: 1px solid var(--color-grey-light);
   border-radius: 999px;
 }
 
@@ -104,8 +83,7 @@
 }
 
 /* stretched link: the ::after overlay makes the whole card clickable while the
-   quote text stays the link's accessible name. The admin retract row sits above
-   the overlay via z-index so it stays independently clickable. */
+   quote text stays the link's accessible name. */
 .cardLink {
   color: inherit;
 }
@@ -137,15 +115,6 @@
   font-size: var(--text13);
   line-height: 1.5;
   color: var(--color-grey-dark);
-}
-
-/* admin-only retract */
-.retractRow {
-  position: relative;
-  z-index: 1;
-  display: flex;
-  gap: var(--sp8);
-  margin-top: var(--sp8);
 }
 
 /* mobile one-line entry */

--- a/src/views/CampaignDetail/QuoteWall/styles.module.css
+++ b/src/views/CampaignDetail/QuoteWall/styles.module.css
@@ -97,12 +97,12 @@
 }
 
 .quote {
-  /* match the article body text: 17px / 1.75 / #333, inheriting the body sans */
+  /* campaign-description size (text15) at a 1.75 line-height, body colour #333 */
   display: -webkit-box;
   margin: 0;
   overflow: hidden;
   -webkit-line-clamp: 3;
-  font-size: var(--font-size-article-base);
+  font-size: var(--text15);
   line-height: var(--line-height-article-base);
   color: var(--color-black);
   -webkit-box-orient: vertical;

--- a/src/views/CampaignDetail/QuoteWall/styles.module.css
+++ b/src/views/CampaignDetail/QuoteWall/styles.module.css
@@ -38,13 +38,6 @@
   border-radius: 999px;
 }
 
-/* per-campaign "view all" (opens the dialog), centred below the card row */
-.bandViewMore {
-  display: flex;
-  justify-content: center;
-  margin-top: var(--sp12);
-}
-
 /* compact preview: a vertical stack of memo cards */
 .previewWall {
   display: flex;
@@ -72,8 +65,9 @@
   color: var(--color-matters-green);
 }
 
-/* quote card — refined pull-quote: light card, green quote mark, footer with
-   author + back-link split by a thin DS-compliant rule (no 2px green line) */
+/* quote card — refined pull-quote: light card, green quote mark, an author
+   footer split by a thin DS rule. The whole card is a stretched link to the
+   source article (see .cardLink). */
 .card {
   position: relative;
   display: flex;
@@ -93,19 +87,29 @@
   color: var(--color-matters-green);
 }
 
-.quoteLink {
+/* stretched link: the ::after overlay makes the whole card clickable while the
+   quote text stays the link's accessible name. The admin retract row sits above
+   the overlay via z-index so it stays independently clickable. */
+.cardLink {
   color: inherit;
 }
 
+.cardLink::after {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  content: '';
+}
+
 .quote {
-  /* match the campaign description size (text15); cap at 3 lines */
+  /* identical to the campaign description: text15 / 1.733rem / grey-dark */
   display: -webkit-box;
   margin: var(--sp4) 0 0;
   overflow: hidden;
   -webkit-line-clamp: 3;
   font-size: var(--text15);
-  line-height: 1.7;
-  color: var(--color-grey-darkest);
+  line-height: 1.733rem;
+  color: var(--color-grey-dark);
   -webkit-box-orient: vertical;
 }
 
@@ -113,7 +117,6 @@
   display: flex;
   gap: var(--sp8);
   align-items: flex-end;
-  justify-content: space-between;
   padding-top: var(--sp12);
   margin-top: var(--sp12);
   border-top: 1px solid var(--color-grey-light);
@@ -125,15 +128,10 @@
   color: var(--color-grey-dark);
 }
 
-.back {
-  flex-shrink: 0;
-  font-size: var(--text12);
-  color: var(--color-matters-green);
-  white-space: nowrap;
-}
-
 /* admin-only retract */
 .retractRow {
+  position: relative;
+  z-index: 1;
   display: flex;
   gap: var(--sp8);
   margin-top: var(--sp8);
@@ -164,13 +162,16 @@
   padding: var(--sp24) 0 var(--sp8);
 }
 
+/* joined strip: the cards share one outer frame; a thin DS rule divides each
+   quote (no gaps, borders connected) */
 .bandRow {
   display: flex;
-  gap: var(--sp24);
-  padding-bottom: var(--sp4);
   overflow-x: auto;
   scrollbar-width: none;
   -ms-overflow-style: none;
+  background: var(--color-grey-lighter);
+  border: 1px solid var(--color-grey-light);
+  border-radius: 0.625rem;
 }
 
 .bandRow::-webkit-scrollbar {
@@ -180,6 +181,14 @@
 .bandRow > .card {
   flex: 0 0 15rem; /* 240px */
   margin: 0;
+  background: transparent;
+  border: none;
+  border-right: 1px solid var(--color-grey-light);
+  border-radius: 0;
+}
+
+.bandRow > .card:last-child {
+  border-right: none;
 }
 
 /* empty band: an invitation card (soft green fill + green accent rule) shown

--- a/src/views/CampaignDetail/QuoteWall/styles.module.css
+++ b/src/views/CampaignDetail/QuoteWall/styles.module.css
@@ -102,13 +102,13 @@
 }
 
 .quote {
-  /* identical to the campaign description: text15 / 1.733rem / grey-dark */
+  /* match the article feed summary: text14 / 1.375rem / grey-dark */
   display: -webkit-box;
   margin: var(--sp4) 0 0;
   overflow: hidden;
   -webkit-line-clamp: 3;
-  font-size: var(--text15);
-  line-height: 1.733rem;
+  font-size: var(--text14);
+  line-height: 1.375rem;
   color: var(--color-grey-dark);
   -webkit-box-orient: vertical;
 }

--- a/src/views/CampaignDetail/QuoteWall/styles.module.css
+++ b/src/views/CampaignDetail/QuoteWall/styles.module.css
@@ -26,6 +26,25 @@
   color: var(--color-matters-green);
 }
 
+/* "see all quotes" pill in the band header → external museum wall */
+.viewAllLink {
+  flex-shrink: 0;
+  padding: 0.1875rem 0.75rem;
+  font-size: var(--text13);
+  font-weight: var(--font-medium);
+  color: var(--color-matters-green);
+  white-space: nowrap;
+  border: 1px solid var(--color-matters-green);
+  border-radius: 999px;
+}
+
+/* per-campaign "view all" (opens the dialog), centred below the card row */
+.bandViewMore {
+  display: flex;
+  justify-content: center;
+  margin-top: var(--sp12);
+}
+
 /* compact preview: a vertical stack of memo cards */
 .previewWall {
   display: flex;
@@ -53,16 +72,25 @@
   color: var(--color-matters-green);
 }
 
-/* pull-quote card: a left green rule, no fill (Option A — uniform, not the
-   old random sticky-note colours) */
+/* quote card — refined pull-quote: light card, green quote mark, footer with
+   author + back-link split by a thin DS-compliant rule (no 2px green line) */
 .card {
+  position: relative;
   display: flex;
   flex-direction: column;
-  gap: var(--sp4);
-  padding-left: var(--sp16);
-  margin: 0 0 var(--sp12);
-  border-left: 2px solid var(--color-matters-green);
+  padding: var(--sp16);
+  margin: 0;
+  background: var(--color-grey-lighter);
+  border: 1px solid var(--color-grey-light);
+  border-radius: 0.625rem;
   break-inside: avoid;
+}
+
+.quoteMark {
+  font-size: 1.75rem;
+  font-weight: var(--font-semibold);
+  line-height: 1;
+  color: var(--color-matters-green);
 }
 
 .quoteLink {
@@ -70,36 +98,45 @@
 }
 
 .quote {
-  /* safety net: cap display at 3 lines even within the 80-char limit */
+  /* match the campaign description size (text15); cap at 3 lines */
   display: -webkit-box;
-  margin: 0;
+  margin: var(--sp4) 0 0;
   overflow: hidden;
   -webkit-line-clamp: 3;
-  font-size: var(--text16);
-  line-height: 1.6;
+  font-size: var(--text15);
+  line-height: 1.7;
   color: var(--color-grey-darkest);
   -webkit-box-orient: vertical;
 }
 
 .meta {
   display: flex;
-  flex-direction: column;
-  gap: var(--sp4);
+  gap: var(--sp8);
+  align-items: flex-end;
+  justify-content: space-between;
+  padding-top: var(--sp12);
+  margin-top: var(--sp12);
+  border-top: 1px solid var(--color-grey-light);
 }
 
 .author {
   font-size: var(--text12);
+  line-height: 1.5;
   color: var(--color-grey-dark);
 }
 
 .back {
+  flex-shrink: 0;
   font-size: var(--text12);
   color: var(--color-matters-green);
+  white-space: nowrap;
 }
 
+/* admin-only retract */
 .retractRow {
   display: flex;
   gap: var(--sp8);
+  margin-top: var(--sp8);
 }
 
 /* mobile one-line entry */
@@ -141,12 +178,12 @@
 }
 
 .bandRow > .card {
-  flex: 0 0 14.375rem; /* 230px */
+  flex: 0 0 15rem; /* 240px */
   margin: 0;
 }
 
-/* empty band: an "invitation card" shaped like a real quote card (left green
-   rule), so the wall keeps its card feel without showing any fake quote */
+/* empty band: an invitation card (soft green fill + green accent rule) shown
+   while the wall is enabled but still empty — keeps a card feel, no fake quote */
 .inviteCard {
   /* full width, matching the article list / centre column (not a half-width
      card) */

--- a/src/views/CampaignDetail/QuoteWall/styles.module.css
+++ b/src/views/CampaignDetail/QuoteWall/styles.module.css
@@ -26,6 +26,14 @@
   color: var(--color-matters-green);
 }
 
+/* band header right side: admin manage button + the see-all pill */
+.headerActions {
+  display: flex;
+  flex-shrink: 0;
+  gap: var(--sp8);
+  align-items: center;
+}
+
 /* "see all quotes" pill in the band header → external museum wall */
 .viewAllLink {
   flex-shrink: 0;
@@ -35,6 +43,19 @@
   color: var(--color-matters-green);
   white-space: nowrap;
   border: 1px solid var(--color-matters-green);
+  border-radius: 999px;
+}
+
+/* admin-only manage button → opens the in-app dialog to retract quotes;
+   grey pill to distinguish it from the green see-all pill */
+.manageLink {
+  flex-shrink: 0;
+  padding: 0.1875rem 0.75rem;
+  font-size: var(--text13);
+  font-weight: var(--font-medium);
+  color: var(--color-grey-dark);
+  white-space: nowrap;
+  border: 1px solid var(--color-grey-light);
   border-radius: 999px;
 }
 

--- a/src/views/CampaignDetail/QuoteWall/styles.module.css
+++ b/src/views/CampaignDetail/QuoteWall/styles.module.css
@@ -78,7 +78,7 @@
   flex-direction: column;
   padding-left: var(--sp16);
   margin: 0;
-  border-left: 2px solid var(--color-matters-green);
+  border-left: 1px solid var(--color-matters-green);
   break-inside: avoid;
 }
 
@@ -173,7 +173,7 @@
   padding: var(--sp16);
   margin: var(--sp4) 0 var(--sp8);
   background: var(--color-green-lighter);
-  border-left: 2px solid var(--color-matters-green);
+  border-left: 1px solid var(--color-matters-green);
   border-radius: 0 var(--sp8) var(--sp8) 0;
 }
 


### PR DESCRIPTION
## What

Brings the campaign **quote wall** (the centre-column pull-quote band on the activity page) to its final form, and makes it **display-only** — moderation moves to the OSS admin console.

### Quote cards
- Pull-quote style: a **1px green left rule**, no fill/box, no ❝ glyph (matches the Matters `border-left-grey` left-rule convention).
- Quote text uses the **campaign-description size** (`--text15`) / `1.75` line-height / `--color-black`.
- The **whole card is a stretched link** to the source article (`.cardLink::after` overlay).
- Removed the "back to article" footer link.

### Band layout
- Up to **3 quotes per row** (`flex: 0 1 15rem` + `min-width: 12rem`, gap-separated): 1–2 quotes don't stretch the full column; narrow viewports keep a min width and scroll horizontally.
- Header keeps a **"See all quotes"** pill → external museum wall.
- Empty state shows an **invitation card** (no fake quote) while the wall is enabled but still empty.

### Moderation → OSS
- **All in-app quote retraction was removed** (the admin "Manage quotes" entry and the per-card retract). The quote wall is now purely a display surface; retraction will live in the OSS admin console (`matters-oss-next`), not on the public page.

## Notes
- The quote wall renders only on the **Vercel preview** (it's `ssr:false` + fresnel `Media`), not in local `next dev` — verify visually on the preview.
- Backend deps already merged: #4842 (data layer), #4857 / #4858 (enableQuoteWall + default-on). This PR does **not** depend on the count-limit removal (matters-server #4867).

## Test
- CI green: build / unit / Vercel.
- Verify on preview at desktop **and** mobile (band becomes a horizontally-scrollable card row).
