### PR TITLE
fix(quote-image): 修回「貼上金句牆」按鈕（backmerge 掉了 article prop）

### DIFF
--- a/src/views/ArticleDetail/index.tsx
+++ b/src/views/ArticleDetail/index.tsx
@@ -362,6 +362,7 @@ const BaseArticleDetail = ({
           <>
             <Content
               articleId={article.id}
+              article={article}
               content={content}
               indentFirstLine={article.indentFirstLine}
             />


### PR DESCRIPTION
## 問題
正式站/測試站的金句彈窗「貼上金句牆」按鈕不見了（作者名、標題、七日書 logo 也一起消失）。

## 根因
一次 backmerge（master→develop）在解衝突時，把文章內文 `<Content>` 的 `article={article}` 這行**掉了**（master 沒有金句功能，衝突解成 master 版本）。因此 `article` 不再傳進 `TextSelectionPopover` → `canPostQuoteToWall(article)` 恆為 false → 按鈕被隱藏；作者/標題/logo 也因為拿不到 `article` 而消失。

（比對：金句改版 #5996 的 `ArticleDetail/index.tsx` 有這行；現行 develop 少了它。）

## 修法
在 `src/views/ArticleDetail/index.tsx` 的內文 `<Content>` 補回 `article={article}`（一行）。鏈路恢復：
`ArticleDetail <Content article> → Content → TextSelectionPopover article → canPostQuoteToWall(article)`。

## 驗證
- tsc（僅剩既有、無關的 UserDigest 型別漂移）、next lint、prettier 皆綠。
- 部署到 matters.icu 後請真人驗：七日書文章選字 → 金句彈窗應有「貼上金句牆」鈕、卡片有作者/標題/七日書 logo。

> 正式站（matters.town）目前跑的是 develop 衍生 build；此修正併入 develop 後，正式站再從 develop 重新部署即可修復。

🤖 Generated with [Claude Code](https://claude.com/claude-code)