### PR TITLE
chore: bump @matters/matters-editor to 0.3.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "matters-web",
-  "version": "6.11.1",
+  "version": "6.11.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "matters-web",
-      "version": "6.11.1",
+      "version": "6.11.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@apollo/client": "^3.13.8",
         "@artsy/fresnel": "^8.1.0",
-        "@matters/matters-editor": "^0.3.1",
+        "@matters/matters-editor": "^0.3.3",
         "@next/bundle-analyzer": "^15.3.3",
         "@sentry/nextjs": "^9.28.0",
         "@storybook/addon-styling-webpack": "^1.0.1",
@@ -6886,9 +6886,9 @@
       "license": "MIT"
     },
     "node_modules/@matters/matters-editor": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@matters/matters-editor/-/matters-editor-0.3.1.tgz",
-      "integrity": "sha512-nbiKt2sVhPUsoOzA90hd1AxKnQOmqOjP3ttKcwnB/C4RIekmVm2FINUskpHTxFvX6K+tVh5jN7eydQLSga8XMw==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@matters/matters-editor/-/matters-editor-0.3.3.tgz",
+      "integrity": "sha512-zh4WpXVblL/D6NxQqmMA1NTjIrq0CMZ6aWXVFIOPbJyUl7Ukz1nl10HIIvJLmjB/LL/UdI/ZNd7XYdWVRruI/w==",
       "license": "MIT",
       "dependencies": {
         "@tiptap/core": "2.8.0",
@@ -6938,7 +6938,7 @@
         "zeed-dom": "^0.13.3"
       },
       "engines": {
-        "node": ">=18.19 <19.0"
+        "node": ">=18.19 <25.0.0"
       },
       "peerDependencies": {
         "react": ">=17.0.0",
@@ -47336,9 +47336,9 @@
       "integrity": "sha512-+//cqVWKis//t0YH62EDtwaFSPG/CDtYNg4CZmzNmG2d5W17Iu3fuDAdpQXCDHUDrrU9q0veze4A7tPZXlR/mg=="
     },
     "@matters/matters-editor": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@matters/matters-editor/-/matters-editor-0.3.1.tgz",
-      "integrity": "sha512-nbiKt2sVhPUsoOzA90hd1AxKnQOmqOjP3ttKcwnB/C4RIekmVm2FINUskpHTxFvX6K+tVh5jN7eydQLSga8XMw==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@matters/matters-editor/-/matters-editor-0.3.3.tgz",
+      "integrity": "sha512-zh4WpXVblL/D6NxQqmMA1NTjIrq0CMZ6aWXVFIOPbJyUl7Ukz1nl10HIIvJLmjB/LL/UdI/ZNd7XYdWVRruI/w==",
       "requires": {
         "@tiptap/core": "2.8.0",
         "@tiptap/extension-blockquote": "2.8.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "@apollo/client": "^3.13.8",
     "@artsy/fresnel": "^8.1.0",
-    "@matters/matters-editor": "^0.3.1",
+    "@matters/matters-editor": "^0.3.3",
     "@next/bundle-analyzer": "^15.3.3",
     "@sentry/nextjs": "^9.28.0",
     "@storybook/addon-styling-webpack": "^1.0.1",


### PR DESCRIPTION
## Summary
- Bump `@matters/matters-editor` from `^0.3.1` to `^0.3.3` (`package.json` + `package-lock.json`, no source changes)
- Unblocks the fix landed in thematters/matters-editor#525, which had been stuck unpublished because the `NPM_AUTH_TOKEN` GitHub secret on that repo was stale (last rotated 2020-06-19, causing 404s on publish)
- Token has been rotated and the Publish workflow rerun successfully — `npm view @matters/matters-editor version` confirms `latest` is now `0.3.3`

## Test plan
- [x] `npm install @matters/matters-editor@0.3.3` — lockfile resolves to `0.3.3`, diff scoped to the two dependency files only
- [ ] `npm run lint:ts` / `next lint` — not run to a clean result in this environment: fails on pre-existing `Cannot find module '~/gql/graphql'` because the generated GraphQL types require `npm run gen:type` against a live schema, unrelated to this bump. Please confirm CI's codegen step passes lint clean.
- [ ] Smoke test the editor (article/comment/moment editors, since those are the `@matters/matters-editor` consumers) in CI/preview deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)