### PR TITLE
feat(web-next): show frozen state on user profile (release/next)

### DIFF
--- a/lang/default.json
+++ b/lang/default.json
@@ -1558,6 +1558,9 @@
     "defaultMessage": "Connect wallet",
     "description": "src/components/Dialogs/AddWalletLoginDialog/Content.tsx"
   },
+  "MeqJEO": {
+    "defaultMessage": "Frozen user"
+  },
   "Mgl1bT": {
     "defaultMessage": "OAuth authorize"
   },

--- a/lang/en.json
+++ b/lang/en.json
@@ -1558,6 +1558,9 @@
     "defaultMessage": "Connect wallet",
     "description": "src/components/Dialogs/AddWalletLoginDialog/Content.tsx"
   },
+  "MeqJEO": {
+    "defaultMessage": "Frozen user"
+  },
   "Mgl1bT": {
     "defaultMessage": "OAuth authorize"
   },

--- a/lang/zh-Hans.json
+++ b/lang/zh-Hans.json
@@ -1558,6 +1558,9 @@
     "defaultMessage": "绑定钱包",
     "description": "src/components/Dialogs/AddWalletLoginDialog/Content.tsx"
   },
+  "MeqJEO": {
+    "defaultMessage": "已冻结用户"
+  },
   "Mgl1bT": {
     "defaultMessage": "应用授权"
   },

--- a/lang/zh-Hant.json
+++ b/lang/zh-Hant.json
@@ -1558,6 +1558,9 @@
     "defaultMessage": "綁定錢包",
     "description": "src/components/Dialogs/AddWalletLoginDialog/Content.tsx"
   },
+  "MeqJEO": {
+    "defaultMessage": "已凍結用戶"
+  },
   "Mgl1bT": {
     "defaultMessage": "應用授權"
   },

--- a/src/views/User/UserProfile/Inactive.tsx
+++ b/src/views/User/UserProfile/Inactive.tsx
@@ -5,7 +5,8 @@ import { Avatar, Cover, Media } from '~/components'
 
 import styles from './styles.module.css'
 
-const Inactive = () => {
+const Inactive = ({ state }: { state?: string }) => {
+  const isFrozen = state === 'frozen'
   return (
     <section className={styles.userProfile}>
       <Cover fallbackCover={IMAGE_COVER.src} />
@@ -20,7 +21,11 @@ const Inactive = () => {
         <section className={styles.info}>
           <section className={styles.displayName}>
             <h1 className={styles.name}>
-              <FormattedMessage defaultMessage="Deleted user" id="9J0iCw" />
+              {isFrozen ? (
+                <FormattedMessage defaultMessage="Frozen user" id="MeqJEO" />
+              ) : (
+                <FormattedMessage defaultMessage="Deleted user" id="9J0iCw" />
+              )}
             </h1>
           </section>
         </section>

--- a/src/views/User/UserProfile/index.tsx
+++ b/src/views/User/UserProfile/index.tsx
@@ -127,8 +127,9 @@ export const UserProfile = () => {
    * Inactive User
    */
   const isUserArchived = userState === 'archived'
-  if (isUserArchived) {
-    return <Inactive />
+  const isUserFrozen = userState === 'frozen'
+  if (isUserArchived || isUserFrozen) {
+    return <Inactive state={userState} />
   }
 
   /**


### PR DESCRIPTION
## 問題
`web-next.matters.town` 跑的是 **release/next** 分支,它的 `UserProfile` 只判斷 `archived`、**不認 `frozen`** → 被凍結的帳號(例如剛凍的 spam 集團成員)在 web-next 仍以**正常個人頁**渲染、把 spam 文章全部露出來。master(matters.town)早有 frozen UI(#5988/#5992),但 release/next 落後 master 203 個 commit、沒帶到。

## 修法(針對性移植,配合 release/next 既有風格用字串比對)
- `UserProfile/index.tsx`:`frozen` 也視為 inactive → `return <Inactive state={userState} />`
- `Inactive.tsx`:接受 `state`,frozen 顯示「Frozen user / 已凍結用戶」(MeqJEO),否則維持「Deleted user」
- `lang/*`:補 MeqJEO(繁『已凍結用戶』/簡/英)

效果:web-next 上被凍結帳號的個人頁不再露出 spam,改顯示已凍結。

> 註:這只是把 frozen 個人頁判斷補到 release/next;master 端已具備。release/next 與 master 分歧大(WIP web-next 遷移),完整 frozen UX(digest/notice 等)可後續再對齊。

🤖 Generated with [Claude Code](https://claude.com/claude-code)