### PR TITLE
[hotfix] Fall back to singleFileUpload while Cloudflare direct upload is down

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matters-web",
-  "version": "6.11.3",
+  "version": "6.11.4",
   "description": "codebase of Matters' website",
   "author": "Matters <hi@matters.town>",
   "engines": {

--- a/src/components/Editor/SetCover/Item.tsx
+++ b/src/components/Editor/SetCover/Item.tsx
@@ -20,11 +20,13 @@ import {
 import {
   DIRECT_IMAGE_UPLOAD,
   DIRECT_IMAGE_UPLOAD_DONE,
+  SINGLE_FILE_UPLOAD,
 } from '~/components/GQL/mutations/uploadFile'
 import {
   AssetType,
   DirectImageUploadDoneMutation,
   DirectImageUploadMutation,
+  SingleFileUploadMutation,
 } from '~/gql/graphql'
 
 import { EditorAsset } from '.'
@@ -64,6 +66,10 @@ const Item: React.FC<ItemProps> = ({
     undefined,
     { showToast: false }
   )
+  const [singleFileUpload, { loading: singleUploading }] =
+    useMutation<SingleFileUploadMutation>(SINGLE_FILE_UPLOAD, undefined, {
+      showToast: false,
+    })
   const { upload: uploadImage, uploading } = useDirectImageUpload()
 
   const { isInPath } = useRoute()
@@ -101,38 +107,71 @@ const Item: React.FC<ItemProps> = ({
           mime,
         },
       }
-      const { data } = await upload({
-        variables: _omit(variables, ['input.file']),
-      })
-
-      const { id: assetId, path, uploadURL } = data?.directImageUpload || {}
-
-      if (assetId && path && uploadURL) {
-        await uploadImage({ uploadURL, file })
-
-        // (async) mark asset draft as false
-        directImageUploadDone({
-          variables: {
-            ..._omit(variables.input, ['file']),
-            draft: false,
-            url: path,
-          },
-        }).catch(console.error)
-        updateAsset({
-          draftId: asset.draftId,
-          id: assetId,
-          path: asset.path,
-          type: ASSET_TYPE.cover as unknown as AssetType,
-          draft: false,
-          file: undefined,
+      const tryDirectUpload = async () => {
+        const { data } = await upload({
+          variables: _omit(variables, ['input.file']),
         })
-        refetchAssets()
 
-        if (data?.directImageUpload) {
-          setSelected(data?.directImageUpload)
+        const { id: assetId, path, uploadURL } = data?.directImageUpload || {}
+
+        if (assetId && path && uploadURL) {
+          await uploadImage({ uploadURL, file })
+
+          // (async) mark asset draft as false
+          directImageUploadDone({
+            variables: {
+              ..._omit(variables.input, ['file']),
+              draft: false,
+              url: path,
+            },
+          }).catch(console.error)
+          updateAsset({
+            draftId: asset.draftId,
+            id: assetId,
+            path: asset.path,
+            type: ASSET_TYPE.cover as unknown as AssetType,
+            draft: false,
+            file: undefined,
+          })
+          refetchAssets()
+
+          if (data?.directImageUpload) {
+            setSelected(data?.directImageUpload)
+          }
+        } else {
+          throw new Error('directImageUpload failed')
         }
-      } else {
-        throw new Error()
+      }
+
+      const trySingleUpload = async () => {
+        const result = await singleFileUpload({
+          variables: { input: _omit(variables.input, ['mime']) },
+        })
+        const uploadedAsset = result?.data?.singleFileUpload
+
+        if (uploadedAsset?.id && uploadedAsset?.path) {
+          updateAsset({
+            draftId: asset.draftId,
+            id: uploadedAsset.id,
+            path: asset.path,
+            type: ASSET_TYPE.cover as unknown as AssetType,
+            draft: false,
+            file: undefined,
+          })
+          refetchAssets()
+          setSelected(uploadedAsset)
+        } else {
+          throw new Error('singleFileUpload failed')
+        }
+      }
+
+      try {
+        await tryDirectUpload()
+      } catch (directUploadError) {
+        console.error(directUploadError)
+
+        // fall back to server-side upload when direct upload fails
+        await trySingleUpload()
       }
     } catch {
       toast.error({
@@ -152,7 +191,7 @@ const Item: React.FC<ItemProps> = ({
     }
   }, [])
 
-  useUnloadConfirm({ block: loading || uploading })
+  useUnloadConfirm({ block: loading || uploading || singleUploading })
 
   const isSelected = asset.id === selected?.id
 
@@ -171,9 +210,9 @@ const Item: React.FC<ItemProps> = ({
           id: 'BNupBu',
         })}
         className={itemClasses}
-        disabled={loading || uploading}
+        disabled={loading || uploading || singleUploading}
       >
-        {(loading || uploading) && (
+        {(loading || uploading || singleUploading) && (
           <div className={styles.loading}>
             <Spinner color="greyLight" size={32} />
           </div>

--- a/src/components/FileUploader/AvatarUploader/index.tsx
+++ b/src/components/FileUploader/AvatarUploader/index.tsx
@@ -25,10 +25,12 @@ import {
 import {
   DIRECT_IMAGE_UPLOAD,
   DIRECT_IMAGE_UPLOAD_DONE,
+  SINGLE_FILE_UPLOAD,
 } from '~/components/GQL/mutations/uploadFile'
 import {
   DirectImageUploadDoneMutation,
   DirectImageUploadMutation,
+  SingleFileUploadMutation,
 } from '~/gql/graphql'
 
 import styles from './styles.module.css'
@@ -66,6 +68,10 @@ export const AvatarUploader: React.FC<AvatarUploaderProps> = ({
     undefined,
     { showToast: false }
   )
+  const [singleFileUpload, { loading: singleUploading }] =
+    useMutation<SingleFileUploadMutation>(SINGLE_FILE_UPLOAD, undefined, {
+      showToast: false,
+    })
   const { upload: uploadImage, uploading } = useDirectImageUpload()
 
   const [avatar, setAvatar] = useState<string | undefined | null>(
@@ -122,27 +128,52 @@ export const AvatarUploader: React.FC<AvatarUploaderProps> = ({
           mime,
         },
       }
-      const { data } = await upload({
-        variables: _omit(variables, ['input.file']),
-      })
-      const { id: assetId, path, uploadURL } = data?.directImageUpload || {}
+      const tryDirectUpload = async () => {
+        const { data } = await upload({
+          variables: _omit(variables, ['input.file']),
+        })
+        const { id: assetId, path, uploadURL } = data?.directImageUpload || {}
 
-      if (assetId && path && uploadURL) {
-        await uploadImage({ uploadURL, file })
+        if (assetId && path && uploadURL) {
+          await uploadImage({ uploadURL, file })
 
-        // (async) mark asset draft as false
-        directImageUploadDone({
-          variables: {
-            ..._omit(variables.input, ['file']),
-            draft: false,
-            url: path,
-          },
-        }).catch(console.error)
+          // (async) mark asset draft as false
+          directImageUploadDone({
+            variables: {
+              ..._omit(variables.input, ['file']),
+              draft: false,
+              url: path,
+            },
+          }).catch(console.error)
 
-        setAvatar(path)
-        onUploaded(assetId, path)
-      } else {
-        throw new Error()
+          setAvatar(path)
+          onUploaded(assetId, path)
+        } else {
+          throw new Error('directImageUpload failed')
+        }
+      }
+
+      const trySingleUpload = async () => {
+        const result = await singleFileUpload({
+          variables: { input: _omit(variables.input, ['mime']) },
+        })
+        const { id: assetId, path } = result?.data?.singleFileUpload || {}
+
+        if (assetId && path) {
+          setAvatar(path)
+          onUploaded(assetId, path)
+        } else {
+          throw new Error('singleFileUpload failed')
+        }
+      }
+
+      try {
+        await tryDirectUpload()
+      } catch (directUploadError) {
+        console.error(directUploadError)
+
+        // fall back to server-side upload when direct upload fails
+        await trySingleUpload()
       }
     } catch {
       toast.error({
@@ -177,7 +208,7 @@ export const AvatarUploader: React.FC<AvatarUploaderProps> = ({
       )}
 
       <div className={styles.mask}>
-        {loading || uploading ? (
+        {loading || uploading || singleUploading ? (
           <SpinnerBlock />
         ) : (
           <Icon icon={IconCamera} color="white" size={32} />

--- a/src/components/FileUploader/CoverUploader/index.tsx
+++ b/src/components/FileUploader/CoverUploader/index.tsx
@@ -26,10 +26,12 @@ import {
 import {
   DIRECT_IMAGE_UPLOAD,
   DIRECT_IMAGE_UPLOAD_DONE,
+  SINGLE_FILE_UPLOAD,
 } from '~/components/GQL/mutations/uploadFile'
 import {
   DirectImageUploadDoneMutation,
   DirectImageUploadMutation,
+  SingleFileUploadMutation,
 } from '~/gql/graphql'
 
 import styles from './styles.module.css'
@@ -104,6 +106,10 @@ export const CoverUploader = ({
     undefined,
     { showToast: false }
   )
+  const [singleFileUpload, { loading: singleUploading }] =
+    useMutation<SingleFileUploadMutation>(SINGLE_FILE_UPLOAD, undefined, {
+      showToast: false,
+    })
   const { upload: uploadImage, uploading } = useDirectImageUpload()
 
   const [localSrc, setLocalSrc] = useState<string | undefined>(undefined)
@@ -150,27 +156,52 @@ export const CoverUploader = ({
       const variables = {
         input: { file, mime, type: assetType, entityId, entityType },
       }
-      const { data } = await upload({
-        variables: _omit(variables, ['input.file']),
-      })
-      const { id: assetId, path, uploadURL } = data?.directImageUpload || {}
+      const tryDirectUpload = async () => {
+        const { data } = await upload({
+          variables: _omit(variables, ['input.file']),
+        })
+        const { id: assetId, path, uploadURL } = data?.directImageUpload || {}
 
-      if (assetId && path && uploadURL) {
-        await uploadImage({ uploadURL, file })
+        if (assetId && path && uploadURL) {
+          await uploadImage({ uploadURL, file })
 
-        // (async) mark asset draft as false
-        directImageUploadDone({
-          variables: {
-            ..._omit(variables.input, ['file']),
-            draft: false,
-            url: path,
-          },
-        }).catch(console.error)
+          // (async) mark asset draft as false
+          directImageUploadDone({
+            variables: {
+              ..._omit(variables.input, ['file']),
+              draft: false,
+              url: path,
+            },
+          }).catch(console.error)
 
-        setCover(path)
-        onUploaded(assetId, path)
-      } else {
-        throw new Error()
+          setCover(path)
+          onUploaded(assetId, path)
+        } else {
+          throw new Error('directImageUpload failed')
+        }
+      }
+
+      const trySingleUpload = async () => {
+        const result = await singleFileUpload({
+          variables: { input: _omit(variables.input, ['mime']) },
+        })
+        const { id: assetId, path } = result?.data?.singleFileUpload || {}
+
+        if (assetId && path) {
+          setCover(path)
+          onUploaded(assetId, path)
+        } else {
+          throw new Error('singleFileUpload failed')
+        }
+      }
+
+      try {
+        await tryDirectUpload()
+      } catch (directUploadError) {
+        console.error(directUploadError)
+
+        // fall back to server-side upload when direct upload fails
+        await trySingleUpload()
       }
     } catch {
       toast.error({
@@ -200,7 +231,7 @@ export const CoverUploader = ({
 
   const Mask = () => (
     <div className={styles.mask}>
-      {loading || uploading ? (
+      {loading || uploading || singleUploading ? (
         <SpinnerBlock />
       ) : (
         <Icon icon={IconCamera} color="white" size={48} />
@@ -215,7 +246,7 @@ export const CoverUploader = ({
     })
     return (
       <div className={maskClasses}>
-        {loading || uploading ? (
+        {loading || uploading || singleUploading ? (
           <SpinnerBlock color={cover ? 'greyLight' : 'white'} />
         ) : (
           <section className={styles.userProfileCover}>
@@ -257,7 +288,7 @@ export const CoverUploader = ({
               title={bookTitle || ''}
               cover={localSrc || cover}
               hasMask
-              loading={loading}
+              loading={loading || singleUploading}
             />
           </section>
         </section>

--- a/src/components/FileUploader/MomentAssetsUploader/Item.tsx
+++ b/src/components/FileUploader/MomentAssetsUploader/Item.tsx
@@ -10,6 +10,7 @@ import { useDirectImageUpload, useMutation, ViewerContext } from '~/components'
 import {
   DIRECT_IMAGE_UPLOAD,
   DIRECT_IMAGE_UPLOAD_DONE,
+  SINGLE_FILE_UPLOAD,
 } from '~/components/GQL/mutations/uploadFile'
 import { Icon } from '~/components/Icon'
 import { ResponsiveImage } from '~/components/ResponsiveImage'
@@ -17,6 +18,7 @@ import { Spinner } from '~/components/Spinner'
 import {
   DirectImageUploadDoneMutation,
   DirectImageUploadMutation,
+  SingleFileUploadMutation,
 } from '~/gql/graphql'
 
 import { MomentAsset } from '.'
@@ -59,6 +61,11 @@ export const Item = memo(function Item({
     { showToast: false }
   )
 
+  const [singleFileUpload, { loading: singleUploading }] =
+    useMutation<SingleFileUploadMutation>(SINGLE_FILE_UPLOAD, undefined, {
+      showToast: false,
+    })
+
   const { upload: uploadImage, uploading } = useDirectImageUpload()
 
   useEffect(() => {
@@ -88,17 +95,17 @@ export const Item = memo(function Item({
         return
       }
 
-      try {
-        const variables = {
-          input: {
-            file,
-            mime,
-            type: ASSET_TYPE.moment,
-            entityId: viewer.id,
-            entityType: ENTITY_TYPE.user,
-          },
-        }
+      const variables = {
+        input: {
+          file,
+          mime,
+          type: ASSET_TYPE.moment,
+          entityId: viewer.id,
+          entityType: ENTITY_TYPE.user,
+        },
+      }
 
+      const tryDirectUpload = async () => {
         const { data } = await upload({
           variables: _omit(variables, ['input.file']),
         })
@@ -119,10 +126,34 @@ export const Item = memo(function Item({
 
           setUploadedAsset({ assetId, path })
         } else {
-          throw new Error()
+          throw new Error('directImageUpload failed')
         }
-      } catch (e) {
-        setError(e as Error)
+      }
+
+      const trySingleUpload = async () => {
+        const result = await singleFileUpload({
+          variables: { input: _omit(variables.input, ['mime']) },
+        })
+        const { id: assetId, path } = result?.data?.singleFileUpload || {}
+
+        if (assetId && path) {
+          setUploadedAsset({ assetId, path })
+        } else {
+          throw new Error('singleFileUpload failed')
+        }
+      }
+
+      try {
+        await tryDirectUpload()
+      } catch (directUploadError) {
+        console.error(directUploadError)
+
+        // fall back to server-side upload when direct upload fails
+        try {
+          await trySingleUpload()
+        } catch (e) {
+          setError(e as Error)
+        }
       }
     }
 
@@ -140,10 +171,10 @@ export const Item = memo(function Item({
         onMouseEnter={() => setHoverAction(true)}
         onMouseLeave={() => setHoverAction(false)}
       >
-        {(loading || uploading) && !hoverAction && (
+        {(loading || uploading || singleUploading) && !hoverAction && (
           <Spinner color="greyDarker" size={24} />
         )}
-        {((!loading && !uploading) || hoverAction) && (
+        {((!loading && !uploading && !singleUploading) || hoverAction) && (
           <Icon icon={IconCircleTimesFill} color="greyDarker" size={24} />
         )}
       </div>


### PR DESCRIPTION
## Summary

Site-wide image uploads (moment, avatar, profile/tag/circle/collection covers, article cover picker) currently fail with `Unknown Error` because Cloudflare's `upload.imagedelivery.net` direct-upload endpoint returns **HTTP 415 `{"code":5550,"message":"Internal Server Error"}`** for all of our direct-upload reservations. The GraphQL leg (`directImageUpload`) is healthy — audit logs show ~1,900 `upload_image status:pending` in the last 48h with **zero** completions.

Reproduction (uploadURL taken from prod server logs, fresh reservation):

```
curl -X POST "https://upload.imagedelivery.net/kDRCweMmqLnTPNlbum-pYA/prod%2Fmoment%2F<uuid>.jpeg" \
  -F "file=@test.jpg;type=image/jpeg"
# → 415 {"result":null,"success":false,"errors":[{"message":"Internal Server Error","code":5550}]}
# control: bogus id → 404 {"code":5404,"message":"Image not found"} (so reservations exist; the upload leg itself is broken)
```

Server-side uploads via `api.cloudflare.com` (`singleFileUpload`, `directImageUploadDone`'s url flow) still work.

## Change

Editor content images (`Me/DraftDetail`, `ArticleDetail/Edit`) already fall back from `directImageUpload` to `singleFileUpload` on failure. This PR applies the exact same fallback pattern to the four call sites that had none:

- `FileUploader/MomentAssetsUploader/Item.tsx` (moments — the user-reported breakage)
- `FileUploader/AvatarUploader/index.tsx`
- `FileUploader/CoverUploader/index.tsx`
- `Editor/SetCover/Item.tsx`

Direct upload remains the primary path, so behavior reverts automatically once Cloudflare fixes their endpoint. Loading indicators account for the fallback mutation's in-flight state.

Also bumps version to `6.11.4` so the `Create Release` workflow stops failing on the already-existing `v6.11.3` tag (it has been red since #6007).

## Hotfix Path

Base branch: `master` (production user-facing uploads are broken site-wide)

SOP note: after merge, open the mandatory `master -> develop` back-merge; `release/next` also needs this (on top of the still-open #6015 sync).

A Cloudflare support ticket should be filed in parallel — this PR is mitigation, not the root-cause fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)