### PR TITLE
fix(i18n): 凍結用戶標示補繁中／簡中翻譯

### DIFF
--- a/lang/zh-Hans.json
+++ b/lang/zh-Hans.json
@@ -1669,7 +1669,7 @@
     "description": "src/components/Dialogs/AddWalletLoginDialog/Content.tsx"
   },
   "MeqJEO": {
-    "defaultMessage": "Frozen user"
+    "defaultMessage": "已冻结用户"
   },
   "Mgl1bT": {
     "defaultMessage": "应用授权"
@@ -3622,7 +3622,7 @@
     "defaultMessage": "作品已成功发布，稍后将同步到 IPFS"
   },
   "sE2Ui3": {
-    "defaultMessage": "Account Frozen"
+    "defaultMessage": "账号已冻结"
   },
   "sFJ/Is": {
     "defaultMessage": "确认清空当前编辑的内容吗？"

--- a/lang/zh-Hant.json
+++ b/lang/zh-Hant.json
@@ -1669,7 +1669,7 @@
     "description": "src/components/Dialogs/AddWalletLoginDialog/Content.tsx"
   },
   "MeqJEO": {
-    "defaultMessage": "Frozen user"
+    "defaultMessage": "已凍結用戶"
   },
   "Mgl1bT": {
     "defaultMessage": "應用授權"
@@ -3622,7 +3622,7 @@
     "defaultMessage": "已成功發布作品，稍後同步到 IPFS"
   },
   "sE2Ui3": {
-    "defaultMessage": "Account Frozen"
+    "defaultMessage": "帳號已凍結"
   },
   "sFJ/Is": {
     "defaultMessage": "確認清空當前編輯的内容嗎？"


### PR DESCRIPTION
## 為什麼

#5988（frozen-user identity redaction）新增的兩個前台凍結標示在 zh-Hant/zh-Hans
仍是英文預設值，凍結帳號的中文站點會看到英文 "Account Frozen" / "Frozen user"。

## 改了什麼

| id | 來源 | 繁體 | 簡體 | 出現位置 |
| --- | --- | --- | --- | --- |
| `sE2Ui3` | Account Frozen | 帳號已凍結 | 账号已冻结 | UserDigest Mini/Plain/Rich（取代凍結用戶識別） |
| `MeqJEO` | Frozen user | 已凍結用戶 | 已冻结用户 | UserProfile Inactive（凍結用戶個人頁） |

用詞與既有 archived 標示「已註銷用戶 / 已注销用户」（`9J0iCw`）風格對齊。

`compiled-lang` 為 gitignored，build/CI 會重新 compile，故只改 `lang/{zh-Hant,zh-Hans}.json`，
不動 source `defaultMessage`、不需 i18n:extract。

## 背景

搭配 matters-server PR #4879（集團凍結改設 `state='frozen'`）——被 ring 凍的帳號現在會落在
`frozen` 狀態，吃到上述前台「凍結」標示與本翻譯。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
