### PR TITLE
chore(campaign): point quote-wall see-all to the museum memo wall

### DIFF
--- a/src/common/enums/externalLinks.ts
+++ b/src/common/enums/externalLinks.ts
@@ -14,7 +14,7 @@ export const EXTERNAL_LINKS = {
     isProd
       ? `https://liker.land/${likerId}/civic?utm_source=Matters`
       : `https://rinkeby.liker.land/${likerId}/civic?utm_source=Matters`,
-  SEVEN_DAY_BOOK_QUOTE_WALL: 'https://freewriting.matters.town/memo-wall',
+  SEVEN_DAY_BOOK_QUOTE_WALL: 'https://freewriting.matters.town/museum/memo-wall/',
   PLANET: 'https://www.planetable.xyz/',
   ENS_DOCS: 'https://docs.ens.domains/',
   METAMASK: 'https://metamask.io/download/',


### PR DESCRIPTION
## What
Point the quote wall's **"See all quotes"** pill (and the in-app wall dialog's museum link) at the museum's memo wall:

`EXTERNAL_LINKS.SEVEN_DAY_BOOK_QUOTE_WALL`: `https://freewriting.matters.town/memo-wall` → **`https://freewriting.matters.town/museum/memo-wall/`**

The memo wall moved under `/museum/` on the freewriting (seven-day-book) site. Single-constant change in `src/common/enums/externalLinks.ts`, so both usages update at once.

## Test
- eslint ✓ / tsc ✓
- No behaviour change beyond the link target.
