### PR TITLE
feat: hide frozen user identity

### DIFF
--- a/lang/default.json
+++ b/lang/default.json
@@ -1668,6 +1668,9 @@
     "defaultMessage": "Connect wallet",
     "description": "src/components/Dialogs/AddWalletLoginDialog/Content.tsx"
   },
+  "MeqJEO": {
+    "defaultMessage": "Frozen user"
+  },
   "Mgl1bT": {
     "defaultMessage": "OAuth authorize"
   },
@@ -3623,6 +3626,9 @@
   },
   "s2s6tx": {
     "defaultMessage": "The article has been successfully published and will be synced to IPFS soon."
+  },
+  "sE2Ui3": {
+    "defaultMessage": "Account Frozen"
   },
   "sFJ/Is": {
     "defaultMessage": "Are you sure you want to clear the current content?"

--- a/lang/en.json
+++ b/lang/en.json
@@ -1668,6 +1668,9 @@
     "defaultMessage": "Connect wallet",
     "description": "src/components/Dialogs/AddWalletLoginDialog/Content.tsx"
   },
+  "MeqJEO": {
+    "defaultMessage": "Frozen user"
+  },
   "Mgl1bT": {
     "defaultMessage": "OAuth authorize"
   },
@@ -3623,6 +3626,9 @@
   },
   "s2s6tx": {
     "defaultMessage": "The article has been successfully published and will be synced to IPFS soon."
+  },
+  "sE2Ui3": {
+    "defaultMessage": "Account Frozen"
   },
   "sFJ/Is": {
     "defaultMessage": "Are you sure you want to clear the current content?"

--- a/lang/zh-Hans.json
+++ b/lang/zh-Hans.json
@@ -1668,6 +1668,9 @@
     "defaultMessage": "绑定钱包",
     "description": "src/components/Dialogs/AddWalletLoginDialog/Content.tsx"
   },
+  "MeqJEO": {
+    "defaultMessage": "Frozen user"
+  },
   "Mgl1bT": {
     "defaultMessage": "应用授权"
   },
@@ -3623,6 +3626,9 @@
   },
   "s2s6tx": {
     "defaultMessage": "作品已成功发布，稍后将同步到 IPFS"
+  },
+  "sE2Ui3": {
+    "defaultMessage": "Account Frozen"
   },
   "sFJ/Is": {
     "defaultMessage": "确认清空当前编辑的内容吗？"

--- a/lang/zh-Hant.json
+++ b/lang/zh-Hant.json
@@ -1668,6 +1668,9 @@
     "defaultMessage": "綁定錢包",
     "description": "src/components/Dialogs/AddWalletLoginDialog/Content.tsx"
   },
+  "MeqJEO": {
+    "defaultMessage": "Frozen user"
+  },
   "Mgl1bT": {
     "defaultMessage": "應用授權"
   },
