### PR TITLE
feat(quote-image): 上牆成功頁「回活動頁」＋社群分享選單

### DIFF
--- a/lang/default.json
+++ b/lang/default.json
@@ -3344,6 +3344,9 @@
     "defaultMessage": "This circle is already taken.",
     "description": "DUPLICATE_CIRCLE"
   },
+  "nBpgyU": {
+    "defaultMessage": "Quote image downloaded — attach it to your post, and share the link from the menu."
+  },
   "nGBrvw": {
     "defaultMessage": "Bookmarks"
   },

--- a/lang/default.json
+++ b/lang/default.json
@@ -3344,9 +3344,6 @@
     "defaultMessage": "This circle is already taken.",
     "description": "DUPLICATE_CIRCLE"
   },
-  "nBpgyU": {
-    "defaultMessage": "Quote image downloaded — attach it to your post, and share the link from the menu."
-  },
   "nGBrvw": {
     "defaultMessage": "Bookmarks"
   },

--- a/lang/default.json
+++ b/lang/default.json
@@ -1026,9 +1026,6 @@
     "defaultMessage": "Comment deleted",
     "description": "src/components/Notice/NoticeComment.tsx/moment"
   },
-  "Cmc/He": {
-    "defaultMessage": "On the wall ✓"
-  },
   "CnPG8j": {
     "defaultMessage": "Featured"
   },
@@ -1048,6 +1045,9 @@
   },
   "D+uyeZ": {
     "defaultMessage": "Unsubscribe circle will immediately lose your membership, The next billing date (the 1st of each month) will not incur any charges."
+  },
+  "D0pP8T": {
+    "defaultMessage": "Go to the event page"
   },
   "D3idYv": {
     "defaultMessage": "Settings"
@@ -1267,6 +1267,9 @@
     "defaultMessage": "Image",
     "description": "src/components/Editor"
   },
+  "GGd44x": {
+    "defaultMessage": "Your quote is now on the quote wall."
+  },
   "GHxtae": {
     "defaultMessage": "Wallet",
     "description": "src/components/Forms/SelectAuthMethodForm/AuthTabs.tsx"
@@ -1298,6 +1301,9 @@
   "Gju939": {
     "defaultMessage": "mentioned you",
     "description": "src/components/Notice/ArticleNotice/ArticleMentionedYouNotice.tsx"
+  },
+  "GpR55j": {
+    "defaultMessage": "Your quote is now on the wall of “{name}”."
   },
   "Gt7K6r": {
     "defaultMessage": "Wallet address",

--- a/lang/en.json
+++ b/lang/en.json
@@ -3344,6 +3344,9 @@
     "defaultMessage": "This circle is already taken.",
     "description": "DUPLICATE_CIRCLE"
   },
+  "nBpgyU": {
+    "defaultMessage": "Quote image downloaded — attach it to your post, and share the link from the menu."
+  },
   "nGBrvw": {
     "defaultMessage": "Bookmarks"
   },

--- a/lang/en.json
+++ b/lang/en.json
@@ -3344,9 +3344,6 @@
     "defaultMessage": "This circle is already taken.",
     "description": "DUPLICATE_CIRCLE"
   },
-  "nBpgyU": {
-    "defaultMessage": "Quote image downloaded — attach it to your post, and share the link from the menu."
-  },
   "nGBrvw": {
     "defaultMessage": "Bookmarks"
   },

--- a/lang/en.json
+++ b/lang/en.json
@@ -1026,9 +1026,6 @@
     "defaultMessage": "Comment deleted",
     "description": "src/components/Notice/NoticeComment.tsx/moment"
   },
-  "Cmc/He": {
-    "defaultMessage": "On the wall ✓"
-  },
   "CnPG8j": {
     "defaultMessage": "Featured"
   },
@@ -1048,6 +1045,9 @@
   },
   "D+uyeZ": {
     "defaultMessage": "Unsubscribe circle will immediately lose your membership, The next billing date (the 1st of each month) will not incur any charges."
+  },
+  "D0pP8T": {
+    "defaultMessage": "Go to the event page"
   },
   "D3idYv": {
     "defaultMessage": "Settings"
@@ -1267,6 +1267,9 @@
     "defaultMessage": "Image",
     "description": "src/components/Editor"
   },
