### PR TITLE
fix(web-next): repair release/next tsc baseline to unblock build

### DIFF
--- a/src/common/utils/route.ts
+++ b/src/common/utils/route.ts
@@ -48,7 +48,15 @@ interface CampaignStageArgs {
 
 interface CommentArgs {
   id: string
-  type: 'article' | 'circleDiscussion' | 'circleBroadcast' | 'moment' // comment type: article/discussion/broadcast
+  // comment type; mirrors GraphQL CommentType. campaignDiscussion has no
+  // dedicated comment route yet, so toPath's commentDetail switch leaves it
+  // unhandled (falls through) until that feature lands.
+  type:
+    | 'article'
+    | 'circleDiscussion'
+    | 'circleBroadcast'
+    | 'moment'
+    | 'campaignDiscussion'
   parentComment?: {
     id: string
   } | null

--- a/src/components/Dialogs/SubmitReportDialog/Dialog.tsx
+++ b/src/components/Dialogs/SubmitReportDialog/Dialog.tsx
@@ -54,7 +54,9 @@ interface FormValues {
 const SubmitReportDialog = ({ id, children }: SubmitReportDialogProps) => {
   const { show, openDialog, closeDialog: _closeDialog } = useDialogSwitch(true)
   const formId = useId()
-  const order = [
+  // only the user-facing reasons; internal reasons (e.g. CommunityWatchPornAd)
+  // are intentionally excluded from the public report dialog
+  const order: Array<keyof typeof Reasons> = [
     ReportReason.Tort,
     ReportReason.DiscriminationInsultHatred,
     ReportReason.PornographyInvolvingMinors,

--- a/src/stories/mocks/index.ts
+++ b/src/stories/mocks/index.ts
@@ -75,6 +75,7 @@ export const MOCK_USER = {
   isFollower: false,
   isFollowee: false,
   isBlocking: false,
+  isMomentFeedApplied: false,
 }
 
 // Circle


### PR DESCRIPTION
## 問題

`release/next` 的 build 從新 schema 欄位落地後就在 tsc 卡住(#5994 等所有 web-next PR 的 build 都被擋)。失敗全是既有 baseline 型別漂移,與各 PR 自身無關。

## 三個真正的破口(已修)

1. **`route.ts`** — `CommentType` enum 多了 `CampaignDiscussion`,但 `CommentArgs['type']` union 沒跟著加寬 → 一整面牆的 `CommentType is not assignable`。加上 `'campaignDiscussion'`。(campaignDiscussion 尚無留言路由,`toPath` 的 commentDetail switch 維持不處理、fall through。)
2. **`SubmitReportDialog/Dialog.tsx`** — `ReportReason` 多了內部用的 `CommunityWatchPornAd`,index `Reasons[reason]` 型別炸。把顯示用的 `order` 標成 `Array<keyof typeof Reasons>`,公開檢舉對話框只列 5 個使用者可見理由,內部理由不進 UI。
3. **`stories/mocks/index.ts`** — `ViewerUserPrivateFragment` 新增必填 `isMomentFeedApplied`,共用 `MOCK_USER` 沒有 → 6 個 viewer 相關測試 typecheck 失敗。補上欄位。

## 驗證

- 乾淨 `npm run lint:ts`(`tsc --noEmit && next lint`)→ **green**(先清掉 stale `tsconfig.tsbuildinfo`;先前本機殘留的 4 個 Circle 錯是增量快取幻影,CI fresh build 不會有)。
- codegen 重跑確認 `graphql.ts` 無需變更。

## 影響

解鎖 #5994(web-next 個人頁 frozen 標示)以及所有 web-next 部署。純型別修補,無行為變更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)