### PR TITLE
fix: disable frozen-author article links

### DIFF
--- a/src/components/ArticleDigest/Dropdown/Dropdown.test.tsx
+++ b/src/components/ArticleDigest/Dropdown/Dropdown.test.tsx
@@ -4,7 +4,19 @@ import { describe, expect, it, vi } from 'vitest'
 import { TEST_ID } from '~/common/enums'
 import { fireEvent, render, screen } from '~/common/utils/test'
 import { ArticleDigestDropdown } from '~/components'
+import { UserState } from '~/gql/graphql'
 import { MOCK_ARTILCE } from '~/stories/mocks'
+
+const MOCK_FROZEN_AUTHOR_ARTICLE = {
+  ...MOCK_ARTILCE,
+  author: {
+    ...MOCK_ARTILCE.author,
+    status: {
+      ...MOCK_ARTILCE.author.status,
+      state: UserState.Frozen,
+    },
+  },
+}
 
 describe('<ArticleDigest.Dropdown>', () => {
   it('should render an ArticleDigest.Dropdown', () => {
@@ -52,6 +64,24 @@ describe('<ArticleDigest.Dropdown>', () => {
     expect($author).toBeInTheDocument()
 
     fireEvent.click($digest)
+    expect(mockRouter.asPath).not.toContain(MOCK_ARTILCE.shortHash)
+    expect(handleClickDigest).not.toHaveBeenCalled()
+  })
+
+  it('should not link to articles by frozen authors', () => {
+    mockRouter.setCurrentUrl('/')
+    const handleClickDigest = vi.fn()
+
+    render(
+      <ArticleDigestDropdown
+        article={MOCK_FROZEN_AUTHOR_ARTICLE}
+        onClick={handleClickDigest}
+      />
+    )
+
+    const $digest = screen.getByTestId(TEST_ID.DIGEST_ARTICLE_DROPDOWN)
+    fireEvent.click($digest)
+
     expect(mockRouter.asPath).not.toContain(MOCK_ARTILCE.shortHash)
     expect(handleClickDigest).not.toHaveBeenCalled()
   })

--- a/src/components/ArticleDigest/Dropdown/index.tsx
+++ b/src/components/ArticleDigest/Dropdown/index.tsx
@@ -13,6 +13,7 @@ import {
   ArticleDigestTitleIs,
   ArticleDigestTitleTextSize,
   ArticleDigestTitleTextWeight,
+  isArticleAuthorFrozen,
 } from '../Title'
 import styles from './styles.module.css'
 
@@ -72,6 +73,7 @@ export const ArticleDigestDropdown = ({
 }: ArticleDigestDropdownProps) => {
   const { articleState: state } = article
   const isBanned = state === 'banned'
+  const isAuthorFrozen = isArticleAuthorFrozen(article)
   const containerClasses = classNames({
     [styles.container]: true,
     [styles.hasExtraButton]: !!extraButton,
@@ -80,7 +82,7 @@ export const ArticleDigestDropdown = ({
     page: 'articleDetail',
     article,
   })
-  const cardDisabled = isBanned || disabled
+  const cardDisabled = isBanned || isAuthorFrozen || disabled
 
   return (
     <Card

--- a/src/components/ArticleDigest/Feed/Feed.test.tsx
+++ b/src/components/ArticleDigest/Feed/Feed.test.tsx
@@ -4,8 +4,19 @@ import { describe, expect, it, vi } from 'vitest'
 import { TEST_ID } from '~/common/enums'
 import { fireEvent, render, screen } from '~/common/utils/test'
 import { ArticleDigestFeed } from '~/components'
-import { ArticleState } from '~/gql/graphql'
+import { ArticleState, UserState } from '~/gql/graphql'
 import { MOCK_ARTILCE } from '~/stories/mocks'
+
+const MOCK_FROZEN_AUTHOR_ARTICLE = {
+  ...MOCK_ARTILCE,
+  author: {
+    ...MOCK_ARTILCE.author,
+    status: {
+      ...MOCK_ARTILCE.author.status,
+      state: UserState.Frozen,
+    },
+  },
+}
 
 describe('ArticleDigest.Feed', () => {
   describe('Rendering', () => {
@@ -83,6 +94,30 @@ describe('ArticleDigest.Feed', () => {
       // Assert
       const cover = screen.queryByTestId(TEST_ID.DIGEST_ARTICLE_FEED_COVER)
       expect(cover).not.toBeInTheDocument()
+    })
+
+    it('should not render article links for frozen authors', () => {
+      // Arrange
+      mockRouter.setCurrentUrl('/')
+      const handleClickDigest = vi.fn()
+      render(
+        <ArticleDigestFeed
+          article={MOCK_FROZEN_AUTHOR_ARTICLE}
+          onClick={handleClickDigest}
+        />
+      )
+
+      // Act
+      const title = screen.getByRole('heading', { name: MOCK_ARTILCE.title })
+      fireEvent.click(title)
+
+      // Assert
+      expect(mockRouter.asPath).not.toContain(MOCK_ARTILCE.shortHash)
+      expect(handleClickDigest).not.toHaveBeenCalled()
+      expect(screen.queryByText(MOCK_ARTILCE.summary)).not.toBeInTheDocument()
+      expect(
+        screen.queryByTestId(TEST_ID.DIGEST_ARTICLE_FEED_COVER)
+      ).not.toBeInTheDocument()
     })
   })
 

--- a/src/components/ArticleDigest/Feed/index.tsx
+++ b/src/components/ArticleDigest/Feed/index.tsx
@@ -11,7 +11,7 @@ import {
   ArticleDigestFeedArticlePublicFragment,
 } from '~/gql/graphql'
 
-import { ArticleDigestTitle } from '../Title'
+import { ArticleDigestTitle, isArticleAuthorFrozen } from '../Title'
 import FooterActions, { FooterActionsProps } from './FooterActions'
 import { fragments } from './gql'
 import Placeholder from './Placeholder'
@@ -56,9 +56,14 @@ const BaseArticleDigestFeed = ({
   const { author, summary } = article
   const isBanned = article.articleState === 'banned'
   const isArchived = article.articleState === 'archived'
-  const cover = !isBanned && !isArchived ? article.displayCover : null
+  const isAuthorFrozen = isArticleAuthorFrozen(article)
+  const isArticleLinkDisabled = isBanned || isAuthorFrozen
+  const cover =
+    !isBanned && !isArchived && !isAuthorFrozen ? article.displayCover : null
   const cleanedSummary =
-    isBanned && !isArchived ? '' : makeSummary(summary, MAX_FEED_SUMMARY_LENGTH)
+    isBanned || isAuthorFrozen
+      ? ''
+      : makeSummary(summary, MAX_FEED_SUMMARY_LENGTH)
 
   const path = toPath({
     page: 'articleDetail',
@@ -106,9 +111,15 @@ const BaseArticleDigestFeed = ({
             </section>
           )}
           {!excludesTimeStamp && (
-            <Link {...path}>
-              <DateTime date={article.createdAt} color="grey" minimal />
-            </Link>
+            <>
+              {isArticleLinkDisabled ? (
+                <DateTime date={article.createdAt} color="grey" minimal />
+              ) : (
+                <Link {...path}>
+                  <DateTime date={article.createdAt} color="grey" minimal />
+                </Link>
+              )}
+            </>
           )}
         </header>
       )}
@@ -123,14 +134,21 @@ const BaseArticleDigestFeed = ({
                 lineClamp={2}
                 onClick={onClick}
                 disabledArchived={disabledArchived}
+                disabled={isAuthorFrozen}
               />
             </section>
           </section>
 
           {!(isArchived && disabledArchived) && (
-            <Link {...path} onClick={onClick}>
-              <p className={styles.description}>{cleanedSummary}</p>
-            </Link>
+            <>
+              {isArticleLinkDisabled ? (
+                <p className={styles.description}>{cleanedSummary}</p>
+              ) : (
+                <Link {...path} onClick={onClick}>
+                  <p className={styles.description}>{cleanedSummary}</p>
+                </Link>
+              )}
+            </>
           )}
 
           <Media greaterThanOrEqual="md">{footerActions}</Media>

--- a/src/components/ArticleDigest/List/List.test.tsx
+++ b/src/components/ArticleDigest/List/List.test.tsx
@@ -4,7 +4,19 @@ import { describe, expect, it, vi } from 'vitest'
 import { TEST_ID } from '~/common/enums'
 import { fireEvent, render, screen } from '~/common/utils/test'
 import { ArticleDigestList } from '~/components'
+import { UserState } from '~/gql/graphql'
 import { MOCK_ARTILCE } from '~/stories/mocks'
+
+const MOCK_FROZEN_AUTHOR_ARTICLE = {
+  ...MOCK_ARTILCE,
+  author: {
+    ...MOCK_ARTILCE.author,
+    status: {
+      ...MOCK_ARTILCE.author.status,
+      state: UserState.Frozen,
+    },
+  },
+}
 
 describe('<ArticleDigest.List>', () => {
   it('should render an ArticleDigest.List', () => {
@@ -26,5 +38,23 @@ describe('<ArticleDigest.List>', () => {
     fireEvent.click($digest)
     expect(mockRouter.asPath).toContain(MOCK_ARTILCE.shortHash)
     expect(handleClickDigest).toHaveBeenCalled()
+  })
+
+  it('should not link to articles by frozen authors', () => {
+    mockRouter.setCurrentUrl('/')
+    const handleClickDigest = vi.fn()
+
+    render(
+      <ArticleDigestList
+        article={MOCK_FROZEN_AUTHOR_ARTICLE}
+        onClick={handleClickDigest}
+      />
+    )
+
+    const $digest = screen.getByTestId(TEST_ID.DIGEST_ARTICLE_LIST)
+    fireEvent.click($digest)
+
+    expect(mockRouter.asPath).not.toContain(MOCK_ARTILCE.shortHash)
+    expect(handleClickDigest).not.toHaveBeenCalled()
   })
 })

--- a/src/components/ArticleDigest/List/index.tsx
+++ b/src/components/ArticleDigest/List/index.tsx
@@ -11,7 +11,7 @@ import {
   UserDigestMiniUserFragment,
 } from '~/gql/graphql'
 
-import { ArticleDigestTitle } from '../Title'
+import { ArticleDigestTitle, isArticleAuthorFrozen } from '../Title'
 import styles from './styles.module.css'
 
 export type ArticleDigestListProps = {
@@ -50,6 +50,7 @@ export const ArticleDigestList = ({
   right,
 }: ArticleDigestListProps) => {
   const { author } = article
+  const isAuthorFrozen = isArticleAuthorFrozen(article)
 
   const path = toPath({
     page: 'articleDetail',
@@ -67,10 +68,10 @@ export const ArticleDigestList = ({
 
   return (
     <Card
-      {...path}
+      href={isAuthorFrozen ? undefined : path.href}
       spacing={[0, 0]}
       bgActiveColor="none"
-      onClick={onClick}
+      onClick={isAuthorFrozen ? undefined : onClick}
       testId={TEST_ID.DIGEST_ARTICLE_LIST}
     >
       <section className={styles.container}>
@@ -88,6 +89,7 @@ export const ArticleDigestList = ({
               textSize={14}
               textWeight="normal"
               lineClamp={1}
+              disabled={isAuthorFrozen}
             />
           </section>
 

--- a/src/components/ArticleDigest/Notice/index.tsx
+++ b/src/components/ArticleDigest/Notice/index.tsx
@@ -6,7 +6,11 @@ import { toPath } from '~/common/utils'
 import { Card } from '~/components'
 import { ArticleDigestNoticeArticleFragment } from '~/gql/graphql'
 
-import { ArticleDigestTitle, ArticleDigestTitleTextSize } from '../Title'
+import {
+  ArticleDigestTitle,
+  ArticleDigestTitleTextSize,
+  isArticleAuthorFrozen,
+} from '../Title'
 import styles from './styles.module.css'
 
 export type ArticleDigestNoticeProps = {
@@ -30,6 +34,7 @@ export const ArticleDigestNotice = ({
   titleTextSize = 16,
 }: ArticleDigestNoticeProps) => {
   const { summary } = article
+  const isAuthorFrozen = isArticleAuthorFrozen(article)
 
   const containerClasses = classNames({
     [styles.container]: true,
@@ -40,7 +45,11 @@ export const ArticleDigestNotice = ({
   })
 
   return (
-    <Card {...path} spacing={[0, 0]} bgColor="none">
+    <Card
+      href={isAuthorFrozen ? undefined : path.href}
+      spacing={[0, 0]}
+      bgColor="none"
+    >
       <section
         className={containerClasses}
         data-test-id={TEST_ID.DIGEST_ARTICLE_NOTICE}
@@ -51,6 +60,7 @@ export const ArticleDigestNotice = ({
             textSize={titleTextSize}
             is="h3"
             lineClamp={1}
+            disabled={isAuthorFrozen}
           />
         </header>
 

--- a/src/components/ArticleDigest/NoticeCard/index.tsx
+++ b/src/components/ArticleDigest/NoticeCard/index.tsx
@@ -6,7 +6,11 @@ import { toPath } from '~/common/utils'
 import { Card, Icon } from '~/components'
 import { ArticleDigestNoticeArticleFragment } from '~/gql/graphql'
 
-import { ArticleDigestTitle, ArticleDigestTitleTextSize } from '../Title'
+import {
+  ArticleDigestTitle,
+  ArticleDigestTitleTextSize,
+  isArticleAuthorFrozen,
+} from '../Title'
 import styles from './styles.module.css'
 
 export type ArticleDigestNoticeCardProps = {
@@ -35,6 +39,7 @@ export const ArticleDigestNoticeCard = ({
   hasIcon = true,
   hasBorder = false,
 }: ArticleDigestNoticeCardProps) => {
+  const isAuthorFrozen = isArticleAuthorFrozen(article)
   const containerClasses = classNames({
     [styles.container]: true,
     [styles.black]: color === 'black',
@@ -46,7 +51,11 @@ export const ArticleDigestNoticeCard = ({
   })
 
   return (
-    <Card {...path} spacing={[0, 0]} bgColor="none">
+    <Card
+      href={isAuthorFrozen ? undefined : path.href}
+      spacing={[0, 0]}
+      bgColor="none"
+    >
       <section className={containerClasses}>
         {hasIcon && <Icon icon={IconDraft} size={16} />}
         <ArticleDigestTitle
@@ -55,6 +64,7 @@ export const ArticleDigestNoticeCard = ({
           textWeight="normal"
           is="h3"
           lineClamp={1}
+          disabled={isAuthorFrozen}
         />
       </section>
     </Card>

--- a/src/components/ArticleDigest/Title/Title.test.tsx
+++ b/src/components/ArticleDigest/Title/Title.test.tsx
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest'
 
 import { fireEvent, render, screen } from '~/common/utils/test'
 import { ArticleDigestTitle } from '~/components'
+import { UserState } from '~/gql/graphql'
 import { MOCK_ARTILCE } from '~/stories/mocks'
 
 describe('<ArticleDigest.Title>', () => {
@@ -51,6 +52,30 @@ describe('<ArticleDigest.Title>', () => {
         onClick={handleClickDigest}
       />
     )
+    const $title = screen.getByRole('heading', {
+      name: MOCK_ARTILCE.title,
+    })
+
+    fireEvent.click($title)
+    expect(mockRouter.asPath).not.toContain(MOCK_ARTILCE.shortHash)
+    expect(handleClickDigest).not.toHaveBeenCalled()
+  })
+
+  it('should not link to articles by frozen authors', () => {
+    mockRouter.setCurrentUrl('/')
+    const handleClickDigest = vi.fn()
+    const article = {
+      ...MOCK_ARTILCE,
+      author: {
+        ...MOCK_ARTILCE.author,
+        status: {
+          ...MOCK_ARTILCE.author.status,
+          state: UserState.Frozen,
+        },
+      },
+    }
+
+    render(<ArticleDigestTitle article={article} onClick={handleClickDigest} />)
     const $title = screen.getByRole('heading', {
       name: MOCK_ARTILCE.title,
     })

--- a/src/components/ArticleDigest/Title/index.tsx
+++ b/src/components/ArticleDigest/Title/index.tsx
@@ -6,7 +6,7 @@ import { FormattedMessage, useIntl } from 'react-intl'
 import { TEST_ID } from '~/common/enums'
 import { capitalizeFirstLetter, toPath } from '~/common/utils'
 import { toast } from '~/components'
-import { ArticleDigestTitleArticleFragment } from '~/gql/graphql'
+import { ArticleDigestTitleArticleFragment, UserState } from '~/gql/graphql'
 
 import styles from './styles.module.css'
 
@@ -40,10 +40,17 @@ const fragments = {
       author {
         id
         userName
+        status {
+          state
+        }
       }
     }
   `,
 }
+
+export const isArticleAuthorFrozen = (
+  article: Pick<ArticleDigestTitleArticleFragment, 'author'>
+) => article.author.status?.state === UserState.Frozen
 
 export const ArticleDigestTitle = ({
   article,
@@ -61,6 +68,7 @@ export const ArticleDigestTitle = ({
 }: ArticleDigestTitleProps) => {
   const intl = useIntl()
   const { articleState: state } = article
+  const isAuthorFrozen = isArticleAuthorFrozen(article)
   const path = toPath({
     page: 'articleDetail',
     article,
@@ -85,7 +93,7 @@ export const ArticleDigestTitle = ({
     [textColor ? styles[`textColor${capitalizeFirstLetter(textColor)}`] : '']:
       !!textColor,
   })
-  const isClickable = !disabled && !isBanned
+  const isClickable = !disabled && !isBanned && !isAuthorFrozen
 
   const titleElement = (
     <>


### PR DESCRIPTION
## Summary
- Disable ArticleDigest links when the article author is frozen.
- Remove clickable cover, title, timestamp, summary, list-card, dropdown-card, and notice-card entry points for frozen-author articles.
- Hide digest summary and cover for frozen-author articles to reduce spam exposure.
- Add regression coverage for Title, Feed, List, and Dropdown render paths.

## SOP classification
- Path: `codex/hide-frozen-author-article-links` -> `develop` -> `master`.
- Placement: web public UI guard for frozen account moderation.
- State: Done, no feature flag. Intended to be active after merge because the frontend should not provide article links for frozen-author spam surfaces.
- Security gate: touches public navigation and frozen account handling. Keep GitHub CI and Codecov as required merge gates before promotion.

## Regression guard
- Base: `origin/develop` at `e0ce923b146bfd1baf62e677f862a32424c22556`.
- Branch commit: `0999e90fa8e76bb6e95159faee79d2c8c73601e3`.
- Behind `origin/develop`: 0 before commit.
- Changed files only:
  - `src/components/ArticleDigest/Dropdown/Dropdown.test.tsx`
  - `src/components/ArticleDigest/Dropdown/index.tsx`
  - `src/components/ArticleDigest/Feed/Feed.test.tsx`
  - `src/components/ArticleDigest/Feed/index.tsx`
  - `src/components/ArticleDigest/List/List.test.tsx`
  - `src/components/ArticleDigest/List/index.tsx`
  - `src/components/ArticleDigest/Notice/index.tsx`
  - `src/components/ArticleDigest/NoticeCard/index.tsx`
  - `src/components/ArticleDigest/Title/Title.test.tsx`
  - `src/components/ArticleDigest/Title/index.tsx`
- The diff scan only found intentional `disabled` condition changes for frozen-author link blocking. No release or sunsetting guard removal found.

## Local checks
- Passed: `npm run gen:type`
- Passed: `npx prettier --check src/components/ArticleDigest/Dropdown/Dropdown.test.tsx src/components/ArticleDigest/Dropdown/index.tsx src/components/ArticleDigest/Feed/Feed.test.tsx src/components/ArticleDigest/Feed/index.tsx src/components/ArticleDigest/List/List.test.tsx src/components/ArticleDigest/List/index.tsx src/components/ArticleDigest/Notice/index.tsx src/components/ArticleDigest/NoticeCard/index.tsx src/components/ArticleDigest/Title/Title.test.tsx src/components/ArticleDigest/Title/index.tsx`
- Passed: `npm run i18n`
- Passed: `npm run lint:css`
- Passed: `npm run lint:ts`
- Passed: `npm run test:unit -- src/components/ArticleDigest/Title/Title.test.tsx src/components/ArticleDigest/Feed/Feed.test.tsx src/components/ArticleDigest/List/List.test.tsx src/components/ArticleDigest/Dropdown/Dropdown.test.tsx`
  - 4 suites passed, 19 tests passed.
- Passed: `npm run build`
  - Existing warnings: PWA sourcemap size, `_app.getInitialProps` static optimization opt-out, and stale caniuse-lite data.
