### PR TITLE
chore(campaign): point quote-wall see-all to museum #memo-wall anchor

### DIFF
--- a/src/common/enums/externalLinks.ts
+++ b/src/common/enums/externalLinks.ts
@@ -14,7 +14,8 @@ export const EXTERNAL_LINKS = {
     isProd
       ? `https://liker.land/${likerId}/civic?utm_source=Matters`
       : `https://rinkeby.liker.land/${likerId}/civic?utm_source=Matters`,
-  SEVEN_DAY_BOOK_QUOTE_WALL: 'https://freewriting.matters.town/museum/memo-wall/',
+  SEVEN_DAY_BOOK_QUOTE_WALL:
+    'https://freewriting.matters.town/museum/#memo-wall',
   PLANET: 'https://www.planetable.xyz/',
   ENS_DOCS: 'https://docs.ens.domains/',
   METAMASK: 'https://metamask.io/download/',


### PR DESCRIPTION
The museum memo wall moved from its own page (`/museum/memo-wall/`) to an anchor section on the museum page (`/museum/#memo-wall`). Updates `EXTERNAL_LINKS.SEVEN_DAY_BOOK_QUOTE_WALL` — one-constant change, covers both the quote-wall 'See all quotes' pill and the in-app dialog museum link.

Verified live: `freewriting.matters.town/museum/` renders the 金句牆 section with a `#memo-wall` nav anchor.

eslint OK / tsc OK (after gen:type).