### PR TITLE
[hotfix] Clarify moment image upload errors

### DIFF
--- a/lang/default.json
+++ b/lang/default.json
@@ -97,6 +97,9 @@
     "defaultMessage": "Last 1 month",
     "description": "src/views/Me/Analytics/SelectPeriod/index.tsx"
   },
+  "/BZiQv": {
+    "defaultMessage": "Upload Failed"
+  },
   "/GCoTA": {
     "defaultMessage": "Clear"
   },
@@ -2204,6 +2207,9 @@
   },
   "WFCO2w": {
     "defaultMessage": "Set Collection"
+  },
+  "WHd6DD": {
+    "defaultMessage": "Too Frequent"
   },
   "WIOxG+": {
     "defaultMessage": "Collapse",

--- a/lang/en.json
+++ b/lang/en.json
@@ -97,6 +97,9 @@
     "defaultMessage": "Last 1 month",
     "description": "src/views/Me/Analytics/SelectPeriod/index.tsx"
   },
+  "/BZiQv": {
+    "defaultMessage": "Upload Failed"
+  },
   "/GCoTA": {
     "defaultMessage": "Clear"
   },
@@ -2204,6 +2207,9 @@
   },
   "WFCO2w": {
     "defaultMessage": "Set Collection"
+  },
+  "WHd6DD": {
+    "defaultMessage": "Too Frequent"
   },
   "WIOxG+": {
     "defaultMessage": "Collapse",

--- a/lang/zh-Hans.json
+++ b/lang/zh-Hans.json
@@ -97,6 +97,9 @@
     "defaultMessage": "最近 1 个月",
     "description": "src/views/Me/Analytics/SelectPeriod/index.tsx"
   },
+  "/BZiQv": {
+    "defaultMessage": "Upload Failed"
+  },
   "/GCoTA": {
     "defaultMessage": "清空"
   },
@@ -2204,6 +2207,9 @@
   },
   "WFCO2w": {
     "defaultMessage": "关联作品"
+  },
+  "WHd6DD": {
+    "defaultMessage": "Too Frequent"
   },
   "WIOxG+": {
     "defaultMessage": "取消折叠",

--- a/lang/zh-Hant.json
+++ b/lang/zh-Hant.json
@@ -97,6 +97,9 @@
     "defaultMessage": "最近 1 個月",
     "description": "src/views/Me/Analytics/SelectPeriod/index.tsx"
   },
+  "/BZiQv": {
+    "defaultMessage": "Upload Failed"
+  },
   "/GCoTA": {
     "defaultMessage": "清空"
   },
@@ -2204,6 +2207,9 @@
   },
   "WFCO2w": {
     "defaultMessage": "關聯作品"
+  },
+  "WHd6DD": {
+    "defaultMessage": "Too Frequent"
   },
   "WIOxG+": {
     "defaultMessage": "闔上",

--- a/src/components/FileUploader/MomentAssetsUploader/Item.tsx
+++ b/src/components/FileUploader/MomentAssetsUploader/Item.tsx
@@ -1,12 +1,15 @@
+import { ApolloError } from '@apollo/client'
 import _omit from 'lodash/omit'
 import { memo, useContext, useEffect, useState } from 'react'
 import { FormattedMessage } from 'react-intl'
 
 import IconCircleTimesFill from '@/public/static/icons/24px/circle-times-fill.svg'
 import IconWarn from '@/public/static/icons/24px/warn.svg'
+import { ERROR_CODES } from '~/common/enums'
 import { ASSET_TYPE, ENTITY_TYPE } from '~/common/enums/file'
 import { validateImage } from '~/common/utils'
 import { useDirectImageUpload, useMutation, ViewerContext } from '~/components'
+import { getErrorCodes } from '~/components/GQL'
 import {
   DIRECT_IMAGE_UPLOAD,
   DIRECT_IMAGE_UPLOAD_DONE,
@@ -31,6 +34,20 @@ type ItemProps = {
 type UploadedAsset = {
   assetId: string
   path: string
+}
+
+const UploadErrorMessage = ({ error }: { error?: Error }) => {
+  const [code] = getErrorCodes(error as ApolloError)
+
+  if (code === ERROR_CODES.ACTION_LIMIT_EXCEEDED) {
+    return <FormattedMessage defaultMessage="Too Frequent" id="WHd6DD" />
+  }
+
+  if (error) {
+    return <FormattedMessage defaultMessage="Upload Failed" id="/BZiQv" />
+  }
+
+  return <FormattedMessage defaultMessage="Unknown Error" id="tQV8l8" />
 }
 
 export const Item = memo(function Item({
@@ -115,7 +132,13 @@ export const Item = memo(function Item({
               draft: false,
               url: path,
             },
-          }).catch(console.error)
+          }).catch((error) => {
+            console.error('[MomentAssetsUploader] direct upload done failed', {
+              error,
+              assetId,
+              path,
+            })
+          })
 
           setUploadedAsset({ assetId, path })
         } else {
@@ -151,7 +174,7 @@ export const Item = memo(function Item({
         <div className={styles.error}>
           <Icon icon={IconWarn} color="red" size={24} />
           <span>
-            <FormattedMessage defaultMessage="Unknown Error" id="tQV8l8" />
+            <UploadErrorMessage error={error} />
           </span>
         </div>
       )}


### PR DESCRIPTION
## Summary
- Show actionable moment image upload errors instead of always rendering `Unknown Error`.
- Display a specific `Too Frequent` state for `ACTION_LIMIT_EXCEEDED`, which can happen during repeated image upload attempts because `directImageUpload` is rate-limited.
- Add a labeled console error for the background `directImageUploadDone` mutation so future debugging does not only show `#<Object>`.

## Verification
- `npm run i18n`
- `npm run lint:ts`
- `npm run format -- --list-different`
- `git diff --check`
- commit hook: format, i18n, lint:ts, lint:css

## Notes
Follow-up to #6011 and #6013. Production is on the new build, but repeated upload attempts can still surface a generic `Unknown Error`; this PR makes that state diagnosable and user-readable.
