### PR TITLE
hotfix: filter restricted-author comments in public UI

### DIFF
--- a/src/common/utils/comment.test.ts
+++ b/src/common/utils/comment.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { ArticleState, CommentState } from '~/gql/graphql'
+import { ArticleState, CommentState, UserState } from '~/gql/graphql'
 import { MOCK_ARTILCE, MOCK_COMMENT } from '~/stories/mocks'
 
 import { filterComments, filterResponses } from './comment'
@@ -19,6 +19,29 @@ describe('utils/comment/filterComments', () => {
     const comments = [
       { ...MOCK_COMMENT, state: CommentState.Banned },
       { ...MOCK_COMMENT, state: CommentState.Archived },
+    ]
+    const result = filterComments(comments)
+    expect(result.length).toEqual(0)
+  })
+
+  it('should filter out comments by restricted authors', () => {
+    const comments = [
+      {
+        ...MOCK_COMMENT,
+        state: CommentState.Active,
+        author: {
+          ...MOCK_COMMENT.author,
+          status: { ...MOCK_COMMENT.author.status, state: UserState.Frozen },
+        },
+      },
+      {
+        ...MOCK_COMMENT,
+        state: CommentState.Collapsed,
+        author: {
+          ...MOCK_COMMENT.author,
+          status: { ...MOCK_COMMENT.author.status, state: UserState.Archived },
+        },
+      },
     ]
     const result = filterComments(comments)
     expect(result.length).toEqual(0)
@@ -102,8 +125,16 @@ describe('utils/comment/filterResponses', () => {
       { ...MOCK_ARTILCE, state: ArticleState.Banned },
       { ...MOCK_COMMENT, state: CommentState.Active },
       { ...MOCK_COMMENT, state: CommentState.Banned },
+      {
+        ...MOCK_COMMENT,
+        state: CommentState.Active,
+        author: {
+          ...MOCK_COMMENT.author,
+          status: { ...MOCK_COMMENT.author.status, state: UserState.Frozen },
+        },
+      },
     ]
     const result = filterResponses(responses)
-    expect(result.length).toEqual(responses.length - 1)
+    expect(result.length).toEqual(responses.length - 2)
   })
 })

--- a/src/common/utils/comment/index.ts
+++ b/src/common/utils/comment/index.ts
@@ -1,7 +1,7 @@
 import _get from 'lodash/get'
 import _has from 'lodash/has'
 
-import { CommentState } from '~/gql/graphql'
+import { CommentState, UserState } from '~/gql/graphql'
 
 import styles from './styles.module.css'
 
@@ -12,6 +12,11 @@ import styles from './styles.module.css'
  */
 interface Comment {
   state: string
+  author?: {
+    status?: {
+      state?: string | null
+    } | null
+  } | null
   communityWatchAction?: {
     uuid: string
   } | null
@@ -25,6 +30,13 @@ type Response = {
 }
 
 const filterComment = (comment: Comment) => {
+  if (
+    comment.author?.status?.state === UserState.Frozen ||
+    comment.author?.status?.state === UserState.Archived
+  ) {
+    return false
+  }
+
   // skip if comment's state is active or collapse
   if (
     comment.state === CommentState.Active ||


### PR DESCRIPTION
## Summary
- Promote only the public UI fallback from #6003 to `master`.
- Hide comments whose author is frozen or archived in the shared public comment filtering utility.
- Apply the same fallback to mixed article response filtering through `filterResponses`.

## Why this is selective
The normal web release path is the existing `develop -> master` PR #5991. That PR already includes #6003, but it is currently `DIRTY` because the whole `develop` branch contains many unrelated campaign/quote/NCC/frozen-user-redaction changes and conflicts with current `master`.

This PR is scoped to the anti-abuse visibility fallback only, so production UI can align with the already-prepared server release without waiting for the broader #5991 release conflict resolution.

## Included changes
Cherry-picked from #6003:
- `src/common/utils/comment/index.ts`
- `src/common/utils/comment.test.ts`

## SOP notes
- Exception type: selective hotfix because the normal `develop -> master` PR is blocked by unrelated release conflicts.
- Server authority remains #4897 / #4896. This web PR is a defense-in-depth UI fallback.
- Follow-up after merge: back-merge `master` into `develop` or resolve #5991 so the selective production commit does not create long-lived drift.

## Checks
Local on branch based on `origin/master`:
- `npx prettier --check src/common/utils/comment/index.ts src/common/utils/comment.test.ts`
- `npm run test:unit -- src/common/utils/comment.test.ts`
- `npm run lint:ts`
- `npm run lint:css`
- `npm run build`

Build warnings observed: existing Browserslist data age warning and PWA sourcemap precache size warning.