+  "GGd44x": {
+    "defaultMessage": "Your quote is now on the quote wall."
+  },
   "GHxtae": {
     "defaultMessage": "Wallet",
     "description": "src/components/Forms/SelectAuthMethodForm/AuthTabs.tsx"
@@ -1298,6 +1301,9 @@
   "Gju939": {
     "defaultMessage": "mentioned you",
     "description": "src/components/Notice/ArticleNotice/ArticleMentionedYouNotice.tsx"
+  },
+  "GpR55j": {
+    "defaultMessage": "Your quote is now on the wall of “{name}”."
   },
   "Gt7K6r": {
     "defaultMessage": "Wallet address",

--- a/lang/zh-Hans.json
+++ b/lang/zh-Hans.json
@@ -3342,9 +3342,6 @@
     "defaultMessage": "围炉名称已被使用",
     "description": "DUPLICATE_CIRCLE"
   },
-  "nBpgyU": {
-    "defaultMessage": "已下载金句图，发文时可一并附上；文章链接请从菜单分享。"
-  },
   "nGBrvw": {
     "defaultMessage": "我的收藏"
   },

--- a/lang/zh-Hans.json
+++ b/lang/zh-Hans.json
@@ -1025,9 +1025,6 @@
     "defaultMessage": "留言已删除",
     "description": "src/components/Notice/NoticeComment.tsx/moment"
   },
-  "Cmc/He": {
-    "defaultMessage": "已在墙上 ✓"
-  },
   "CnPG8j": {
     "defaultMessage": "精选"
   },
@@ -1047,6 +1044,9 @@
   },
   "D+uyeZ": {
     "defaultMessage": "选择离开围炉，你将马上失去成员资格。下一个账单日（每月 1 日）将不会扣除费用。"
+  },
+  "D0pP8T": {
+    "defaultMessage": "前往活动页"
   },
   "D3idYv": {
     "defaultMessage": "设定"
@@ -1266,6 +1266,9 @@
     "defaultMessage": "图片",
     "description": "src/components/Editor"
   },
+  "GGd44x": {
+    "defaultMessage": "你的金句已贴上金句墙。"
+  },
   "GHxtae": {
     "defaultMessage": "数字钱包",
     "description": "src/components/Forms/SelectAuthMethodForm/AuthTabs.tsx"
@@ -1297,6 +1300,9 @@
   "Gju939": {
     "defaultMessage": "在作品中提及了你",
     "description": "src/components/Notice/ArticleNotice/ArticleMentionedYouNotice.tsx"
+  },
+  "GpR55j": {
+    "defaultMessage": "你的金句已贴上「{name}」的金句墙。"
   },
   "Gt7K6r": {
     "defaultMessage": "钱包地址",

--- a/lang/zh-Hans.json
+++ b/lang/zh-Hans.json
@@ -3342,6 +3342,9 @@
     "defaultMessage": "围炉名称已被使用",
     "description": "DUPLICATE_CIRCLE"
   },
+  "nBpgyU": {
+    "defaultMessage": "已下载金句图，发文时可一并附上；文章链接请从菜单分享。"
+  },
   "nGBrvw": {
     "defaultMessage": "我的收藏"
   },

--- a/lang/zh-Hant.json
+++ b/lang/zh-Hant.json
@@ -1025,9 +1025,6 @@
     "defaultMessage": "留言已刪除",
     "description": "src/components/Notice/NoticeComment.tsx/moment"
   },
-  "Cmc/He": {
-    "defaultMessage": "已在牆上 ✓"
-  },
   "CnPG8j": {
     "defaultMessage": "精選"
   },
@@ -1047,6 +1044,9 @@
   },
   "D+uyeZ": {
     "defaultMessage": "選擇離開圍爐，你將馬上失去成員資格。下一個賬單日（每月 1 日）將不會扣除費用。"
+  },
+  "D0pP8T": {
+    "defaultMessage": "前往活動頁"
   },
   "D3idYv": {
     "defaultMessage": "設定"
@@ -1266,6 +1266,9 @@
     "defaultMessage": "影像",
     "description": "src/components/Editor"
   },
+  "GGd44x": {
+    "defaultMessage": "你的金句已貼上金句牆。"
+  },
   "GHxtae": {
     "defaultMessage": "數字錢包",
     "description": "src/components/Forms/SelectAuthMethodForm/AuthTabs.tsx"
@@ -1297,6 +1300,9 @@
   "Gju939": {
     "defaultMessage": "在作品中提及了你",
     "description": "src/components/Notice/ArticleNotice/ArticleMentionedYouNotice.tsx"
+  },
+  "GpR55j": {
+    "defaultMessage": "你的金句已貼上「{name}」的金句牆。"
   },
   "Gt7K6r": {
     "defaultMessage": "錢包地址",

--- a/lang/zh-Hant.json
+++ b/lang/zh-Hant.json
@@ -3342,6 +3342,9 @@
     "defaultMessage": "圍爐名稱已被使用",
     "description": "DUPLICATE_CIRCLE"
   },
+  "nBpgyU": {
+    "defaultMessage": "已下載金句圖，貼文時可一併附上；文章連結請從選單分享。"
+  },
   "nGBrvw": {
     "defaultMessage": "我的收藏"
   },

--- a/lang/zh-Hant.json
+++ b/lang/zh-Hant.json
@@ -3342,9 +3342,6 @@
     "defaultMessage": "圍爐名稱已被使用",
     "description": "DUPLICATE_CIRCLE"
   },
