### PR TITLE
fix(campaign): order the quote-wall band newest-first

### DIFF
--- a/src/views/CampaignDetail/QuoteWall/index.tsx
+++ b/src/views/CampaignDetail/QuoteWall/index.tsx
@@ -31,7 +31,9 @@ const QuoteWall = ({ shortHash, entry = 'module' }: QuoteWallProps) => {
 
   const { data } = usePublicQuery<CampaignQuotesQuery>(
     CAMPAIGN_QUOTES,
-    { variables: { shortHash, first: PREVIEW_COUNT, random: true } },
+    // newest-first: show the most recently posted quotes (random off → the
+    // backend orders by id desc)
+    { variables: { shortHash, first: PREVIEW_COUNT, random: false } },
     { publicQuery: !viewer.isAuthed }
   )
 


### PR DESCRIPTION
The activity-page quote-wall **band** was fetching a random sample (`random: true`), so quotes appeared in random order. Switch to `random: false` — the backend then orders by `id desc`, so the **most recently posted quote shows first**.

Single change in `QuoteWall/index.tsx` (band query). The in-app wall dialog keeps its own shuffle behaviour; only the band changes.

eslint / prettier / tsc ✓.