### PR TITLE
chore(bump): 6.11.3 — unblock prod release/deploy (v6.11.2 tag already exists)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matters-web",
-  "version": "6.11.2",
+  "version": "6.11.3",
   "description": "codebase of Matters' website",
   "author": "Matters <hi@matters.town>",
   "engines": {


### PR DESCRIPTION
#5992 merged the frozen UI to master, but **Create Release failed**: `Validation Failed: {resource: Release, code: already_exists, field: tag_name}` for **v6.11.2**. master's package.json was still 6.11.2 and the v6.11.2 tag exists (leftover from the 6/17 release that was reverted). No tag → no release → **no prod deploy**.

Bump 6.11.2 → **6.11.3** so Create Release tags v6.11.3 and the production deploy runs (shipping the frozen UI already on master). One-line change, mirrors the previous `chore(bump)` convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)