-  "nBpgyU": {
-    "defaultMessage": "已下載金句圖，貼文時可一併附上；文章連結請從選單分享。"
-  },
   "nGBrvw": {
     "defaultMessage": "我的收藏"
   },

--- a/src/components/QuoteImageDialog/Complete.test.tsx
+++ b/src/components/QuoteImageDialog/Complete.test.tsx
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { fireEvent, render, screen } from '~/common/utils/test'
+
+import Complete from './Complete'
+import { QuoteWallCampaign } from './gql'
+
+// 三種語系用同名，讓斷言不依賴測試環境的預設語系
+const campaign: QuoteWallCampaign = {
+  id: 'camp-1',
+  shortHash: 'abc123',
+  nameZhHant: 'QuoteWallCampaignName',
+  nameZhHans: 'QuoteWallCampaignName',
+  nameEn: 'QuoteWallCampaignName',
+}
+
+describe('QuoteImageDialog <Complete>', () => {
+  it('shows the campaign name and links to its event page', () => {
+    render(<Complete campaign={campaign} closeDialog={vi.fn()} />)
+    // 活動名稱出現在成功提示中
+    expect(screen.getAllByText(/QuoteWallCampaignName/).length).toBeGreaterThan(
+      0
+    )
+    // 「前往活動頁」連到 /e/{shortHash}
+    const eventLinks = screen
+      .getAllByRole('link')
+      .filter((a) => a.getAttribute('href') === '/e/abc123')
+    expect(eventLinks.length).toBeGreaterThan(0)
+  })
+
+  it('falls back to a generic message with no event link when there is no campaign', () => {
+    const closeDialog = vi.fn()
+    render(<Complete campaign={null} closeDialog={closeDialog} />)
+    // 沒有活動就不顯示「前往活動頁」連結
+    const eventLinks = screen
+      .queryAllByRole('link')
+      .filter((a) => a.getAttribute('href')?.startsWith('/e/'))
+    expect(eventLinks).toHaveLength(0)
+    // 「完成」可關閉對話框
+    fireEvent.click(screen.getAllByText(/完成|Done/)[0])
+    expect(closeDialog).toHaveBeenCalled()
+  })
+})

--- a/src/components/QuoteImageDialog/Complete.tsx
+++ b/src/components/QuoteImageDialog/Complete.tsx
@@ -37,7 +37,10 @@ const Complete: React.FC<CompleteProps> = ({ campaign, closeDialog }) => {
     <>
       <Dialog.Header
         title={
-          <FormattedMessage defaultMessage="Posted to the quote wall" id="IWLb33" />
+          <FormattedMessage
+            defaultMessage="Posted to the quote wall"
+            id="IWLb33"
+          />
         }
       />
 

--- a/src/components/QuoteImageDialog/Complete.tsx
+++ b/src/components/QuoteImageDialog/Complete.tsx
@@ -1,0 +1,112 @@
+import { useContext } from 'react'
+import { FormattedMessage } from 'react-intl'
+
+import IconCircleCheckFill from '@/public/static/icons/24px/circle-check-fill.svg'
+import { toPath } from '~/common/utils'
+import { Dialog, Icon, LanguageContext } from '~/components'
+import { UserLanguage } from '~/gql/graphql'
+
+import { QuoteWallCampaign } from './gql'
+import styles from './styles.module.css'
+
+interface CompleteProps {
+  campaign?: QuoteWallCampaign | null
+  closeDialog: () => void
+}
+
+/**
+ * 上牆成功後的對話框內容（取代原本的 toast）：
+ * 打勾 + 提示 +「前往活動頁」主按鈕，讓使用者貼完金句可直接回到該期活動頁。
+ */
+const Complete: React.FC<CompleteProps> = ({ campaign, closeDialog }) => {
+  const { lang } = useContext(LanguageContext)
+
+  const campaignName = campaign
+    ? lang === UserLanguage.En
+      ? campaign.nameEn
+      : lang === UserLanguage.ZhHans
+        ? campaign.nameZhHans
+        : campaign.nameZhHant
+    : null
+
+  const campaignPath = campaign
+    ? toPath({ page: 'campaignDetail', campaign }).href
+    : null
+
+  return (
+    <>
+      <Dialog.Header
+        title={
+          <FormattedMessage defaultMessage="Posted to the quote wall" id="IWLb33" />
+        }
+      />
+
+      <Dialog.Content>
+        <section className={styles.complete}>
+          <Icon icon={IconCircleCheckFill} size={40} color="green" />
+          <p className={styles.completeHint}>
+            {campaignName ? (
+              <FormattedMessage
+                defaultMessage="Your quote is now on the wall of “{name}”."
+                id="GpR55j"
+                values={{ name: campaignName }}
+              />
+            ) : (
+              <FormattedMessage
+                defaultMessage="Your quote is now on the quote wall."
+                id="GGd44x"
+              />
+            )}
+          </p>
+        </section>
+      </Dialog.Content>
+
+      <Dialog.Footer
+        btns={
+          <>
+            {campaignPath && (
+              <Dialog.RoundedButton
+                text={
+                  <FormattedMessage
+                    defaultMessage="Go to the event page"
+                    id="D0pP8T"
+                  />
+                }
+                color="green"
+                htmlHref={campaignPath}
+              />
+            )}
+            <Dialog.RoundedButton
+              text={<FormattedMessage defaultMessage="Done" id="JXdbo8" />}
+              color="greyDarker"
+              onClick={closeDialog}
+            />
+          </>
+        }
+        smUpBtns={
+          <>
+            {campaignPath && (
+              <Dialog.TextButton
+                text={
+                  <FormattedMessage
+                    defaultMessage="Go to the event page"
+                    id="D0pP8T"
+                  />
+                }
+                color="green"
+                htmlHref={campaignPath}
+              />
+            )}
+            <Dialog.TextButton
+              text={<FormattedMessage defaultMessage="Done" id="JXdbo8" />}
+              color="greyDarker"
+              onClick={closeDialog}
+            />
+          </>
+        }
+      />
+    </>
+  )
+}
+
+export default Complete

--- a/src/components/QuoteImageDialog/Content.tsx
+++ b/src/components/QuoteImageDialog/Content.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import { defineMessages, FormattedMessage, useIntl } from 'react-intl'
 
 import { analytics } from '~/common/utils'
-import { Dialog, ShareDialog, toast, useMutation } from '~/components'
+import { Dialog, toast, useMutation } from '~/components'
 import { PUT_QUOTE } from '~/components/GQL/mutations/putQuote'
 import { PutQuoteMutation } from '~/gql/graphql'
 
@@ -110,15 +110,6 @@ const QuoteImageDialogContent: React.FC<QuoteImageDialogContentProps> = ({
     })
   }
 
