### PR TITLE
fix(quote-image): 補上正式站缺的貼牆按鈕修正＋具體錯誤訊息（#6020＋#6021）

### DIFF
--- a/lang/default.json
+++ b/lang/default.json
@@ -1150,6 +1150,9 @@
   "E8W3qa": {
     "defaultMessage": "Must be between 2-20 characters long. Chinese characters, letters, numbers and underscores are allowed."
   },
+  "EAzXiX": {
+    "defaultMessage": "This event's quote wall isn't open."
+  },
   "EBEwaP": {
     "defaultMessage": "Please fill in a valid email address"
   },
@@ -1479,6 +1482,9 @@
   "JD0T8w": {
     "defaultMessage": "Close Menu",
     "description": "src/components/Editor"
+  },
+  "JHH4g5": {
+    "defaultMessage": "This quote is already on the wall."
   },
   "JTWayV": {
     "defaultMessage": "Add description",
@@ -2160,6 +2166,9 @@
   },
   "UUJzml": {
     "defaultMessage": "Logbook 2.0 has just launched. If you are an owner of Traveloggers, and haven't claimed, you may claim one from the new Logbook page:"
+  },
+  "UVStSp": {
+    "defaultMessage": "The quote must be an exact excerpt of the article. Please select again."
   },
   "Ub+AGc": {
     "defaultMessage": "Sign In"

--- a/lang/en.json
+++ b/lang/en.json
@@ -1150,6 +1150,9 @@
   "E8W3qa": {
     "defaultMessage": "Must be between 2-20 characters long. Chinese characters, letters, numbers and underscores are allowed."
   },
+  "EAzXiX": {
+    "defaultMessage": "This event's quote wall isn't open."
+  },
   "EBEwaP": {
     "defaultMessage": "Please fill in a valid email address"
   },
@@ -1479,6 +1482,9 @@
   "JD0T8w": {
     "defaultMessage": "Close Menu",
     "description": "src/components/Editor"
+  },
+  "JHH4g5": {
+    "defaultMessage": "This quote is already on the wall."
   },
   "JTWayV": {
     "defaultMessage": "Add description",
@@ -2160,6 +2166,9 @@
   },
   "UUJzml": {
     "defaultMessage": "Logbook 2.0 has just launched. If you are an owner of Traveloggers, and haven't claimed, you may claim one from the new Logbook page:"
+  },
+  "UVStSp": {
+    "defaultMessage": "The quote must be an exact excerpt of the article. Please select again."
   },
   "Ub+AGc": {
     "defaultMessage": "Sign In"

--- a/lang/zh-Hans.json
+++ b/lang/zh-Hans.json
@@ -1149,6 +1149,9 @@
   "E8W3qa": {
     "defaultMessage": "2-20 个字符"
   },
+  "EAzXiX": {
+    "defaultMessage": "这个活动尚未开放金句墙。"
+  },
   "EBEwaP": {
     "defaultMessage": "请填写有效邮箱"
   },
@@ -1478,6 +1481,9 @@
   "JD0T8w": {
     "defaultMessage": "关闭菜单",
     "description": "src/components/Editor"
+  },
+  "JHH4g5": {
+    "defaultMessage": "这则金句已经贴过了。"
   },
   "JTWayV": {
     "defaultMessage": "添加描述",
@@ -2159,6 +2165,9 @@
   },
   "UUJzml": {
     "defaultMessage": "Logbook 2.0 刚刚推出。如果你是 Traveloggers 的所有者，且尚未领取，你可以从新的日志页面领取："
+  },
+  "UVStSp": {
+    "defaultMessage": "金句必须是文章原文，请重新选取文章中的段落。"
   },
   "Ub+AGc": {
     "defaultMessage": "登录"

--- a/lang/zh-Hant.json
+++ b/lang/zh-Hant.json
@@ -1149,6 +1149,9 @@
   "E8W3qa": {
     "defaultMessage": "2-20 個字元"
   },
+  "EAzXiX": {
+    "defaultMessage": "這個活動尚未開放金句牆。"
+  },
   "EBEwaP": {
     "defaultMessage": "請填寫有效郵件地址"
   },
@@ -1478,6 +1481,9 @@
   "JD0T8w": {
     "defaultMessage": "關閉選單",
     "description": "src/components/Editor"
+  },
+  "JHH4g5": {
+    "defaultMessage": "這則金句已經貼過了。"
   },
   "JTWayV": {
     "defaultMessage": "添加描述",
@@ -2159,6 +2165,9 @@
   },
   "UUJzml": {
     "defaultMessage": "Logbook 2.0 剛剛推出。如果你是 Traveloggers 的所有者，且尚未領取，你可以從新的日誌頁面領取："
+  },
+  "UVStSp": {
+    "defaultMessage": "金句必須是文章原文，請重新選取文章中的段落。"
   },
   "Ub+AGc": {
     "defaultMessage": "登入"

--- a/src/components/QuoteImageDialog/Content.tsx
+++ b/src/components/QuoteImageDialog/Content.tsx
@@ -1,3 +1,4 @@
+import { ApolloError } from '@apollo/client'
 import { toJpeg } from 'html-to-image'
 import QRCode from 'qrcode'
 import { useEffect, useMemo, useRef, useState } from 'react'
@@ -10,9 +11,27 @@ import { PutQuoteMutation } from '~/gql/graphql'
 
 import { QuoteCard } from './Card'
 import Complete from './Complete'
-import { QuoteWallCampaign } from './gql'
+import { classifyPostToWallError, QuoteWallCampaign } from './gql'
 import { clampQuote, MAX_QUOTE_LEN, QUOTE_SIZES, QUOTE_STYLES } from './presets'
 import styles from './styles.module.css'
+
+// 上牆失敗各原因的友善提示（server 端都回 BAD_USER_INPUT，靠訊息分類）
+const postToWallErrors = defineMessages({
+  duplicate: {
+    defaultMessage: 'This quote is already on the wall.',
+    id: 'JHH4g5',
+  },
+  excerpt: {
+    defaultMessage:
+      'The quote must be an exact excerpt of the article. Please select again.',
+    id: 'UVStSp',
+  },
+  noWall: {
+    defaultMessage: "This event's quote wall isn't open.",
+    id: 'EAzXiX',
+  },
+  generic: { defaultMessage: 'Failed to post to the wall', id: '5IlTNw' },
+})
 
 const PREVIEW_WIDTH = 320 // 預覽寬度（卡片以此等比縮放顯示）
 
@@ -64,7 +83,11 @@ const QuoteImageDialogContent: React.FC<QuoteImageDialogContentProps> = ({
   const [styleId, setStyleId] = useState('warm')
   const [sizeId, setSizeId] = useState('portrait')
   const [qrDataUrl, setQrDataUrl] = useState('')
-  const [putQuote] = useMutation<PutQuoteMutation>(PUT_QUOTE)
+  // showToast: false — 我們在 onPostToWall 依 server 訊息顯示具體原因，
+  // 不讓通用的錯誤 toast 一起跳出（避免雙重、且訊息含糊）
+  const [putQuote] = useMutation<PutQuoteMutation>(PUT_QUOTE, undefined, {
+    showToast: false,
+  })
   const [isPosting, setPosting] = useState(false)
   const [posted, setPosted] = useState(false)
 
@@ -144,16 +167,15 @@ const QuoteImageDialogContent: React.FC<QuoteImageDialogContentProps> = ({
       })
       // 上牆成功後切換到成功頁（含「前往活動頁」），取代原本的 toast
       setPosted(true)
-    } catch {
-      // 每日／同篇上限已於 matters-server#4867 移除，其餘失敗顯示通用訊息
-      toast.error({
-        message: (
-          <FormattedMessage
-            defaultMessage="Failed to post to the wall"
-            id="5IlTNw"
-          />
-        ),
-      })
+    } catch (error) {
+      // server 這些情況都回 BAD_USER_INPUT，靠訊息分類成具體提示
+      // （例如「已貼過」「非文章原文」），比通用的「出錯了」清楚
+      const kind = classifyPostToWallError(
+        error instanceof ApolloError
+          ? error.graphQLErrors?.[0]?.message
+          : undefined
+      )
+      toast.error({ message: intl.formatMessage(postToWallErrors[kind]) })
     } finally {
       setPosting(false)
     }

--- a/src/components/QuoteImageDialog/gql.test.ts
+++ b/src/components/QuoteImageDialog/gql.test.ts
@@ -4,6 +4,7 @@ import { QuoteImageArticleFragment } from '~/gql/graphql'
 
 import {
   canPostQuoteToWall,
+  classifyPostToWallError,
   getQuoteWallCampaign,
   isSevenDayBookArticle,
 } from './gql'
@@ -78,6 +79,30 @@ describe('canPostQuoteToWall', () => {
       false
     )
     expect(canPostQuoteToWall(makeArticle([]))).toBe(false)
+  })
+})
+
+describe('classifyPostToWallError', () => {
+  it('maps each server BAD_USER_INPUT message to a specific reason', () => {
+    expect(classifyPostToWallError('this quote is already on the wall')).toBe(
+      'duplicate'
+    )
+    expect(
+      classifyPostToWallError('quote must be an excerpt of the article')
+    ).toBe('excerpt')
+    expect(
+      classifyPostToWallError('this campaign does not have a quote wall')
+    ).toBe('noWall')
+    expect(
+      classifyPostToWallError('only campaign articles can be quoted onto wall')
+    ).toBe('noWall')
+  })
+
+  it('falls back to generic for unknown or missing messages', () => {
+    expect(classifyPostToWallError('some unexpected error')).toBe('generic')
+    expect(classifyPostToWallError('')).toBe('generic')
+    expect(classifyPostToWallError(undefined)).toBe('generic')
+    expect(classifyPostToWallError(null)).toBe('generic')
   })
 })
 

--- a/src/components/QuoteImageDialog/gql.ts
+++ b/src/components/QuoteImageDialog/gql.ts
@@ -101,3 +101,25 @@ export const getQuoteWallCampaign = (
     nameEn: campaign.nameEn,
   }
 }
+
+/**
+ * 上牆失敗的原因分類。server 端這些情況都回同一個 BAD_USER_INPUT，
+ * 只能靠訊息內容區分，好對應到具體的友善提示。
+ */
+export type PostToWallErrorKind = 'duplicate' | 'excerpt' | 'noWall' | 'generic'
+
+export const classifyPostToWallError = (
+  message?: string | null
+): PostToWallErrorKind => {
+  const m = message || ''
+  if (/already on the wall/i.test(m)) {
+    return 'duplicate'
+  }
+  if (/excerpt/i.test(m)) {
+    return 'excerpt'
+  }
+  if (/quote wall|campaign article/i.test(m)) {
+    return 'noWall'
+  }
+  return 'generic'
+}

--- a/src/views/ArticleDetail/index.tsx
+++ b/src/views/ArticleDetail/index.tsx
@@ -362,6 +362,7 @@ const BaseArticleDetail = ({
           <>
             <Content
               articleId={article.id}
+              article={article}
               content={content}
               indentFirstLine={article.indentFirstLine}
             />


### PR DESCRIPTION
## 背景
release #5991（develop → master）是在這兩個修正**之前**切的，所以正式站雖有金句功能，但：
- 文章內文 `<Content>` 缺 `article={article}` → **「貼上金句牆」按鈕（及卡片作者／標題／七日書 logo）被隱藏**（#6020 要修的）。
- 上牆失敗只顯示含糊的「出錯了」（#6021 要修的）。

#6020（07-06 13:22）與 #6021（07-06 18:41）都晚於 #5991（11:39）才進 develop。

## 內容
把 **#6020 ＋ #6021** 補到 master，**直接採用 develop 上已在 matters.icu 實測過的原檔**（8 檔，無其他改動）：
- `src/views/ArticleDetail/index.tsx`：+1 行 `article={article}`（#6020）
- `QuoteImageDialog/Content.tsx`、`gql.ts`、`gql.test.ts`（#6021）
- `lang/*.json` ×4：僅新增 3 句翻譯（#6021）

## 為何這樣做（相對整包 develop→master）
`master(#5991)` 與 `develop` 的**真實內容差異就只有這 8 檔** = #6020＋#6021，別無其他。此 PR 直接取 develop 原檔，**無合併衝突、面積最小、= ICU 實測版本**。

## 驗證
tsc（僅剩既有無關的 UserDigest 漂移）、next lint、prettier、vitest（17）皆綠。merge 進 master 後 `Deployment` 會以 production 設定部署 matters.town。

🤖 Generated with [Claude Code](https://claude.com/claude-code)