### PR TITLE
chore: back-merge master hotfix into develop

### DIFF
--- a/src/components/FileUploader/MomentAssetsUploader/Item.tsx
+++ b/src/components/FileUploader/MomentAssetsUploader/Item.tsx
@@ -102,11 +102,7 @@ export const Item = memo(function Item({
         const { id: assetId, path, uploadURL } = data?.directImageUpload || {}
 
         if (assetId && path && uploadURL) {
-          const { id: cfImageId } = await uploadImage({ uploadURL, file })
-
-          if (!cfImageId || !path.includes(cfImageId)) {
-            throw new Error()
-          }
+          await uploadImage({ uploadURL, file })
 
           // (async) mark asset draft as false
           directImageUploadDone({


### PR DESCRIPTION
## Summary

Back-merge the production hotfix from `master` into `develop`.

This carries the already-merged production fix from #6011 back into the staging/develop line so `master` and `develop` do not drift after the selective hotfix.

## Included Hotfix

- #6011
- Merge commit: `da665f12054894815ae0f31bd3bec758fbfd1dd7`
- Hotfix commit: `72e7f76561bbda30a7f075ff33a35839ade89bdf`

The only product-code change is:

```text
src/components/FileUploader/MomentAssetsUploader/Item.tsx
```

## Why

The hotfix path targeted `master` directly because production moment image uploads were failing with `Unknown Error`.

Per the Matters branch policy, selective hotfixes must be followed immediately by a `master -> develop` back-merge so the same production fix remains present in future develop-based releases.

## Regression Guard

Target: `origin/develop`
Branch base: latest `origin/develop` (`6f515f91f`)
Behind target count: `0`
Hot-zone files: none
Sentinel/removal scan: no matches
Re-enabled UI/import scan: no matches
Diff scope: one file only

Command evidence:

```bash
git log origin/develop..HEAD --oneline --no-merges
# 72e7f7656 fix: stop rejecting successful moment image uploads

git diff --name-only origin/develop...HEAD
# src/components/FileUploader/MomentAssetsUploader/Item.tsx
```

## Validation

The hotfix branch passed:

```bash
npm ci
npm run i18n
npm run gen:type:prod
npm run lint:ts
```

Commit hook on the hotfix also ran:

```bash
npm run format -- --list-different
npm run i18n
npm run lint
```

This back-merge commit is a clean merge of `origin/master` into latest `origin/develop` with no conflicts.
