### PR TITLE
feat(notice): show '已凍結用戶' for frozen actors in notices (mirror archived)

### DIFF
--- a/src/components/Notice/NoticeActorName.tsx
+++ b/src/components/Notice/NoticeActorName.tsx
@@ -18,11 +18,21 @@ const NoticeActorName = ({
   }
 
   const isArchived = user?.status?.state === 'archived'
+  const isFrozen = user?.status?.state === 'frozen'
 
   if (isArchived) {
     return (
       <span className={styles.archivedDisplayname}>
         <FormattedMessage defaultMessage="Account Archived" id="YS8YSV" />
+      </span>
+    )
+  }
+
+  // frozen actors are redacted in notices, mirroring the archived case
+  if (isFrozen) {
+    return (
+      <span className={styles.archivedDisplayname}>
+        <FormattedMessage defaultMessage="Frozen user" id="MeqJEO" />
       </span>
     )
   }


### PR DESCRIPTION
## #3 (通知處): frozen accounts in notices

You asked: when a comment-notification surfaces an account that's **frozen**, it should read as a frozen account — like the existing **archived** mode ("已註銷用戶").

`NoticeActorName` already redacts archived actors (`status.state === 'archived'` → "Account Archived" / 已註銷用戶). This adds the parallel **frozen** case → "Frozen user" (`MeqJEO`) which is already translated to **已凍結用戶** (the exact parallel of 已註銷用戶), reusing the `archivedDisplayname` style. No fragment change (`status.state` already selected).

> Note: the user-page / digest 'Account Frozen' redaction (#5988) + zh (#5989) are on develop but **not yet on prod** — this all reaches matters.town only on the next matters-web release (develop→master).

🤖 Generated with [Claude Code](https://claude.com/claude-code)