-  const imageFileName = `matters-quote-${style.id}-${size.id}.jpg`
-
-  const triggerDownload = (dataUrl: string) => {
-    const a = document.createElement('a')
-    a.href = dataUrl
-    a.download = imageFileName
-    a.click()
-  }
-
   const onDownload = async () => {
     const url = await generate()
     if (!url) return
@@ -126,7 +117,10 @@ const QuoteImageDialogContent: React.FC<QuoteImageDialogContentProps> = ({
       type: 'quote_image_download',
       pageType: 'article_detail',
     })
-    triggerDownload(url)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = `matters-quote-${style.id}-${size.id}.jpg`
+    a.click()
   }
 
   const onPostToWall = async () => {
@@ -163,49 +157,6 @@ const QuoteImageDialogContent: React.FC<QuoteImageDialogContentProps> = ({
     } finally {
       setPosting(false)
     }
-  }
-
-  // 分享：優先用系統分享一次帶「金句圖 + 文章連結」（行動裝置與支援 Web Share
-  // Level 2 的桌面瀏覽器）；不支援帶檔的瀏覽器則下載金句圖並開啟連結分享選單。
-  const onShare = async (openLinkMenu: () => void) => {
-    analytics.trackEvent('click_button', {
-      type: 'quote_image_share',
-      pageType: 'article_detail',
-    })
-
-    let dataUrl: string | null = null
-    try {
-      dataUrl = await generate()
-      if (dataUrl) {
-        const blob = await (await fetch(dataUrl)).blob()
-        const file = new File([blob], imageFileName, { type: 'image/jpeg' })
-        const shareData: ShareData = { files: [file], url: shareLink, title }
-        if (navigator.canShare?.(shareData)) {
-          try {
-            await navigator.share(shareData)
-          } catch {
-            // 使用者取消或分享失敗；不再退回連結選單
-          }
-          return
-        }
-      }
-    } catch {
-      // 產圖失敗，改用連結選單分享
-    }
-
-    // 桌面瀏覽器多不支援帶檔分享：先下載金句圖供貼文附上，再開連結分享選單
-    if (dataUrl) {
-      triggerDownload(dataUrl)
-      toast.info({
-        message: (
-          <FormattedMessage
-            defaultMessage="Quote image downloaded — attach it to your post, and share the link from the menu."
-            id="nBpgyU"
-          />
-        ),
-      })
-    }
-    openLinkMenu()
   }
 
   // 上牆成功後改顯示成功頁（打勾 +「前往活動頁」）
@@ -324,17 +275,6 @@ const QuoteImageDialogContent: React.FC<QuoteImageDialogContentProps> = ({
               color="green"
               onClick={onDownload}
             />
-            <ShareDialog title={title}>
-              {({ openDialog }) => (
-                <Dialog.RoundedButton
-                  text={
-                    <FormattedMessage defaultMessage="Share" id="OKhRC6" />
-                  }
-                  color="green"
-                  onClick={() => onShare(openDialog)}
-                />
-              )}
-            </ShareDialog>
           </>
         }
         smUpBtns={
@@ -355,15 +295,6 @@ const QuoteImageDialogContent: React.FC<QuoteImageDialogContentProps> = ({
               color="green"
               onClick={onDownload}
             />
-            <ShareDialog title={title}>
-              {({ openDialog }) => (
-                <Dialog.TextButton
-                  text={<FormattedMessage defaultMessage="Share" id="OKhRC6" />}
-                  color="green"
-                  onClick={() => onShare(openDialog)}
-                />
-              )}
-            </ShareDialog>
           </>
         }
       />

--- a/src/components/QuoteImageDialog/Content.tsx
+++ b/src/components/QuoteImageDialog/Content.tsx
@@ -110,6 +110,15 @@ const QuoteImageDialogContent: React.FC<QuoteImageDialogContentProps> = ({
     })
   }
 
+  const imageFileName = `matters-quote-${style.id}-${size.id}.jpg`
+
+  const triggerDownload = (dataUrl: string) => {
+    const a = document.createElement('a')
+    a.href = dataUrl
+    a.download = imageFileName
+    a.click()
+  }
+
   const onDownload = async () => {
     const url = await generate()
     if (!url) return
@@ -117,10 +126,7 @@ const QuoteImageDialogContent: React.FC<QuoteImageDialogContentProps> = ({
       type: 'quote_image_download',
       pageType: 'article_detail',
     })
-    const a = document.createElement('a')
-    a.href = url
-    a.download = `matters-quote-${style.id}-${size.id}.jpg`
-    a.click()
+    triggerDownload(url)
   }
 
   const onPostToWall = async () => {
@@ -159,11 +165,47 @@ const QuoteImageDialogContent: React.FC<QuoteImageDialogContentProps> = ({
     }
   }
 
-  const onShareClick = () => {
+  // 分享：優先用系統分享一次帶「金句圖 + 文章連結」（行動裝置與支援 Web Share
+  // Level 2 的桌面瀏覽器）；不支援帶檔的瀏覽器則下載金句圖並開啟連結分享選單。
+  const onShare = async (openLinkMenu: () => void) => {
     analytics.trackEvent('click_button', {
       type: 'quote_image_share',
       pageType: 'article_detail',
     })
+
+    let dataUrl: string | null = null
+    try {
+      dataUrl = await generate()
+      if (dataUrl) {
+        const blob = await (await fetch(dataUrl)).blob()
+        const file = new File([blob], imageFileName, { type: 'image/jpeg' })
+        const shareData: ShareData = { files: [file], url: shareLink, title }
+        if (navigator.canShare?.(shareData)) {
+          try {
+            await navigator.share(shareData)
+          } catch {
+            // 使用者取消或分享失敗；不再退回連結選單
+          }
+          return
+        }
+      }
+    } catch {
+      // 產圖失敗，改用連結選單分享
+    }
+
+    // 桌面瀏覽器多不支援帶檔分享：先下載金句圖供貼文附上，再開連結分享選單
+    if (dataUrl) {
+      triggerDownload(dataUrl)
+      toast.info({
+        message: (
+          <FormattedMessage
+            defaultMessage="Quote image downloaded — attach it to your post, and share the link from the menu."
+            id="nBpgyU"
+          />
+        ),
+      })
+    }
+    openLinkMenu()
   }
 
   // 上牆成功後改顯示成功頁（打勾 +「前往活動頁」）
@@ -289,10 +331,7 @@ const QuoteImageDialogContent: React.FC<QuoteImageDialogContentProps> = ({
                     <FormattedMessage defaultMessage="Share" id="OKhRC6" />
                   }
                   color="green"
-                  onClick={() => {
-                    onShareClick()
-                    openDialog()
-                  }}
+                  onClick={() => onShare(openDialog)}
                 />
               )}
             </ShareDialog>
@@ -321,10 +360,7 @@ const QuoteImageDialogContent: React.FC<QuoteImageDialogContentProps> = ({
                 <Dialog.TextButton
                   text={<FormattedMessage defaultMessage="Share" id="OKhRC6" />}
                   color="green"
-                  onClick={() => {
-                    onShareClick()
-                    openDialog()
-                  }}
+                  onClick={() => onShare(openDialog)}
                 />
               )}
             </ShareDialog>

--- a/src/components/QuoteImageDialog/Content.tsx
+++ b/src/components/QuoteImageDialog/Content.tsx
@@ -3,12 +3,14 @@ import QRCode from 'qrcode'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { defineMessages, FormattedMessage, useIntl } from 'react-intl'
 
-import { analytics, isMobile } from '~/common/utils'
-import { Dialog, toast, useMutation } from '~/components'
+import { analytics } from '~/common/utils'
+import { Dialog, ShareDialog, toast, useMutation } from '~/components'
 import { PUT_QUOTE } from '~/components/GQL/mutations/putQuote'
 import { PutQuoteMutation } from '~/gql/graphql'
 
 import { QuoteCard } from './Card'
+import Complete from './Complete'
+import { QuoteWallCampaign } from './gql'
 import { clampQuote, MAX_QUOTE_LEN, QUOTE_SIZES, QUOTE_STYLES } from './presets'
 import styles from './styles.module.css'
 
@@ -41,6 +43,8 @@ export type QuoteImageDialogContentProps = {
   articleId?: string
   /** 文章屬於活動（campaign）才可上牆；伺服器端會再驗證 */
   canPostToWall?: boolean
+  /** 上牆的活動（開啟金句牆者）；上牆成功後導回活動頁 */
+  campaign?: QuoteWallCampaign | null
 }
 
 const QuoteImageDialogContent: React.FC<QuoteImageDialogContentProps> = ({
@@ -52,6 +56,7 @@ const QuoteImageDialogContent: React.FC<QuoteImageDialogContentProps> = ({
   isSevenDayBook,
   articleId,
   canPostToWall,
+  campaign,
 }) => {
   const intl = useIntl()
   const cardRef = useRef<HTMLDivElement>(null)
@@ -137,15 +142,8 @@ const QuoteImageDialogContent: React.FC<QuoteImageDialogContentProps> = ({
       await putQuote({
         variables: { input: { articleId, content: wallText } },
       })
+      // 上牆成功後切換到成功頁（含「前往活動頁」），取代原本的 toast
       setPosted(true)
-      toast.info({
-        message: (
-          <FormattedMessage
-            defaultMessage="Posted to the quote wall"
-            id="IWLb33"
-          />
-        ),
-      })
     } catch {
       // 每日／同篇上限已於 matters-server#4867 移除，其餘失敗顯示通用訊息
       toast.error({
@@ -161,24 +159,16 @@ const QuoteImageDialogContent: React.FC<QuoteImageDialogContentProps> = ({
     }
   }
 
-  const onShare = async () => {
-    const url = await generate()
-    if (!url) return
+  const onShareClick = () => {
     analytics.trackEvent('click_button', {
       type: 'quote_image_share',
       pageType: 'article_detail',
     })
-    try {
-      const blob = await (await fetch(url)).blob()
-      const file = new File([blob], 'matters-quote.jpg', { type: 'image/jpeg' })
-      if (isMobile() && navigator.canShare?.({ files: [file] })) {
-        await navigator.share({ files: [file] })
-        return
-      }
-    } catch {
-      // fall through to download
-    }
-    await onDownload()
+  }
+
+  // 上牆成功後改顯示成功頁（打勾 +「前往活動頁」）
+  if (posted) {
+    return <Complete campaign={campaign} closeDialog={closeDialog} />
   }
 
   return (
@@ -279,21 +269,11 @@ const QuoteImageDialogContent: React.FC<QuoteImageDialogContentProps> = ({
             {articleId && canPostToWall && (
               <Dialog.RoundedButton
                 text={
-                  posted ? (
-                    <FormattedMessage
-                      defaultMessage="On the wall ✓"
-                      id="Cmc/He"
-                    />
-                  ) : (
-                    <FormattedMessage
-                      defaultMessage="Post to wall"
-                      id="oCQmLu"
-                    />
-                  )
+                  <FormattedMessage defaultMessage="Post to wall" id="oCQmLu" />
                 }
                 color="green"
                 loading={isPosting}
-                disabled={isPosting || posted}
+                disabled={isPosting}
                 onClick={onPostToWall}
               />
             )}
@@ -302,11 +282,20 @@ const QuoteImageDialogContent: React.FC<QuoteImageDialogContentProps> = ({
               color="green"
               onClick={onDownload}
             />
-            <Dialog.RoundedButton
-              text={<FormattedMessage defaultMessage="Share" id="OKhRC6" />}
-              color="green"
-              onClick={onShare}
-            />
+            <ShareDialog title={title}>
+              {({ openDialog }) => (
+                <Dialog.RoundedButton
+                  text={
+                    <FormattedMessage defaultMessage="Share" id="OKhRC6" />
+                  }
+                  color="green"
+                  onClick={() => {
+                    onShareClick()
+                    openDialog()
+                  }}
+                />
+              )}
+            </ShareDialog>
           </>
         }
         smUpBtns={
@@ -314,21 +303,11 @@ const QuoteImageDialogContent: React.FC<QuoteImageDialogContentProps> = ({
             {articleId && canPostToWall && (
               <Dialog.TextButton
                 text={
-                  posted ? (
-                    <FormattedMessage
-                      defaultMessage="On the wall ✓"
-                      id="Cmc/He"
-                    />
-                  ) : (
-                    <FormattedMessage
-                      defaultMessage="Post to wall"
-                      id="oCQmLu"
-                    />
-                  )
+                  <FormattedMessage defaultMessage="Post to wall" id="oCQmLu" />
                 }
                 color="green"
                 loading={isPosting}
-                disabled={isPosting || posted}
+                disabled={isPosting}
                 onClick={onPostToWall}
               />
             )}
@@ -337,11 +316,18 @@ const QuoteImageDialogContent: React.FC<QuoteImageDialogContentProps> = ({
               color="green"
               onClick={onDownload}
             />
-            <Dialog.TextButton
-              text={<FormattedMessage defaultMessage="Share" id="OKhRC6" />}
-              color="green"
-              onClick={onShare}
-            />
+            <ShareDialog title={title}>
+              {({ openDialog }) => (
+                <Dialog.TextButton
+                  text={<FormattedMessage defaultMessage="Share" id="OKhRC6" />}
+                  color="green"
+                  onClick={() => {
+                    onShareClick()
+                    openDialog()
+                  }}
+                />
+              )}
+            </ShareDialog>
           </>
         }
       />

--- a/src/components/QuoteImageDialog/gql.test.ts
+++ b/src/components/QuoteImageDialog/gql.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest'
+
+import { QuoteImageArticleFragment } from '~/gql/graphql'
+
+import {
+  canPostQuoteToWall,
+  getQuoteWallCampaign,
+  isSevenDayBookArticle,
+} from './gql'
+
+type CampaignInput = {
+  id?: string
+  shortHash?: string
+  enableQuoteWall?: boolean
+  nameZhHant?: string
+  typename?: 'WritingChallenge' | 'Campaign'
+}
+
+// 用最小欄位組出符合 QuoteImageArticleFragment 形狀的文章
+const makeArticle = (campaigns: CampaignInput[]): QuoteImageArticleFragment =>
+  ({
+    campaigns: campaigns.map((c) => ({
+      campaign: {
+        __typename: c.typename ?? 'WritingChallenge',
+        id: c.id ?? 'c1',
+        shortHash: c.shortHash ?? 'hash1',
+        enableQuoteWall: c.enableQuoteWall ?? false,
+        nameZhHant: c.nameZhHant ?? '七日書 · 第 12 期',
+        nameZhHans: '七日书',
+        nameEn: 'Seven Day Book',
+      },
+    })),
+  }) as unknown as QuoteImageArticleFragment
+
+describe('getQuoteWallCampaign', () => {
+  it('returns null when the article has no campaigns', () => {
+    expect(getQuoteWallCampaign(makeArticle([]))).toBeNull()
+    expect(getQuoteWallCampaign(null)).toBeNull()
+  })
+
+  it('returns null when no campaign has the quote wall enabled', () => {
+    expect(
+      getQuoteWallCampaign(makeArticle([{ enableQuoteWall: false }]))
+    ).toBeNull()
+  })
+
+  it('returns the enabled writing-challenge campaign with its shortHash and names', () => {
+    const campaign = getQuoteWallCampaign(
+      makeArticle([
+        { shortHash: 'abc123', enableQuoteWall: true, id: 'camp-1' },
+      ])
+    )
+    expect(campaign).toMatchObject({
+      id: 'camp-1',
+      shortHash: 'abc123',
+      nameZhHant: '七日書 · 第 12 期',
+      nameEn: 'Seven Day Book',
+    })
+  })
+
+  it('picks the first campaign that has the wall enabled', () => {
+    const campaign = getQuoteWallCampaign(
+      makeArticle([
+        { shortHash: 'off', enableQuoteWall: false },
+        { shortHash: 'on', enableQuoteWall: true },
+      ])
+    )
+    expect(campaign?.shortHash).toBe('on')
+  })
+})
+
+describe('canPostQuoteToWall', () => {
+  it('is true only when a campaign has the wall enabled', () => {
+    expect(canPostQuoteToWall(makeArticle([{ enableQuoteWall: true }]))).toBe(
+      true
+    )
+    expect(canPostQuoteToWall(makeArticle([{ enableQuoteWall: false }]))).toBe(
+      false
+    )
+    expect(canPostQuoteToWall(makeArticle([]))).toBe(false)
+  })
+})
+
+describe('isSevenDayBookArticle', () => {
+  it('detects the seven-day-book campaign by name', () => {
+    expect(
+      isSevenDayBookArticle(makeArticle([{ nameZhHant: '七日書 · 第 12 期' }]))
+    ).toBe(true)
+    expect(
+      isSevenDayBookArticle(makeArticle([{ nameZhHant: '其他活動' }]))
+    ).toBe(false)
+  })
+})

--- a/src/components/QuoteImageDialog/gql.ts
+++ b/src/components/QuoteImageDialog/gql.ts
@@ -68,3 +68,36 @@ export const canPostQuoteToWall = (
       campaign?.__typename === 'WritingChallenge' && !!campaign.enableQuoteWall
   )
 }
+
+/** 上牆成功後導回活動頁所需的最小活動資料 */
+export type QuoteWallCampaign = {
+  id: string
+  shortHash: string
+  nameZhHant?: string | null
+  nameZhHans?: string | null
+  nameEn?: string | null
+}
+
+/**
+ * 取得文章「上牆」的那個活動（第一個開啟金句牆的 WritingChallenge），
+ * 供上牆成功後的成功頁顯示活動名稱並導回活動頁。
+ */
+export const getQuoteWallCampaign = (
+  article?: QuoteImageArticleFragment | null
+): QuoteWallCampaign | null => {
+  const match = article?.campaigns?.find(
+    ({ campaign }) =>
+      campaign?.__typename === 'WritingChallenge' && !!campaign.enableQuoteWall
+  )
+  const campaign = match?.campaign
+  if (!campaign || campaign.__typename !== 'WritingChallenge') {
+    return null
+  }
+  return {
+    id: campaign.id,
+    shortHash: campaign.shortHash,
+    nameZhHant: campaign.nameZhHant,
+    nameZhHans: campaign.nameZhHans,
+    nameEn: campaign.nameEn,
+  }
+}

--- a/src/components/QuoteImageDialog/index.tsx
+++ b/src/components/QuoteImageDialog/index.tsx
@@ -35,4 +35,10 @@ export const QuoteImageDialog = (props: QuoteImageDialogProps) => {
   )
 }
 
-export { canPostQuoteToWall, fragments, isSevenDayBookArticle } from './gql'
+export type { QuoteWallCampaign } from './gql'
+export {
+  canPostQuoteToWall,
+  fragments,
+  getQuoteWallCampaign,
+  isSevenDayBookArticle,
+} from './gql'

--- a/src/components/QuoteImageDialog/styles.module.css
+++ b/src/components/QuoteImageDialog/styles.module.css
@@ -202,3 +202,20 @@
   font-weight: 400;
   color: var(--color-grey-dark);
 }
+
+/* === 上牆成功頁 === */
+.complete {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp12, 12px);
+  align-items: center;
+  padding: var(--sp16, 16px) 0;
+  text-align: center;
+}
+
+.completeHint {
+  margin: 0;
+  font-size: var(--text16, 16px);
+  line-height: 1.6;
+  color: var(--color-grey-darker);
+}

--- a/src/components/TextSelectionPopover/index.tsx
+++ b/src/components/TextSelectionPopover/index.tsx
@@ -9,6 +9,7 @@ import { isElementInViewport } from '~/common/utils'
 import { analytics } from '~/common/utils'
 import {
   canPostQuoteToWall,
+  getQuoteWallCampaign,
   Icon,
   isSevenDayBookArticle,
   QuoteImageDialog,
@@ -237,6 +238,8 @@ export const TextSelectionPopover = ({
       articleId={article?.id}
       // 只有「開啟金句牆」的活動文章可上牆（後端 enableQuoteWall；伺服器會再驗證）
       canPostToWall={canPostQuoteToWall(article)}
+      // 上牆成功後導回的活動頁（開啟金句牆的那個活動）
+      campaign={getQuoteWallCampaign(article)}
     >
       {({ openDialog }) => (
         <button


### PR DESCRIPTION
接續 #5996(金句圖改版)。在「分享金句」彈窗加兩個功能。

## 1. 上牆後回活動頁（對話框內成功頁）
貼上金句牆成功後，不再只跳 toast，而是把對話框內容換成成功頁：

- 綠色打勾 ＋「你的金句已貼上『{活動名}』的金句牆。」
- 主按鈕 **前往活動頁** → 連到該活動 `/e/{shortHash}`（`toPath({ page: 'campaignDetail', campaign })`）
- 次按鈕 **完成** 關閉

活動名依 UI 語言顯示繁／簡／英。新增 `getQuoteWallCampaign()`（取文章第一個 `enableQuoteWall` 的活動），由 `TextSelectionPopover` 傳 `campaign` 進彈窗。

## 2. 分享選單（社群連結）
「分享」改成重用既有 `ShareDialog`：**X / Facebook / LINE / Threads / Telegram / 複製連結**，分享的是文章連結（社群 intent 只能帶網址）。金句大圖仍走「下載」/ 手機系統分享。移除舊的 html-to-image 圖片分享 fallback。

## 測試
- `getQuoteWallCampaign` 單元測試（`gql.test.ts`）
- 成功頁 render 測試（`Complete.test.tsx`）：驗證活動名顯示、「前往活動頁」連到 `/e/{shortHash}`、無活動時的 fallback
- i18n zh-Hant / zh-Hans 已補；`next build` webpack + lint 全過

🤖 Generated with [Claude Code](https://claude.com/claude-code)