### PR TITLE
chore: sync moment upload hotfixes + direct-upload fallback to release/next

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matters-web",
-  "version": "6.11.3",
+  "version": "6.11.4",
   "description": "codebase of Matters' website",
   "author": "Matters <hi@matters.town>",
   "engines": {

--- a/src/components/Editor/SetCover/Item.tsx
+++ b/src/components/Editor/SetCover/Item.tsx
@@ -20,11 +20,13 @@ import {
 import {
   DIRECT_IMAGE_UPLOAD,
   DIRECT_IMAGE_UPLOAD_DONE,
+  SINGLE_FILE_UPLOAD,
 } from '~/components/GQL/mutations/uploadFile'
 import {
   AssetType,
   DirectImageUploadDoneMutation,
   DirectImageUploadMutation,
+  SingleFileUploadMutation,
 } from '~/gql/graphql'
 
 import { EditorAsset } from '.'
@@ -64,6 +66,10 @@ const Item: React.FC<ItemProps> = ({
     undefined,
     { showToast: false }
   )
+  const [singleFileUpload, { loading: singleUploading }] =
+    useMutation<SingleFileUploadMutation>(SINGLE_FILE_UPLOAD, undefined, {
+      showToast: false,
+    })
   const { upload: uploadImage, uploading } = useDirectImageUpload()
 
   const { isInPath } = useRoute()
@@ -101,38 +107,71 @@ const Item: React.FC<ItemProps> = ({
           mime,
         },
       }
-      const { data } = await upload({
-        variables: _omit(variables, ['input.file']),
-      })
-
-      const { id: assetId, path, uploadURL } = data?.directImageUpload || {}
-
-      if (assetId && path && uploadURL) {
-        await uploadImage({ uploadURL, file })
-
-        // (async) mark asset draft as false
-        directImageUploadDone({
-          variables: {
-            ..._omit(variables.input, ['file']),
-            draft: false,
-            url: path,
-          },
-        }).catch(console.error)
-        updateAsset({
-          draftId: asset.draftId,
-          id: assetId,
-          path: asset.path,
-          type: ASSET_TYPE.cover as unknown as AssetType,
-          draft: false,
-          file: undefined,
+      const tryDirectUpload = async () => {
+        const { data } = await upload({
+          variables: _omit(variables, ['input.file']),
         })
-        refetchAssets()
 
-        if (data?.directImageUpload) {
-          setSelected(data?.directImageUpload)
+        const { id: assetId, path, uploadURL } = data?.directImageUpload || {}
+
+        if (assetId && path && uploadURL) {
+          await uploadImage({ uploadURL, file })
+
+          // (async) mark asset draft as false
+          directImageUploadDone({
+            variables: {
+              ..._omit(variables.input, ['file']),
+              draft: false,
+              url: path,
+            },
+          }).catch(console.error)
+          updateAsset({
+            draftId: asset.draftId,
+            id: assetId,
+            path: asset.path,
+            type: ASSET_TYPE.cover as unknown as AssetType,
+            draft: false,
+            file: undefined,
+          })
+          refetchAssets()
+
+          if (data?.directImageUpload) {
+            setSelected(data?.directImageUpload)
+          }
+        } else {
+          throw new Error('directImageUpload failed')
         }
-      } else {
-        throw new Error()
+      }
+
+      const trySingleUpload = async () => {
+        const result = await singleFileUpload({
+          variables: { input: _omit(variables.input, ['mime']) },
+        })
+        const uploadedAsset = result?.data?.singleFileUpload
+
+        if (uploadedAsset?.id && uploadedAsset?.path) {
+          updateAsset({
+            draftId: asset.draftId,
+            id: uploadedAsset.id,
+            path: asset.path,
+            type: ASSET_TYPE.cover as unknown as AssetType,
+            draft: false,
+            file: undefined,
+          })
+          refetchAssets()
+          setSelected(uploadedAsset)
+        } else {
+          throw new Error('singleFileUpload failed')
+        }
+      }
+
+      try {
+        await tryDirectUpload()
+      } catch (directUploadError) {
+        console.error(directUploadError)
+
+        // fall back to server-side upload when direct upload fails
+        await trySingleUpload()
       }
     } catch {
       toast.error({
@@ -152,7 +191,7 @@ const Item: React.FC<ItemProps> = ({
     }
   }, [])
 
-  useUnloadConfirm({ block: loading || uploading })
+  useUnloadConfirm({ block: loading || uploading || singleUploading })
 
   const isSelected = asset.id === selected?.id
 
@@ -171,9 +210,9 @@ const Item: React.FC<ItemProps> = ({
           id: 'BNupBu',
         })}
         className={itemClasses}
-        disabled={loading || uploading}
+        disabled={loading || uploading || singleUploading}
       >
-        {(loading || uploading) && (
+        {(loading || uploading || singleUploading) && (
           <div className={styles.loading}>
             <Spinner color="greyLight" size={32} />
           </div>

--- a/src/components/FileUploader/AvatarUploader/index.tsx
+++ b/src/components/FileUploader/AvatarUploader/index.tsx
@@ -25,10 +25,12 @@ import {
 import {
   DIRECT_IMAGE_UPLOAD,
   DIRECT_IMAGE_UPLOAD_DONE,
+  SINGLE_FILE_UPLOAD,
 } from '~/components/GQL/mutations/uploadFile'
 import {
   DirectImageUploadDoneMutation,
   DirectImageUploadMutation,
+  SingleFileUploadMutation,
 } from '~/gql/graphql'
 
 import styles from './styles.module.css'
@@ -66,6 +68,10 @@ export const AvatarUploader: React.FC<AvatarUploaderProps> = ({
     undefined,
     { showToast: false }
   )
+  const [singleFileUpload, { loading: singleUploading }] =
+    useMutation<SingleFileUploadMutation>(SINGLE_FILE_UPLOAD, undefined, {
+      showToast: false,
+    })
   const { upload: uploadImage, uploading } = useDirectImageUpload()
 
   const [avatar, setAvatar] = useState<string | undefined | null>(
@@ -122,27 +128,52 @@ export const AvatarUploader: React.FC<AvatarUploaderProps> = ({
           mime,
         },
       }
-      const { data } = await upload({
-        variables: _omit(variables, ['input.file']),
-      })
-      const { id: assetId, path, uploadURL } = data?.directImageUpload || {}
+      const tryDirectUpload = async () => {
+        const { data } = await upload({
+          variables: _omit(variables, ['input.file']),
+        })
+        const { id: assetId, path, uploadURL } = data?.directImageUpload || {}
 
-      if (assetId && path && uploadURL) {
-        await uploadImage({ uploadURL, file })
+        if (assetId && path && uploadURL) {
+          await uploadImage({ uploadURL, file })
 
-        // (async) mark asset draft as false
-        directImageUploadDone({
-          variables: {
-            ..._omit(variables.input, ['file']),
-            draft: false,
-            url: path,
-          },
-        }).catch(console.error)
+          // (async) mark asset draft as false
+          directImageUploadDone({
+            variables: {
+              ..._omit(variables.input, ['file']),
+              draft: false,
+              url: path,
+            },
+          }).catch(console.error)
 
-        setAvatar(path)
-        onUploaded(assetId, path)
-      } else {
-        throw new Error()
+          setAvatar(path)
+          onUploaded(assetId, path)
+        } else {
+          throw new Error('directImageUpload failed')
+        }
+      }
+
+      const trySingleUpload = async () => {
+        const result = await singleFileUpload({
+          variables: { input: _omit(variables.input, ['mime']) },
+        })
+        const { id: assetId, path } = result?.data?.singleFileUpload || {}
+
+        if (assetId && path) {
+          setAvatar(path)
+          onUploaded(assetId, path)
+        } else {
+          throw new Error('singleFileUpload failed')
+        }
+      }
+
+      try {
+        await tryDirectUpload()
+      } catch (directUploadError) {
+        console.error(directUploadError)
+
+        // fall back to server-side upload when direct upload fails
+        await trySingleUpload()
       }
     } catch {
       toast.error({
@@ -177,7 +208,7 @@ export const AvatarUploader: React.FC<AvatarUploaderProps> = ({
       )}
 
       <div className={styles.mask}>
-        {loading || uploading ? (
+        {loading || uploading || singleUploading ? (
           <SpinnerBlock />
         ) : (
           <Icon icon={IconCamera} color="white" size={32} />

--- a/src/components/FileUploader/CoverUploader/index.tsx
+++ b/src/components/FileUploader/CoverUploader/index.tsx
@@ -26,10 +26,12 @@ import {
 import {
   DIRECT_IMAGE_UPLOAD,
   DIRECT_IMAGE_UPLOAD_DONE,
+  SINGLE_FILE_UPLOAD,
 } from '~/components/GQL/mutations/uploadFile'
 import {
   DirectImageUploadDoneMutation,
   DirectImageUploadMutation,
+  SingleFileUploadMutation,
 } from '~/gql/graphql'
 
 import styles from './styles.module.css'
@@ -104,6 +106,10 @@ export const CoverUploader = ({
     undefined,
     { showToast: false }
   )
+  const [singleFileUpload, { loading: singleUploading }] =
+    useMutation<SingleFileUploadMutation>(SINGLE_FILE_UPLOAD, undefined, {
+      showToast: false,
+    })
   const { upload: uploadImage, uploading } = useDirectImageUpload()
 
   const [localSrc, setLocalSrc] = useState<string | undefined>(undefined)
@@ -150,27 +156,52 @@ export const CoverUploader = ({
       const variables = {
         input: { file, mime, type: assetType, entityId, entityType },
       }
-      const { data } = await upload({
-        variables: _omit(variables, ['input.file']),
-      })
-      const { id: assetId, path, uploadURL } = data?.directImageUpload || {}
+      const tryDirectUpload = async () => {
+        const { data } = await upload({
+          variables: _omit(variables, ['input.file']),
+        })
+        const { id: assetId, path, uploadURL } = data?.directImageUpload || {}
 
-      if (assetId && path && uploadURL) {
-        await uploadImage({ uploadURL, file })
+        if (assetId && path && uploadURL) {
+          await uploadImage({ uploadURL, file })
 
-        // (async) mark asset draft as false
-        directImageUploadDone({
-          variables: {
-            ..._omit(variables.input, ['file']),
-            draft: false,
-            url: path,
-          },
-        }).catch(console.error)
+          // (async) mark asset draft as false
+          directImageUploadDone({
+            variables: {
+              ..._omit(variables.input, ['file']),
+              draft: false,
+              url: path,
+            },
+          }).catch(console.error)
 
-        setCover(path)
-        onUploaded(assetId, path)
-      } else {
-        throw new Error()
+          setCover(path)
+          onUploaded(assetId, path)
+        } else {
+          throw new Error('directImageUpload failed')
+        }
+      }
+
+      const trySingleUpload = async () => {
+        const result = await singleFileUpload({
+          variables: { input: _omit(variables.input, ['mime']) },
+        })
+        const { id: assetId, path } = result?.data?.singleFileUpload || {}
+
+        if (assetId && path) {
+          setCover(path)
+          onUploaded(assetId, path)
+        } else {
+          throw new Error('singleFileUpload failed')
+        }
+      }
+
+      try {
+        await tryDirectUpload()
+      } catch (directUploadError) {
+        console.error(directUploadError)
+
+        // fall back to server-side upload when direct upload fails
+        await trySingleUpload()
       }
     } catch {
       toast.error({
@@ -200,7 +231,7 @@ export const CoverUploader = ({
 
   const Mask = () => (
     <div className={styles.mask}>
-      {loading || uploading ? (
+      {loading || uploading || singleUploading ? (
         <SpinnerBlock />
       ) : (
         <Icon icon={IconCamera} color="white" size={48} />
@@ -215,7 +246,7 @@ export const CoverUploader = ({
     })
     return (
       <div className={maskClasses}>
-        {loading || uploading ? (
+        {loading || uploading || singleUploading ? (
           <SpinnerBlock color={cover ? 'greyLight' : 'white'} />
         ) : (
           <section className={styles.userProfileCover}>
@@ -257,7 +288,7 @@ export const CoverUploader = ({
               title={bookTitle || ''}
               cover={localSrc || cover}
               hasMask
-              loading={loading}
+              loading={loading || singleUploading}
             />
           </section>
         </section>

--- a/src/components/FileUploader/MomentAssetsUploader/Item.tsx
+++ b/src/components/FileUploader/MomentAssetsUploader/Item.tsx
@@ -10,6 +10,7 @@ import { useDirectImageUpload, useMutation, ViewerContext } from '~/components'
 import {
   DIRECT_IMAGE_UPLOAD,
   DIRECT_IMAGE_UPLOAD_DONE,
+  SINGLE_FILE_UPLOAD,
 } from '~/components/GQL/mutations/uploadFile'
 import { Icon } from '~/components/Icon'
 import { ResponsiveImage } from '~/components/ResponsiveImage'
@@ -17,6 +18,7 @@ import { Spinner } from '~/components/Spinner'
 import {
   DirectImageUploadDoneMutation,
   DirectImageUploadMutation,
+  SingleFileUploadMutation,
 } from '~/gql/graphql'
 
 import { MomentAsset } from '.'
@@ -59,6 +61,11 @@ export const Item = memo(function Item({
     { showToast: false }
   )
 
+  const [singleFileUpload, { loading: singleUploading }] =
+    useMutation<SingleFileUploadMutation>(SINGLE_FILE_UPLOAD, undefined, {
+      showToast: false,
+    })
+
   const { upload: uploadImage, uploading } = useDirectImageUpload()
 
   useEffect(() => {
@@ -88,17 +95,17 @@ export const Item = memo(function Item({
         return
       }
 
-      try {
-        const variables = {
-          input: {
-            file,
-            mime,
-            type: ASSET_TYPE.moment,
-            entityId: viewer.id,
-            entityType: ENTITY_TYPE.user,
-          },
-        }
+      const variables = {
+        input: {
+          file,
+          mime,
+          type: ASSET_TYPE.moment,
+          entityId: viewer.id,
+          entityType: ENTITY_TYPE.user,
+        },
+      }
 
+      const tryDirectUpload = async () => {
         const { data } = await upload({
           variables: _omit(variables, ['input.file']),
         })
@@ -119,10 +126,34 @@ export const Item = memo(function Item({
 
           setUploadedAsset({ assetId, path })
         } else {
-          throw new Error()
+          throw new Error('directImageUpload failed')
         }
-      } catch (e) {
-        setError(e as Error)
+      }
+
+      const trySingleUpload = async () => {
+        const result = await singleFileUpload({
+          variables: { input: _omit(variables.input, ['mime']) },
+        })
+        const { id: assetId, path } = result?.data?.singleFileUpload || {}
+
+        if (assetId && path) {
+          setUploadedAsset({ assetId, path })
+        } else {
+          throw new Error('singleFileUpload failed')
+        }
+      }
+
+      try {
+        await tryDirectUpload()
+      } catch (directUploadError) {
+        console.error(directUploadError)
+
+        // fall back to server-side upload when direct upload fails
+        try {
+          await trySingleUpload()
+        } catch (e) {
+          setError(e as Error)
+        }
       }
     }
 
@@ -140,10 +171,10 @@ export const Item = memo(function Item({
         onMouseEnter={() => setHoverAction(true)}
         onMouseLeave={() => setHoverAction(false)}
       >
-        {(loading || uploading) && !hoverAction && (
+        {(loading || uploading || singleUploading) && !hoverAction && (
           <Spinner color="greyDarker" size={24} />
         )}
-        {((!loading && !uploading) || hoverAction) && (
+        {((!loading && !uploading && !singleUploading) || hoverAction) && (
           <Icon icon={IconCircleTimesFill} color="greyDarker" size={24} />
         )}
       </div>

--- a/src/components/FileUploader/MomentAssetsUploader/Item.tsx
+++ b/src/components/FileUploader/MomentAssetsUploader/Item.tsx
@@ -102,11 +102,7 @@ export const Item = memo(function Item({
         const { id: assetId, path, uploadURL } = data?.directImageUpload || {}
 
         if (assetId && path && uploadURL) {
-          const { id: cfImageId } = await uploadImage({ uploadURL, file })
-
-          if (!cfImageId || !path.includes(cfImageId)) {
-            throw new Error()
-          }
+          await uploadImage({ uploadURL, file })
 
           // (async) mark asset draft as false
           directImageUploadDone({

--- a/src/components/FileUploader/MomentAssetsUploader/Item.tsx
+++ b/src/components/FileUploader/MomentAssetsUploader/Item.tsx
@@ -78,6 +78,10 @@ export const Item = memo(function Item({
       }
 
       const { file } = asset
+      if (!(file instanceof File)) {
+        setError(new Error('Moment asset upload file is missing'))
+        return
+      }
 
       const mime = await validateImage(file)
       if (!mime) {

--- a/src/components/FileUploader/MomentAssetsUploader/index.tsx
+++ b/src/components/FileUploader/MomentAssetsUploader/index.tsx
@@ -18,11 +18,21 @@ import styles from './styles.module.css'
 
 export type MomentAsset = {
   id: string
-  file: File
+  file?: File
   uploaded: boolean
   path: string
   assetId?: string
 }
+
+export const getStorableMomentAssets = (assets?: MomentAsset[]) =>
+  (assets || [])
+    .filter(({ uploaded, assetId, path }) => uploaded && assetId && path)
+    .map(({ id, assetId, path }) => ({
+      id,
+      assetId,
+      path,
+      uploaded: true,
+    }))
 
 type MomentAssetsUploaderProps = {
   assets: MomentAsset[]

--- a/src/components/Forms/MomentForm/index.tsx
+++ b/src/components/Forms/MomentForm/index.tsx
@@ -29,7 +29,11 @@ import {
   ViewerContext,
 } from '~/components'
 import MomentEditor from '~/components/Editor/Moment'
-import { MomentAsset, MomentAssetsUploader } from '~/components/FileUploader'
+import {
+  getStorableMomentAssets,
+  MomentAsset,
+  MomentAssetsUploader,
+} from '~/components/FileUploader'
 import { PUT_MOMENT } from '~/components/GQL/mutations/putMoment'
 import { MomentState, PutMomentMutation } from '~/gql/graphql'
 
@@ -74,12 +78,15 @@ const MomentForm = ({ setFirstRendered }: MomentFormProps) => {
   const [isSubmitting, setSubmitting] = useState(false)
   const [editor, setEditor] = useState<Editor | null>(null)
   const [content, setContent] = useState(formDraft?.content || '')
-  const [assets, setAssets] = useState<MomentAsset[]>(formDraft?.assets || [])
+  const [assets, setAssets] = useState<MomentAsset[]>(
+    getStorableMomentAssets(formDraft?.assets)
+  )
   const [isDragging, setIsDragging] = useState(false)
   const updateAssets = (assets: MomentAsset[]) => {
+    const currentDraft = formStorage.get<FormDraft>(formStorageKey, 'local')
     formStorage.set<FormDraft>(
       formStorageKey,
-      { ...formDraft, assets },
+      { ...currentDraft, assets: getStorableMomentAssets(assets) },
       'local'
     )
     setAssets(assets)
@@ -254,9 +261,10 @@ const MomentForm = ({ setFirstRendered }: MomentFormProps) => {
   }
 
   const onUpdate = ({ content: newContent }: { content: string }) => {
+    const currentDraft = formStorage.get<FormDraft>(formStorageKey, 'local')
     formStorage.set<FormDraft>(
       formStorageKey,
-      { ...formDraft, content: newContent },
+      { ...currentDraft, content: newContent },
       'local'
     )
     setContent(newContent)

--- a/src/views/MomentDetail/Edit/index.tsx
+++ b/src/views/MomentDetail/Edit/index.tsx
@@ -26,7 +26,11 @@ import {
   ViewerContext,
 } from '~/components'
 import MomentEditor from '~/components/Editor/Moment'
-import { MomentAsset, MomentAssetsUploader } from '~/components/FileUploader'
+import {
+  getStorableMomentAssets,
+  MomentAsset,
+  MomentAssetsUploader,
+} from '~/components/FileUploader'
 import { PUT_MOMENT } from '~/components/GQL/mutations/putMoment'
 import { PutMomentMutation } from '~/gql/graphql'
 
@@ -52,7 +56,9 @@ const Edit = () => {
   const [isSubmitting, setSubmitting] = useState(false)
   const [editor, setEditor] = useState<Editor | null>(null)
   const [content, setContent] = useState(formDraft?.content || '')
-  const [assets, setAssets] = useState<MomentAsset[]>(formDraft?.assets || [])
+  const [assets, setAssets] = useState<MomentAsset[]>(
+    getStorableMomentAssets(formDraft?.assets)
+  )
 
   const [isClient, setIsClient] = useState(false)
 
@@ -61,9 +67,10 @@ const Edit = () => {
   }, [])
 
   const updateAssets = (assets: MomentAsset[]) => {
+    const currentDraft = formStorage.get<FormDraft>(formStorageKey, 'local')
     formStorage.set<FormDraft>(
       formStorageKey,
-      { ...formDraft, assets },
+      { ...currentDraft, assets: getStorableMomentAssets(assets) },
       'local'
     )
     setAssets(assets)
@@ -153,9 +160,10 @@ const Edit = () => {
   }, [editor])
 
   const onUpdate = ({ content: newContent }: { content: string }) => {
+    const currentDraft = formStorage.get<FormDraft>(formStorageKey, 'local')
     formStorage.set<FormDraft>(
       formStorageKey,
-      { ...formDraft, content: newContent },
+      { ...currentDraft, content: newContent },
       'local'
     )
     setContent(newContent)


### PR DESCRIPTION
Sync all master hotfixes to `release/next` so web-next users stop hitting the image-upload `Unknown Error`:

- #6011 stop rejecting successful moment image uploads
- #6013 keep moment upload drafts serializable
- #6017 fall back to `singleFileUpload` while Cloudflare's direct-upload endpoint returns 415/5550 (site-wide outage; this fallback is what actually restores uploads)
- v6.11.4 version bump

Without #6017's fallback, web-next uploads would still fail even with the first two fixes, since the root cause is on Cloudflare's side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)