@@ -3623,6 +3626,9 @@
   },
   "s2s6tx": {
     "defaultMessage": "已成功發布作品，稍後同步到 IPFS"
+  },
+  "sE2Ui3": {
+    "defaultMessage": "Account Frozen"
   },
   "sFJ/Is": {
     "defaultMessage": "確認清空當前編輯的内容嗎？"

--- a/src/components/UserDigest/Mini/Mini.test.tsx
+++ b/src/components/UserDigest/Mini/Mini.test.tsx
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { TEST_ID } from '~/common/enums'
 import { fireEvent, render, screen } from '~/common/utils/test'
 import { UserDigest } from '~/components'
+import { UserState } from '~/gql/graphql'
 import { MOCK_USER } from '~/stories/mocks'
 
 describe('<UserDigest.Mini>', () => {
@@ -60,6 +61,28 @@ describe('<UserDigest.Mini>', () => {
     expect($avatar).toBeInTheDocument()
 
     fireEvent.click($avatar)
+    expect(mockRouter.asPath).not.toContain(MOCK_USER.userName)
+  })
+
+  it('should hide original identity for a frozen user', () => {
+    render(
+      <UserDigest.Mini
+        user={{
+          ...MOCK_USER,
+          status: { ...MOCK_USER.status, state: UserState.Frozen },
+        }}
+        hasAvatar
+        hasDisplayName
+        hasUserName
+      />
+    )
+
+    expect(screen.getByText('Account Frozen')).toBeInTheDocument()
+    expect(screen.queryByText(MOCK_USER.displayName)).not.toBeInTheDocument()
+    expect(screen.queryByText(`@${MOCK_USER.userName}`)).not.toBeInTheDocument()
+
+    const $digest = screen.getByTestId(TEST_ID.DIGEST_USER_MINI)
+    fireEvent.click($digest)
     expect(mockRouter.asPath).not.toContain(MOCK_USER.userName)
   })
 

--- a/src/components/UserDigest/Mini/index.tsx
+++ b/src/components/UserDigest/Mini/index.tsx
@@ -5,7 +5,7 @@ import { FormattedMessage } from 'react-intl'
 import { TEST_ID } from '~/common/enums'
 import { capitalizeFirstLetter, toPath } from '~/common/utils'
 import { Avatar, AvatarProps, AvatarSize } from '~/components/Avatar'
-import { UserDigestMiniUserFragment } from '~/gql/graphql'
+import { UserDigestMiniUserFragment, UserState } from '~/gql/graphql'
 
 import { fragments } from './gql'
 import styles from './styles.module.css'
@@ -75,7 +75,10 @@ const Mini = ({
 
   onClick,
 }: UserDigestMiniProps) => {
-  const isArchived = user?.status?.state === 'archived'
+  const userState = user?.status?.state
+  const isArchived = userState === UserState.Archived
+  const isFrozen = userState === UserState.Frozen
+  const isInactive = isArchived || isFrozen
   const containerClasses = classNames({
     [styles.container]: true,
     [styles[`text${textSize}`]]: !!textSize,
@@ -84,7 +87,7 @@ const Mini = ({
     [styles[`nameColor${capitalizeFirstLetter(nameColor)}`]]: !!nameColor,
     [styles[`spacing${capitalizeFirstLetter(spacing + '')}`]]: !!spacing,
     [styles.hasAvatar]: hasAvatar,
-    [styles.disabled]: disabled || isArchived,
+    [styles.disabled]: disabled || isInactive,
   })
   const nameClasses = classNames({
     [styles.name]: true,
@@ -92,7 +95,7 @@ const Mini = ({
     [styles.nameNoWrap]: !!nameNoWrap,
   })
 
-  if (isArchived || !user) {
+  if (isInactive || !user) {
     return (
       <span
         className={containerClasses}
@@ -104,10 +107,17 @@ const Mini = ({
           {hasDisplayName && (
             <span className={styles.displayname}>
               {user ? (
-                <FormattedMessage
-                  defaultMessage="Account Archived"
-                  id="YS8YSV"
-                />
+                isFrozen ? (
+                  <FormattedMessage
+                    defaultMessage="Account Frozen"
+                    id="sE2Ui3"
+                  />
+                ) : (
+                  <FormattedMessage
+                    defaultMessage="Account Archived"
+                    id="YS8YSV"
+                  />
+                )
               ) : (
                 <FormattedMessage defaultMessage="Anonymous User" id="GclYG/" />
               )}

--- a/src/components/UserDigest/Plain/Plain.test.tsx
+++ b/src/components/UserDigest/Plain/Plain.test.tsx
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { TEST_ID } from '~/common/enums'
 import { fireEvent, render, screen } from '~/common/utils/test'
 import { UserDigest } from '~/components'
+import { UserState } from '~/gql/graphql'
 import { MOCK_USER } from '~/stories/mocks'
 
 describe('<UserDigest.Plain>', () => {
@@ -35,6 +36,24 @@ describe('<UserDigest.Plain>', () => {
     // display name
     const $displayName = screen.getByText(MOCK_USER.displayName)
     expect($displayName).toBeInTheDocument()
+
+    fireEvent.click($displayName)
+    expect(mockRouter.asPath).not.toContain(MOCK_USER.userName)
+  })
+
+  it('should hide original identity for a frozen user', () => {
+    render(
+      <UserDigest.Plain
+        user={{
+          ...MOCK_USER,
+          status: { ...MOCK_USER.status, state: UserState.Frozen },
+        }}
+      />
+    )
+
+    const $displayName = screen.getByText('Account Frozen')
+    expect($displayName).toBeInTheDocument()
+    expect(screen.queryByText(MOCK_USER.displayName)).not.toBeInTheDocument()
 
     fireEvent.click($displayName)
     expect(mockRouter.asPath).not.toContain(MOCK_USER.userName)

--- a/src/components/UserDigest/Plain/gql.ts
+++ b/src/components/UserDigest/Plain/gql.ts
@@ -6,6 +6,9 @@ export const fragments = {
       id
       userName
       displayName
+      status {
+        state
+      }
     }
   `,
 }

--- a/src/components/UserDigest/Plain/index.tsx
+++ b/src/components/UserDigest/Plain/index.tsx
@@ -1,9 +1,10 @@
 import classNames from 'classnames'
 import Link from 'next/link'
+import { FormattedMessage } from 'react-intl'
 
 import { TEST_ID } from '~/common/enums'
 import { toPath } from '~/common/utils'
-import { UserDigestPlainUserFragment } from '~/gql/graphql'
+import { UserDigestPlainUserFragment, UserState } from '~/gql/graphql'
 
 import { fragments } from './gql'
 import styles from './styles.module.css'
@@ -22,6 +23,10 @@ const Plain = ({
   onClick,
   hasUnderline,
 }: UserDigestPlainProps) => {
+  const userState = user.status?.state
+  const isArchived = userState === UserState.Archived
+  const isFrozen = userState === UserState.Frozen
+  const isInactive = isArchived || isFrozen
   const path = toPath({
     page: 'userProfile',
     userName: user.userName || '',
@@ -29,7 +34,7 @@ const Plain = ({
 
   const containerClasses = classNames({
     [styles.container]: true,
-    [styles.disabled]: disabled,
+    [styles.disabled]: disabled || isInactive,
   })
 
   const displayNameClasses = classNames({
@@ -37,10 +42,18 @@ const Plain = ({
     [styles.hasUnderline]: hasUnderline,
   })
 
-  if (disabled) {
+  if (disabled || isInactive) {
     return (
       <section className={containerClasses}>
-        <span className={displayNameClasses}>{user.displayName}</span>
+        <span className={displayNameClasses}>
+          {isFrozen ? (
+            <FormattedMessage defaultMessage="Account Frozen" id="sE2Ui3" />
+          ) : isArchived ? (
+            <FormattedMessage defaultMessage="Account Archived" id="YS8YSV" />
+          ) : (
+            user.displayName
+          )}
+        </span>
       </section>
     )
   }

--- a/src/components/UserDigest/Rich/Rich.test.tsx
+++ b/src/components/UserDigest/Rich/Rich.test.tsx
@@ -75,6 +75,33 @@ describe('<UserDigest.Rich>', () => {
     expect(handleClick).not.toBeCalled()
   })
 
+  it('should hide original identity for a frozen user', () => {
+    const handleClick = vi.fn()
+
+    render(
+      <UserDigest.Rich
+        user={{
+          ...MOCK_USER,
+          status: { ...MOCK_USER.status, state: UserState.Frozen },
+        }}
+        onClick={handleClick}
+      />
+    )
+
+    const $displayName = screen.getByTestId(
+      TEST_ID.DIGEST_USER_RICH_DISPLAY_NAME
+    )
+    expect($displayName).toHaveTextContent('Account Frozen')
+    expect(screen.queryByText(MOCK_USER.displayName)).not.toBeInTheDocument()
+    expect(
+      screen.queryByText(MOCK_USER.info.description)
+    ).not.toBeInTheDocument()
+
+    fireEvent.click($displayName)
+    expect(mockRouter.asPath).not.toContain(MOCK_USER.userName)
+    expect(handleClick).not.toBeCalled()
+  })
+
   it('should render a UserDigest.Rich with or w/o follow buttons', () => {
     // hide follow button if viewer is the user
     render(<UserDigest.Rich user={MOCK_USER} hasFollow />)

--- a/src/components/UserDigest/Rich/index.tsx
+++ b/src/components/UserDigest/Rich/index.tsx
@@ -12,6 +12,7 @@ import { FollowUserButton } from '~/components/Buttons/FollowUser'
 import {
   UserDigestRichUserPrivateFragment,
   UserDigestRichUserPublicFragment,
+  UserState,
 } from '~/gql/graphql'
 
 import { fragments } from './gql'
@@ -56,20 +57,23 @@ const Rich = ({
 }: UserDigestRichProps) => {
   const { visuallyHiddenProps } = useVisuallyHidden()
 
-  const isArchived = user?.status?.state === 'archived'
+  const userState = user?.status?.state
+  const isArchived = userState === UserState.Archived
+  const isFrozen = userState === UserState.Frozen
+  const isInactive = isArchived || isFrozen
   const containerClasses = classNames({
     [styles.container]: true,
     [styles[`size${capitalizeFirstLetter(size)}`]]: !!size,
-    [styles.disabled]: isArchived,
+    [styles.disabled]: isInactive,
   })
 
   const contentClasses = classNames({
     [styles.content]: true,
     [styles.hasExtraButton]: hasFollow || !!extraButton,
-    [styles.archived]: isArchived,
+    [styles.archived]: isInactive,
   })
 
-  if (isArchived || !user) {
+  if (isInactive || !user) {
     return (
       <Card
         spacing={[12, 12]}
@@ -90,10 +94,17 @@ const Rich = ({
                 data-test-id={TEST_ID.DIGEST_USER_RICH_DISPLAY_NAME}
               >
                 {user ? (
-                  <FormattedMessage
-                    defaultMessage="Account Archived"
-                    id="YS8YSV"
-                  />
+                  isFrozen ? (
+                    <FormattedMessage
+                      defaultMessage="Account Frozen"
+                      id="sE2Ui3"
+                    />
+                  ) : (
+                    <FormattedMessage
+                      defaultMessage="Account Archived"
+                      id="YS8YSV"
+                    />
+                  )
                 ) : (
                   <FormattedMessage
                     defaultMessage="Anonymous User"

--- a/src/views/User/UserProfile/AsideUserProfile/index.tsx
+++ b/src/views/User/UserProfile/AsideUserProfile/index.tsx
@@ -22,7 +22,7 @@ import {
   useRoute,
   ViewerContext,
 } from '~/components'
-import { UserProfileUserPublicQuery } from '~/gql/graphql'
+import { UserProfileUserPublicQuery, UserState } from '~/gql/graphql'
 
 import { BadgeGrandDialog } from '../BadgeGrandDialog'
 import { BadgeNomadDialog } from '../BadgeNomadDialog'
@@ -136,8 +136,9 @@ export const AsideUserProfile = () => {
 
   const userState = user.status?.state as string
   const isCivicLiker = user.liker.civicLiker
-  const isUserArchived = userState === 'archived'
-  const isUserInactive = isUserArchived
+  const isUserArchived = userState === UserState.Archived
+  const isUserFrozen = userState === UserState.Frozen
+  const isUserInactive = isUserArchived || isUserFrozen
 
   /**
    * Inactive User
@@ -156,6 +157,9 @@ export const AsideUserProfile = () => {
             <h1 className={styles.name}>
               {isUserArchived && (
                 <FormattedMessage defaultMessage="Deleted user" id="9J0iCw" />
+              )}
+              {isUserFrozen && (
+                <FormattedMessage defaultMessage="Frozen user" id="MeqJEO" />
               )}
             </h1>
           </section>

--- a/src/views/User/UserProfile/Inactive.tsx
+++ b/src/views/User/UserProfile/Inactive.tsx
@@ -2,10 +2,13 @@ import { FormattedMessage } from 'react-intl'
 
 import IMAGE_COVER from '@/public/static/images/profile-cover.png'
 import { Avatar, Cover, Media } from '~/components'
+import { UserState } from '~/gql/graphql'
 
 import styles from './styles.module.css'
 
-const Inactive = () => {
+const Inactive: React.FC<{ state?: UserState | string }> = ({ state }) => {
+  const isFrozen = state === UserState.Frozen
+
   return (
     <section className={styles.userProfile}>
       <Cover fallbackCover={IMAGE_COVER.src} />
@@ -20,7 +23,11 @@ const Inactive = () => {
         <section className={styles.info}>
           <section className={styles.displayName}>
             <h1 className={styles.name}>
-              <FormattedMessage defaultMessage="Deleted user" id="9J0iCw" />
+              {isFrozen ? (
+                <FormattedMessage defaultMessage="Frozen user" id="MeqJEO" />
+              ) : (
+                <FormattedMessage defaultMessage="Deleted user" id="9J0iCw" />
+              )}
             </h1>
           </section>
         </section>

--- a/src/views/User/UserProfile/index.tsx
+++ b/src/views/User/UserProfile/index.tsx
@@ -23,7 +23,7 @@ import {
   useRoute,
   ViewerContext,
 } from '~/components'
-import { UserProfileUserPublicQuery } from '~/gql/graphql'
+import { UserProfileUserPublicQuery, UserState } from '~/gql/graphql'
 
 import UserTabs from '../UserTabs'
 import { Badges } from './Badges'
@@ -129,9 +129,11 @@ export const UserProfile = () => {
   /**
    * Inactive User
    */
-  const isUserArchived = userState === 'archived'
-  if (isUserArchived) {
-    return <Inactive />
+  const isUserArchived = userState === UserState.Archived
+  const isUserFrozen = userState === UserState.Frozen
+  const isUserInactive = isUserArchived || isUserFrozen
+  if (isUserInactive) {
+    return <Inactive state={userState} />
   }
 
   /**


### PR DESCRIPTION
## Summary\n- show frozen accounts as inactive on user profile surfaces\n- hide original display name/user name/avatar identity in shared UserDigest components\n- add frozen-user coverage for Mini, Plain, and Rich digests\n\n## Checks\n- npm run gen:type\n- npm run i18n\n- npm run lint:ts\n- npm run lint:css\n- npm run test:unit -- src/components/UserDigest/Mini/Mini.test.tsx src/components/UserDigest/Plain/Plain.test.tsx src/components/UserDigest/Rich/Rich.test.tsx\n- npm run build\n\n## Notes\n- Unit tests pass with existing next-router-mock act warnings.\n- Build passes with existing PWA sourcemap precache size warning and browserslist age warning.