### PR TITLE
fix: filter restricted-author comments in public UI

### DIFF
--- a/src/common/utils/comment.test.ts
+++ b/src/common/utils/comment.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { ArticleState, CommentState } from '~/gql/graphql'
+import { ArticleState, CommentState, UserState } from '~/gql/graphql'
 import { MOCK_ARTILCE, MOCK_COMMENT } from '~/stories/mocks'
 
 import { filterComments, filterResponses } from './comment'
@@ -19,6 +19,29 @@ describe('utils/comment/filterComments', () => {
     const comments = [
       { ...MOCK_COMMENT, state: CommentState.Banned },
       { ...MOCK_COMMENT, state: CommentState.Archived },
+    ]
+    const result = filterComments(comments)
+    expect(result.length).toEqual(0)
+  })
+
+  it('should filter out comments by restricted authors', () => {
+    const comments = [
+      {
+        ...MOCK_COMMENT,
+        state: CommentState.Active,
+        author: {
+          ...MOCK_COMMENT.author,
+          status: { ...MOCK_COMMENT.author.status, state: UserState.Frozen },
+        },
+      },
+      {
+        ...MOCK_COMMENT,
+        state: CommentState.Collapsed,
+        author: {
+          ...MOCK_COMMENT.author,
+          status: { ...MOCK_COMMENT.author.status, state: UserState.Archived },
+        },
+      },
     ]
     const result = filterComments(comments)
     expect(result.length).toEqual(0)
@@ -102,8 +125,16 @@ describe('utils/comment/filterResponses', () => {
       { ...MOCK_ARTILCE, state: ArticleState.Banned },
       { ...MOCK_COMMENT, state: CommentState.Active },
       { ...MOCK_COMMENT, state: CommentState.Banned },
+      {
+        ...MOCK_COMMENT,
+        state: CommentState.Active,
+        author: {
+          ...MOCK_COMMENT.author,
+          status: { ...MOCK_COMMENT.author.status, state: UserState.Frozen },
+        },
+      },
     ]
     const result = filterResponses(responses)
-    expect(result.length).toEqual(responses.length - 1)
+    expect(result.length).toEqual(responses.length - 2)
   })
 })

--- a/src/common/utils/comment/index.ts
+++ b/src/common/utils/comment/index.ts
@@ -1,7 +1,7 @@
 import _get from 'lodash/get'
 import _has from 'lodash/has'
 
-import { CommentState } from '~/gql/graphql'
+import { CommentState, UserState } from '~/gql/graphql'
 
 import styles from './styles.module.css'
 
@@ -12,6 +12,11 @@ import styles from './styles.module.css'
  */
 interface Comment {
   state: string
+  author?: {
+    status?: {
+      state?: string | null
+    } | null
+  } | null
   communityWatchAction?: {
     uuid: string
   } | null
@@ -25,6 +30,13 @@ type Response = {
 }
 
 const filterComment = (comment: Comment) => {
+  if (
+    comment.author?.status?.state === UserState.Frozen ||
+    comment.author?.status?.state === UserState.Archived
+  ) {
+    return false
+  }
+
   // skip if comment's state is active or collapse
   if (
     comment.state === CommentState.Active ||


### PR DESCRIPTION
## Summary
- Filter comments whose author is frozen or archived in the shared public comment utility.
- Apply the same fallback to mixed article response filtering through `filterResponses`.
- Add unit coverage for frozen and archived comment authors.

## Public surface audit
- `filterComments` is used by article comments, nested article comments, moment/circle/campaign discussion surfaces, and user comment history style comment lists.
- `filterResponses` now also drops restricted-author comments when a mixed response list reaches the client.
- Server remains the authoritative enforcement PR; this web PR is a UI fallback so stale or preview data does not keep rendering spammer comments.

## SOP notes
- Branch path: feature branch -> `develop` -> `master`.
- State: Done. This is a moderation/public visibility bug fix, not a dark-launched feature.
- Regression guard: branch base equals current `origin/develop`; changed-file sentinel scan found no removed sunsetting/deprecated/hidden markers.

## Checks
- `npm run gen:type` with `GRAPHQL_SCHEMA_URL=https://server.matters.icu/graphql`
- `npm run i18n`
- `PATH=... npm run lint:css`
- `PATH=... npm run build`
- `PATH=... npx prettier --check src/common/utils/comment/index.ts src/common/utils/comment.test.ts`
- `PATH=... npm run test:unit -- src/common/utils/comment.test.ts`
- `PATH=... npm run lint:ts`
- `git diff --check`

Build warnings observed: existing Browserslist data age warning and PWA sourcemap precache size warning.