### PR TITLE
[hotfix] Keep moment upload drafts serializable

### DIFF
--- a/src/components/FileUploader/MomentAssetsUploader/Item.tsx
+++ b/src/components/FileUploader/MomentAssetsUploader/Item.tsx
@@ -78,6 +78,10 @@ export const Item = memo(function Item({
       }
 
       const { file } = asset
+      if (!(file instanceof File)) {
+        setError(new Error('Moment asset upload file is missing'))
+        return
+      }
 
       const mime = await validateImage(file)
       if (!mime) {

--- a/src/components/FileUploader/MomentAssetsUploader/index.tsx
+++ b/src/components/FileUploader/MomentAssetsUploader/index.tsx
@@ -18,11 +18,21 @@ import styles from './styles.module.css'
 
 export type MomentAsset = {
   id: string
-  file: File
+  file?: File
   uploaded: boolean
   path: string
   assetId?: string
 }
+
+export const getStorableMomentAssets = (assets?: MomentAsset[]) =>
+  (assets || [])
+    .filter(({ uploaded, assetId, path }) => uploaded && assetId && path)
+    .map(({ id, assetId, path }) => ({
+      id,
+      assetId,
+      path,
+      uploaded: true,
+    }))
 
 type MomentAssetsUploaderProps = {
   assets: MomentAsset[]

--- a/src/components/Forms/MomentForm/index.tsx
+++ b/src/components/Forms/MomentForm/index.tsx
@@ -29,7 +29,11 @@ import {
   ViewerContext,
 } from '~/components'
 import MomentEditor from '~/components/Editor/Moment'
-import { MomentAsset, MomentAssetsUploader } from '~/components/FileUploader'
+import {
+  getStorableMomentAssets,
+  MomentAsset,
+  MomentAssetsUploader,
+} from '~/components/FileUploader'
 import { PUT_MOMENT } from '~/components/GQL/mutations/putMoment'
 import { MomentState, PutMomentMutation } from '~/gql/graphql'
 
@@ -74,12 +78,15 @@ const MomentForm = ({ setFirstRendered }: MomentFormProps) => {
   const [isSubmitting, setSubmitting] = useState(false)
   const [editor, setEditor] = useState<Editor | null>(null)
   const [content, setContent] = useState(formDraft?.content || '')
-  const [assets, setAssets] = useState<MomentAsset[]>(formDraft?.assets || [])
+  const [assets, setAssets] = useState<MomentAsset[]>(
+    getStorableMomentAssets(formDraft?.assets)
+  )
   const [isDragging, setIsDragging] = useState(false)
   const updateAssets = (assets: MomentAsset[]) => {
+    const currentDraft = formStorage.get<FormDraft>(formStorageKey, 'local')
     formStorage.set<FormDraft>(
       formStorageKey,
-      { ...formDraft, assets },
+      { ...currentDraft, assets: getStorableMomentAssets(assets) },
       'local'
     )
     setAssets(assets)
@@ -254,9 +261,10 @@ const MomentForm = ({ setFirstRendered }: MomentFormProps) => {
   }
 
   const onUpdate = ({ content: newContent }: { content: string }) => {
+    const currentDraft = formStorage.get<FormDraft>(formStorageKey, 'local')
     formStorage.set<FormDraft>(
       formStorageKey,
-      { ...formDraft, content: newContent },
+      { ...currentDraft, content: newContent },
       'local'
     )
     setContent(newContent)

--- a/src/views/MomentDetail/Edit/index.tsx
+++ b/src/views/MomentDetail/Edit/index.tsx
@@ -26,7 +26,11 @@ import {
   ViewerContext,
 } from '~/components'
 import MomentEditor from '~/components/Editor/Moment'
-import { MomentAsset, MomentAssetsUploader } from '~/components/FileUploader'
+import {
+  getStorableMomentAssets,
+  MomentAsset,
+  MomentAssetsUploader,
+} from '~/components/FileUploader'
 import { PUT_MOMENT } from '~/components/GQL/mutations/putMoment'
 import { PutMomentMutation } from '~/gql/graphql'
 
@@ -52,7 +56,9 @@ const Edit = () => {
   const [isSubmitting, setSubmitting] = useState(false)
   const [editor, setEditor] = useState<Editor | null>(null)
   const [content, setContent] = useState(formDraft?.content || '')
-  const [assets, setAssets] = useState<MomentAsset[]>(formDraft?.assets || [])
+  const [assets, setAssets] = useState<MomentAsset[]>(
+    getStorableMomentAssets(formDraft?.assets)
+  )
 
   const [isClient, setIsClient] = useState(false)
 
@@ -61,9 +67,10 @@ const Edit = () => {
   }, [])
 
   const updateAssets = (assets: MomentAsset[]) => {
+    const currentDraft = formStorage.get<FormDraft>(formStorageKey, 'local')
     formStorage.set<FormDraft>(
       formStorageKey,
-      { ...formDraft, assets },
+      { ...currentDraft, assets: getStorableMomentAssets(assets) },
       'local'
     )
     setAssets(assets)
@@ -153,9 +160,10 @@ const Edit = () => {
   }, [editor])
 
   const onUpdate = ({ content: newContent }: { content: string }) => {
+    const currentDraft = formStorage.get<FormDraft>(formStorageKey, 'local')
     formStorage.set<FormDraft>(
       formStorageKey,
-      { ...formDraft, content: newContent },
+      { ...currentDraft, content: newContent },
       'local'
     )
     setContent(newContent)


### PR DESCRIPTION
## Summary
- Do not persist raw File objects in moment form localStorage drafts.
- Restore only uploaded moment assets with assetId/path from drafts.
- Guard stale restored assets without a real File before upload validation.

## Why
The first hotfix fixed successful direct-upload responses being rejected. A tab that already had a failed upload can still keep stale component/draft state, and localStorage cannot serialize File objects. Reloaded forms can then try to validate a non-Blob file and surface the same unknown-error UI.

## Verification
- npm run i18n
- npm run gen:type:prod
- npm run lint:ts
- npm run format -- --list-different
- commit hook: format, i18n, lint:ts, lint:css

## Follow-up
After merge to master, back-merge master into develop per hotfix SOP.