### PR TITLE
[codex] Guard restricted authors in public SSR

### DIFF
--- a/lang/default.json
+++ b/lang/default.json
@@ -220,6 +220,9 @@
   "0xVT+0": {
     "defaultMessage": "Curated"
   },
+  "115cw4": {
+    "defaultMessage": "Unavailable user"
+  },
   "11nXAM": {
     "defaultMessage": "Your schedule article published successfully, but failed to submit because the selection event has ended",
     "description": "src/components/Notice/ArticleNotice/ScheduledArticlePublishedNotice.tsx"

--- a/lang/en.json
+++ b/lang/en.json
@@ -220,6 +220,9 @@
   "0xVT+0": {
     "defaultMessage": "Curated"
   },
+  "115cw4": {
+    "defaultMessage": "Unavailable user"
+  },
   "11nXAM": {
     "defaultMessage": "Your schedule article published successfully, but failed to submit because the selection event has ended",
     "description": "src/components/Notice/ArticleNotice/ScheduledArticlePublishedNotice.tsx"

--- a/lang/zh-Hans.json
+++ b/lang/zh-Hans.json
@@ -220,6 +220,9 @@
   "0xVT+0": {
     "defaultMessage": "已关联"
   },
+  "115cw4": {
+    "defaultMessage": "用户已停用"
+  },
   "11nXAM": {
     "defaultMessage": "你的定时发布作品已发布成功，由于选择活动已结束，投稿未能成功",
     "description": "src/components/Notice/ArticleNotice/ScheduledArticlePublishedNotice.tsx"

--- a/lang/zh-Hant.json
+++ b/lang/zh-Hant.json
@@ -220,6 +220,9 @@
   "0xVT+0": {
     "defaultMessage": "已關聯"
   },
+  "115cw4": {
+    "defaultMessage": "用戶已停用"
+  },
   "11nXAM": {
     "defaultMessage": "你的排程作品已發布成功，由於選擇活動已結束，投稿未能成功",
     "description": "src/components/Notice/ArticleNotice/ScheduledArticlePublishedNotice.tsx"

--- a/src/views/ArticleDetail/index.tsx
+++ b/src/views/ArticleDetail/index.tsx
@@ -47,6 +47,7 @@ import {
   ArticleDetailPublicQuery,
   ArticleTranslationQuery,
   UserLanguage,
+  UserState,
 } from '~/gql/graphql'
 
 import { AuthorSidebar } from './AuthorSidebar'
@@ -105,6 +106,12 @@ const DynamicSupportDrawer = dynamic(
     ssr: false,
   }
 )
+
+const restrictedAuthorStates = new Set<string>([
+  UserState.Archived,
+  UserState.Banned,
+  UserState.Frozen,
+])
 
 const BaseArticleDetail = ({
   article,
@@ -498,6 +505,7 @@ const ArticleDetail = ({
   const resultByHash = usePublicQuery<ArticleDetailPublicQuery>(
     ARTICLE_DETAIL_PUBLIC,
     {
+      fetchPolicy: 'no-cache',
       variables: {
         shortHash,
         language: routerLang || UserLanguage.ZhHant,
@@ -510,6 +518,8 @@ const ArticleDetail = ({
   const article = data?.article
   const authorId = article?.author?.id
   const isAuthor = viewer.id === authorId
+  const authorState = article?.author?.status?.state
+  const isRestrictedAuthor = restrictedAuthorStates.has(authorState || '')
 
   /**
    * fetch private data
@@ -569,6 +579,14 @@ const ArticleDetail = ({
     )
   }
 
+  if (isRestrictedAuthor && !isAuthor) {
+    return (
+      <EmptyLayout>
+        <Throw404 />
+      </EmptyLayout>
+    )
+  }
+
   /**
    * Render:Archived/Banned
    */
@@ -608,7 +626,7 @@ const ArticleDetailOuter = () => {
 
   const resultByHash = usePublicQuery<ArticleAvailableTranslationsQuery>(
     ARTICLE_AVAILABLE_TRANSLATIONS,
-    { variables: { shortHash } }
+    { fetchPolicy: 'no-cache', variables: { shortHash } }
   )
   const { data } = resultByHash
   const loading = resultByHash.loading

--- a/src/views/User/Collections/UserCollections.tsx
+++ b/src/views/User/Collections/UserCollections.tsx
@@ -20,7 +20,7 @@ import {
   ViewerContext,
 } from '~/components'
 import { EmptyCollection } from '~/components/Empty/EmptyCollection'
-import { UserCollectionsQuery } from '~/gql/graphql'
+import { UserCollectionsQuery, UserState } from '~/gql/graphql'
 
 import CreateCollection from './CreateCollection'
 import { USER_COLLECTIONS } from './gql'
@@ -40,7 +40,7 @@ const UserCollections = () => {
   const { data, loading, error, fetchMore } =
     usePublicQuery<UserCollectionsQuery>(
       USER_COLLECTIONS,
-      { variables: { userName } },
+      { fetchPolicy: 'no-cache', variables: { userName } },
       { publicQuery: true }
     )
   const user = data?.user
@@ -87,16 +87,29 @@ const UserCollections = () => {
     return <></>
   }
 
-  if (user?.status?.state === 'archived') {
+  const userState = user?.status?.state
+  const isArchived = userState === UserState.Archived
+  const isFrozen = userState === UserState.Frozen
+  const isBanned = userState === UserState.Banned
+
+  if (isArchived || isFrozen || isBanned) {
     return (
       <Empty
         spacingY="xxxloose"
         description={
-          <Translate
-            en="Deleted user"
-            zh_hans="用户已注销"
-            zh_hant="用戶已註銷"
-          />
+          isArchived ? (
+            <Translate
+              en="Deleted user"
+              zh_hans="用户已注销"
+              zh_hant="用戶已註銷"
+            />
+          ) : (
+            <Translate
+              en="Unavailable user"
+              zh_hans="用户已停用"
+              zh_hant="用戶已停用"
+            />
+          )
         }
       />
     )

--- a/src/views/User/UserProfile/AsideUserProfile/index.tsx
+++ b/src/views/User/UserProfile/AsideUserProfile/index.tsx
@@ -67,6 +67,7 @@ export const AsideUserProfile = () => {
   const { data, loading, client } = usePublicQuery<UserProfileUserPublicQuery>(
     USER_PROFILE_PUBLIC,
     {
+      fetchPolicy: 'no-cache',
       variables: { userName },
     }
   )
@@ -138,7 +139,8 @@ export const AsideUserProfile = () => {
   const isCivicLiker = user.liker.civicLiker
   const isUserArchived = userState === UserState.Archived
   const isUserFrozen = userState === UserState.Frozen
-  const isUserInactive = isUserArchived || isUserFrozen
+  const isUserBanned = userState === UserState.Banned
+  const isUserInactive = isUserArchived || isUserFrozen || isUserBanned
 
   /**
    * Inactive User
@@ -160,6 +162,12 @@ export const AsideUserProfile = () => {
               )}
               {isUserFrozen && (
                 <FormattedMessage defaultMessage="Frozen user" id="MeqJEO" />
+              )}
+              {isUserBanned && (
+                <FormattedMessage
+                  defaultMessage="Unavailable user"
+                  id="115cw4"
+                />
               )}
             </h1>
           </section>

--- a/src/views/User/UserProfile/index.tsx
+++ b/src/views/User/UserProfile/index.tsx
@@ -51,7 +51,7 @@ export const UserProfile = () => {
   const isMe = !userName || viewer.userName === userName
   const { data, loading, client } = usePublicQuery<UserProfileUserPublicQuery>(
     USER_PROFILE_PUBLIC,
-    { variables: { userName } }
+    { fetchPolicy: 'no-cache', variables: { userName } }
   )
   const user = data?.user
 
@@ -131,7 +131,8 @@ export const UserProfile = () => {
    */
   const isUserArchived = userState === UserState.Archived
   const isUserFrozen = userState === UserState.Frozen
-  const isUserInactive = isUserArchived || isUserFrozen
+  const isUserBanned = userState === UserState.Banned
+  const isUserInactive = isUserArchived || isUserFrozen || isUserBanned
   if (isUserInactive) {
     return <Inactive state={userState} />
   }

--- a/src/views/User/Writings/UserWritings.tsx
+++ b/src/views/User/Writings/UserWritings.tsx
@@ -18,7 +18,7 @@ import {
   useRoute,
   ViewerContext,
 } from '~/components'
-import { UserWritingsPublicQuery } from '~/gql/graphql'
+import { UserState, UserWritingsPublicQuery } from '~/gql/graphql'
 
 import MomentForm from '../MomentForm'
 import {
@@ -41,6 +41,7 @@ const UserWritings = () => {
   // public data
   const { data, loading, error, fetchMore, client } =
     usePublicQuery<UserWritingsPublicQuery>(USER_WRITINGS_PUBLIC, {
+      fetchPolicy: 'no-cache',
       variables: { userName },
     })
 
@@ -150,16 +151,29 @@ const UserWritings = () => {
     return <></>
   }
 
-  if (user?.status?.state === 'archived') {
+  const userState = user?.status?.state
+  const isArchived = userState === UserState.Archived
+  const isFrozen = userState === UserState.Frozen
+  const isBanned = userState === UserState.Banned
+
+  if (isArchived || isFrozen || isBanned) {
     return (
       <Empty
         spacingY="xxxloose"
         description={
-          <Translate
-            en="Deleted user"
-            zh_hans="用户已注销"
-            zh_hant="用戶已註銷"
-          />
+          isArchived ? (
+            <Translate
+              en="Deleted user"
+              zh_hans="用户已注销"
+              zh_hant="用戶已註銷"
+            />
+          ) : (
+            <Translate
+              en="Unavailable user"
+              zh_hans="用户已停用"
+              zh_hant="用戶已停用"
+            />
+          )
         }
       />
     )


### PR DESCRIPTION
## Summary
- Add public SSR guards so archived, frozen, and banned authors render unavailable/404 states instead of exposing stale article/profile data.
- Use `fetchPolicy: no-cache` on public article, profile, writings, and collections reads that are sensitive to restricted-user state.
- Add the missing localized `Unavailable user` string for banned user profile display.

## Root cause
Server-side public resolvers now hide frozen-author content correctly, but the web SSR layer can still receive or serialize stale persisted-query/cache data into `__NEXT_DATA__`. This adds a frontend guard so restricted-author content is not rendered even if an old response reaches the page.

## Validation
- `git diff --check`
- `npx prettier --check src/views/ArticleDetail/index.tsx src/views/User/Writings/UserWritings.tsx src/views/User/UserProfile/index.tsx src/views/User/UserProfile/AsideUserProfile/index.tsx src/views/User/Collections/UserCollections.tsx lang/default.json lang/en.json lang/zh-Hans.json lang/zh-Hant.json`
- `PATH=/Users/mashbean/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH npm run lint:ts`
- `PATH=/Users/mashbean/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH npm run build`
- Live GraphQL check on `server.matters.town` for `omisenote01` returns `status.state=frozen`, `writings.totalCount=0`, `articles.totalCount=0`, `latestWorks=[]`, `article(shortHash: "py70epoeykdy")=null`, and `node(QXJ0aWNsZToxMjg3MDY4)=null` with `ARTICLE_NOT_FOUND`.
