### PR TITLE
[hotfix] Fix moment image upload false failure

### DIFF
--- a/src/components/FileUploader/MomentAssetsUploader/Item.tsx
+++ b/src/components/FileUploader/MomentAssetsUploader/Item.tsx
@@ -102,11 +102,7 @@ export const Item = memo(function Item({
         const { id: assetId, path, uploadURL } = data?.directImageUpload || {}
 
         if (assetId && path && uploadURL) {
-          const { id: cfImageId } = await uploadImage({ uploadURL, file })
-
-          if (!cfImageId || !path.includes(cfImageId)) {
-            throw new Error()
-          }
+          await uploadImage({ uploadURL, file })
 
           // (async) mark asset draft as false
           directImageUploadDone({


### PR DESCRIPTION
## Summary

Fix moment image uploads being shown as `Unknown Error` even when the Cloudflare direct upload succeeds.

This removes the moment-asset-only check that required Cloudflare's upload response `result.id` to be a substring of the Matters asset `path`. The direct upload success response remains required, and the existing `directImageUploadDone` call still marks the asset as non-draft after upload.

## Root Cause

PR #5080 added extra client-side validation for moment asset uploads:

```ts
const { id: cfImageId } = await uploadImage({ uploadURL, file })

if (!cfImageId || !path.includes(cfImageId)) {
  throw new Error()
}
```

That assumed Cloudflare's final direct-upload response id format would always match the Matters asset path. This is not a stable contract. When Cloudflare returns an id in a different valid format, the image has uploaded successfully but the moment uploader throws and renders `Unknown Error`.

Other direct image upload callers, such as article images, covers, and avatars, already rely on the direct upload success response without this extra path/id equality check.

## Hotfix Path

User requested hotfix path on 2026-07-04 because the production user-facing moment image upload flow is currently broken.

Base branch: `master`
Head branch: `hotfix/moment-image-upload-error`

SOP note: this is a selective hotfix exception. After this PR is merged, immediately open the mandatory `master -> develop` back-merge and verify:

```bash
git log origin/develop..origin/master --no-merges
```

Before this PR, that command was empty.

## Regression Guard

Target: `origin/master`
Branch base: latest `origin/master` (`5811a600f`)
Behind target count: `0`
Hot-zone files: none
Sentinel/removal scan: no matches
Re-enabled UI/import scan: no matches
Diff scope: one file only

Changed file:

```text
src/components/FileUploader/MomentAssetsUploader/Item.tsx
```

## Security Review

This touches the upload surface, but it does not change server-side validation, accepted MIME types, authentication, authorization, storage keys, or asset ownership. The server still creates the direct upload URL and validates the asset through `directImageUpload`; the client still requires Cloudflare direct upload success before marking the asset uploaded.

The change only removes a client-side false-negative check that could reject a successful Cloudflare upload because of response id formatting.

## Validation

```bash
npm ci
PATH="/Users/mashbean/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" npm run i18n
PATH="/Users/mashbean/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" npm run gen:type:prod
PATH="/Users/mashbean/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" npm run lint:ts
```

Commit hook also ran:

```bash
npm run format -- --list-different
npm run i18n
npm run lint
```

Result: passed.
