### PR TITLE
Release NCC model and ranking transparency

### DIFF
--- a/src/views/RecommendationTransparency/content.ts
+++ b/src/views/RecommendationTransparency/content.ts
@@ -1,144 +1,288 @@
 const zh_hant = `
-本頁說明 Matters 主要內容入口與排序、推薦或排除機制的公開原則。第一版先用使用者可理解的語言描述資訊架構與影響因素，不公開可被操弄的精確公式。
+本頁說明 Matters 主要內容入口如何排序、推薦或排除內容。以下狀態依 2026 年 7 月 13 日的公開程式與 production 功能開關整理。為降低操弄風險，本頁公開主要訊號、人工介入與使用者控制，不公開精確權重、門檻或時間窗。
+
+## 基本原則
+
+- Matters 沒有一套套用於所有頁面的單一推薦演算法，不同入口依其目的採用不同方式。
+- 應區分時間排序、互動加權、人工精選、主題分流與使用者自行選擇。
+- 反濫用或帳號狀態可能先決定內容是否進入候選池，再由各入口排序。
+- 主要排序或排除規則有重大變更時，應記錄目的、影響範圍與檢視日期。
 
 ## 主要內容入口
 
-Matters 使用者可能透過不同入口看到內容，例如熱門、最新、追蹤、標籤、作者頁、搜尋、活動頁或其他主題入口。不同入口的目的不同，因此排序訊號與篩選條件也可能不同。
+### Matters 精選
 
-## 可能影響排序或可見性的因素
+- 由管理員建立主題、選擇文章並設定部分置頂內容，屬於人工策展。
+- 已發布的主題會取代上一個主題，歷史精選文章則依策展資料的更新順序顯示。
+- 僅顯示有效文章，並排除目前受探索限制的作者。
 
-- 內容發布或更新時間。
-- 使用者追蹤關係。
-- 內容互動訊號，例如閱讀、留言、收藏、讚賞或其他正向互動。
-- 內容狀態，例如正常、隱藏、收合、封存或其他限制狀態。
-- 使用者自行設定，例如追蹤、封鎖、靜音或語言偏好。
-- 站方活動、主題或編輯推薦。
-- 反濫用與 spam 訊號。
+### 熱門文章
 
-不同入口不一定使用全部因素。透明度報告應逐步補上各入口的實際說明。
+- 從近期有效文章建立候選池，主要考量不重複讀者、非作者留言及符合條件的贊助等互動。
+- 越近期的互動影響越大，並使用作者規模校正降低既有追蹤者優勢。
+- 候選文章還須通過最低互動條件。管理員可將特定文章排除於熱門頁。
+- 垃圾內容、受限制作者、特定專屬活動文章及申訴專區文章不進入候選池。
 
-## 內容狀態如何影響可見性
+### 最新文章
 
-若內容被站方、Community Watch、使用者檢舉門檻、管理員處理或反濫用機制標記，該內容可能被隱藏、收合、降低曝光，或從特定入口排除。若內容限制影響使用者權益，應提供可理解的理由與申訴管道。
+- 主要依文章發布順序由新到舊排列，不使用個人化互動分數。
+- 已分流至啟用中主題頻道的文章通常不重複出現在一般最新頁，作者選擇不參與頻道分流時不受此排除。
+- 垃圾內容、專屬活動文章與受探索限制的作者會被排除。
 
-目前申訴管道請參考 [申訴與救濟中心](/appeals)。
+### 追蹤動態
+
+- 依時間顯示使用者所追蹤作者的文章與動態，以及使用者所追蹤標籤的文章活動。
+- 已封鎖的作者與使用者自己的活動會被排除。
+- 同一作者在短時間連續發布多則動態時，介面可能合併顯示，避免單一作者佔滿頁面。
+- 此入口主要由使用者的追蹤選擇形成，不使用熱門文章的互動分數。
+
+### 標籤與主題頻道
+
+- 標籤文章可依最新或熱門顯示，並可包含人工置頂文章。
+- 主題頻道依文章與頻道的相關性分流，通過目前相關性條件的文章才會進入。管理員可置頂、調整順序或移除錯誤分流。
+- 策展頻道由管理員選擇與排序，屬於人工策展。
+- 主題頻道目前已啟用獨立的垃圾內容過濾。
+
+### 熱門動態
+
+- 此功能目前已啟用，從近期有效動態建立候選池。
+- 主要考量按讚與非作者留言，越近期的互動影響越大。
+- 系統會限制同一作者在一段時間內可進入候選池的動態數，降低洗版影響。
+- 候選內容須來自已核准進入動態熱門頁的作者，並排除已被 Community Watch 處理或帳號狀態受限的內容。
+
+### 搜尋與作者頁
+
+- 搜尋由使用者輸入查詢，作者頁則由使用者直接選擇作者，兩者不屬於個人化推薦。
+- 搜尋結果仍會受到內容狀態、帳號狀態與反濫用排除規則影響。
+
+## 反濫用與內容狀態
+
+探索入口通常只納入有效內容。文章垃圾內容分數、管理員覆核結果、垃圾群組限制、帳號凍結或封存，以及特定 Community Watch 處理結果，都可能使內容離開部分候選池。
+
+Discovery probation 截至本頁檢視日為停用狀態，不會透過此機制改變內容可見性。模型與自動化角色另見[自動化與反濫用模型](/transparency/automation)。
 
 ## 使用者可控制的項目
 
-使用者可透過追蹤、取消追蹤、封鎖、語言設定、搜尋與直接造訪作者頁等方式調整自己的閱讀路徑。若未來推出更多推薦偏好控制，應在本頁與透明度報告中更新。
+- 在熱門、最新、追蹤、標籤、主題頻道與其他入口間自行切換。
+- 追蹤或取消追蹤作者及標籤。
+- 封鎖特定使用者，使其不出現在自己的追蹤動態。
+- 使用搜尋、直接造訪作者頁或保存直接連結，不經由推薦入口閱讀。
+- 變更介面語言。介面語言目前不等同於推薦權重偏好。
 
-## 重大變更
+目前沒有可供使用者調整熱門權重、查看單篇「推薦原因」或關閉所有站方排序的統一控制。新增相關控制時，本頁應同步更新。
 
-若主要入口、推薦邏輯、spam exclusion 或內容可見性規則有重大變更，Matters 應在透明度報告或更新紀錄中說明變更目的、影響範圍與申訴方式。
+## 2025 年後主要變更
 
-## 本頁尚待補齊
+- 2025 年 1 月，公開程式將垃圾內容排除納入熱門文章的預設流程。
+- 2025 年 4 月，作者與標籤推薦改以快取候選池及近期互動訊號產生。
+- 2025 年 7 月，熱門文章改用近期閱讀、留言與贊助訊號，加入時間衰減與作者規模校正；主題頻道同期擴充階層與置頂機制。
+- 2025 年 8 月，標籤與策展頻道的人工排序及置頂能力完成整合。
+- 2026 年 6 月，熱門動態候選池、互動加權及單一作者防洗版限制上線並持續調整。
+- 2026 年 7 月，熱門、最新、精選、頻道與搜尋的受限作者排除規則加強；discovery probation 以停用狀態完成預備部署。
 
-- 熱門、最新、追蹤與標籤頁的實際排序邏輯摘要。
-- spam exclusion 與內容狀態如何影響不同入口。
-- 使用者可控制項的完整清單。
-- 重大排序變更紀錄。
+上述日期依公開程式變更紀錄整理。實際權重、門檻與分流細節可能因反濫用需要調整，重大影響變更應於後續透明度報告補記。
+
+## 申訴與更正
+
+若內容因反濫用判定或帳號限制而離開探索入口，使用者可透過[申訴與救濟中心](/appeals)要求重新檢視。一般排序位置會隨時間、互動與策展更新變動，無法保證特定內容取得固定曝光。
 
 ## 相關頁面
 
 - [透明度中心](/transparency)
 - [自動化與反濫用模型](/transparency/automation)
-- [2026 H1 透明度報告骨架](/transparency/2026-h1)
+- [2026 H1 透明度報告](/transparency/2026-h1)
 - [申訴與救濟中心](/appeals)
 `
 
 const zh_hans = `
-本页说明 Matters 主要内容入口与排序、推荐或排除机制的公开原则。第一版先用使用者可理解的语言描述资讯架构与影响因素，不公开可被操弄的精确公式。
+本页说明 Matters 主要内容入口如何排序、推荐或排除内容。以下状态依 2026 年 7 月 13 日的公开代码与 production 功能开关整理。为降低操弄风险，本页公开主要讯号、人工介入与使用者控制，不公开精确权重、门槛或时间窗。
+
+## 基本原则
+
+- Matters 没有一套套用于所有页面的单一推荐演算法，不同入口依其目的采用不同方式。
+- 应区分时间排序、互动加权、人工精选、主题分流与使用者自行选择。
+- 反滥用或帐号状态可能先决定内容是否进入候选池，再由各入口排序。
+- 主要排序或排除规则有重大变更时，应记录目的、影响范围与检视日期。
 
 ## 主要内容入口
 
-Matters 使用者可能透过不同入口看到内容，例如热门、最新、追踪、标签、作者页、搜寻、活动页或其他主题入口。不同入口的目的不同，因此排序讯号与筛选条件也可能不同。
+### Matters 精选
 
-## 可能影响排序或可见性的因素
+- 由管理员建立主题、选择文章并设定部分置顶内容，属于人工策展。
+- 已发布的主题会取代上一个主题，历史精选文章则依策展资料的更新顺序显示。
+- 仅显示有效文章，并排除目前受探索限制的作者。
 
-- 内容发布或更新时间。
-- 使用者追踪关系。
-- 内容互动讯号，例如阅读、留言、收藏、赞赏或其他正向互动。
-- 内容状态，例如正常、隐藏、收合、封存或其他限制状态。
-- 使用者自行设定，例如追踪、封锁、静音或语言偏好。
-- 站方活动、主题或编辑推荐。
-- 反滥用与 spam 讯号。
+### 热门文章
 
-不同入口不一定使用全部因素。透明度报告应逐步补上各入口的实际说明。
+- 从近期有效文章建立候选池，主要考量不重复读者、非作者留言及符合条件的赞助等互动。
+- 越近期的互动影响越大，并使用作者规模校正降低既有追踪者优势。
+- 候选文章还须通过最低互动条件。管理员可将特定文章排除于热门页。
+- 垃圾内容、受限制作者、特定专属活动文章及申诉专区文章不进入候选池。
 
-## 内容状态如何影响可见性
+### 最新文章
 
-若内容被站方、Community Watch、使用者举报门槛、管理员处理或反滥用机制标记，该内容可能被隐藏、收合、降低曝光，或从特定入口排除。若内容限制影响使用者权益，应提供可理解的理由与申诉管道。
+- 主要依文章发布顺序由新到旧排列，不使用个人化互动分数。
+- 已分流至启用中主题频道的文章通常不重复出现在一般最新页，作者选择不参与频道分流时不受此排除。
+- 垃圾内容、专属活动文章与受探索限制的作者会被排除。
 
-目前申诉管道请参考 [申诉与救济中心](/appeals)。
+### 追踪动态
+
+- 依时间显示使用者所追踪作者的文章与动态，以及使用者所追踪标签的文章活动。
+- 已封锁的作者与使用者自己的活动会被排除。
+- 同一作者在短时间连续发布多则动态时，介面可能合并显示，避免单一作者占满页面。
+- 此入口主要由使用者的追踪选择形成，不使用热门文章的互动分数。
+
+### 标签与主题频道
+
+- 标签文章可依最新或热门显示，并可包含人工置顶文章。
+- 主题频道依文章与频道的相关性分流，通过目前相关性条件的文章才会进入。管理员可置顶、调整顺序或移除错误分流。
+- 策展频道由管理员选择与排序，属于人工策展。
+- 主题频道目前已启用独立的垃圾内容过滤。
+
+### 热门动态
+
+- 此功能目前已启用，从近期有效动态建立候选池。
+- 主要考量按赞与非作者留言，越近期的互动影响越大。
+- 系统会限制同一作者在一段时间内可进入候选池的动态数，降低洗版影响。
+- 候选内容须来自已核准进入动态热门页的作者，并排除已被 Community Watch 处理或帐号状态受限的内容。
+
+### 搜索与作者页
+
+- 搜索由使用者输入查询，作者页则由使用者直接选择作者，两者不属于个人化推荐。
+- 搜索结果仍会受到内容状态、帐号状态与反滥用排除规则影响。
+
+## 反滥用与内容状态
+
+探索入口通常只纳入有效内容。文章垃圾内容分数、管理员复核结果、垃圾群组限制、帐号冻结或封存，以及特定 Community Watch 处理结果，都可能使内容离开部分候选池。
+
+Discovery probation 截至本页检视日为停用状态，不会透过此机制改变内容可见性。模型与自动化角色另见[自动化与反滥用模型](/transparency/automation)。
 
 ## 使用者可控制的项目
 
-使用者可透过追踪、取消追踪、封锁、语言设定、搜寻与直接造访作者页等方式调整自己的阅读路径。若未来推出更多推荐偏好控制，应在本页与透明度报告中更新。
+- 在热门、最新、追踪、标签、主题频道与其他入口间自行切换。
+- 追踪或取消追踪作者及标签。
+- 封锁特定使用者，使其不出现在自己的追踪动态。
+- 使用搜索、直接造访作者页或保存直接连结，不经由推荐入口阅读。
+- 变更介面语言。介面语言目前不等同于推荐权重偏好。
 
-## 重大变更
+目前没有可供使用者调整热门权重、查看单篇「推荐原因」或关闭所有站方排序的统一控制。新增相关控制时，本页应同步更新。
 
-若主要入口、推荐逻辑、spam exclusion 或内容可见性规则有重大变更，Matters 应在透明度报告或更新记录中说明变更目的、影响范围与申诉方式。
+## 2025 年后主要变更
 
-## 本页尚待补齐
+- 2025 年 1 月，公开代码将垃圾内容排除纳入热门文章的预设流程。
+- 2025 年 4 月，作者与标签推荐改以快取候选池及近期互动讯号产生。
+- 2025 年 7 月，热门文章改用近期阅读、留言与赞助讯号，加入时间衰减与作者规模校正；主题频道同期扩充阶层与置顶机制。
+- 2025 年 8 月，标签与策展频道的人工排序及置顶能力完成整合。
+- 2026 年 6 月，热门动态候选池、互动加权及单一作者防洗版限制上线并持续调整。
+- 2026 年 7 月，热门、最新、精选、频道与搜索的受限作者排除规则加强；discovery probation 以停用状态完成预备部署。
 
-- 热门、最新、追踪与标签页的实际排序逻辑摘要。
-- spam exclusion 与内容状态如何影响不同入口。
-- 使用者可控制项的完整清单。
-- 重大排序变更记录。
+上述日期依公开代码变更记录整理。实际权重、门槛与分流细节可能因反滥用需要调整，重大影响变更应于后续透明度报告补记。
+
+## 申诉与更正
+
+若内容因反滥用判定或帐号限制而离开探索入口，使用者可透过[申诉与救济中心](/appeals)要求重新检视。一般排序位置会随时间、互动与策展更新变动，无法保证特定内容取得固定曝光。
 
 ## 相关页面
 
 - [透明度中心](/transparency)
 - [自动化与反滥用模型](/transparency/automation)
-- [2026 H1 透明度报告骨架](/transparency/2026-h1)
+- [2026 H1 透明度报告](/transparency/2026-h1)
 - [申诉与救济中心](/appeals)
 `
 
 const en = `
-This page explains the public principles behind Matters content entry points, ranking, recommendation, and exclusion mechanisms. This first version uses user-readable language and does not disclose exact formulas that could be manipulated.
+This page explains how Matters ranks, recommends, or excludes content across its main discovery surfaces. The statuses below reflect public code and production feature flags reviewed on July 13, 2026. To reduce manipulation risk, this page discloses primary signals, human intervention, and user controls without publishing exact weights, thresholds, or time windows.
 
-## Main content entry points
+## Principles
 
-Users may discover content through hot, latest, following, tags, author pages, search, campaigns, or topic entry points. Each entry point has a different purpose, so ranking signals and filters may differ.
+- Matters does not use one recommendation algorithm across every page. Each surface uses a method suited to its purpose.
+- Chronological ordering, engagement ranking, human curation, topic routing, and user choice should be distinguished.
+- Anti-abuse and account state may determine whether content enters a candidate pool before a surface ranks it.
+- Major changes to ranking or exclusion rules should record their purpose, affected scope, and review date.
 
-## Factors that may affect ranking or visibility
+## Main content surfaces
 
-- Publish or update time.
-- Following relationships.
-- Engagement signals such as reads, comments, bookmarks, appreciations, or other positive interactions.
-- Content state, such as normal, hidden, collapsed, archived, or restricted.
-- User choices, such as following, blocking, muting, or language preference.
-- Campaigns, topics, or editorial selections.
-- Anti-abuse and spam signals.
+### Matters Picks
 
-Not every entry point uses all factors. Transparency reports should gradually add concrete explanations for each surface.
+- Staff create a topic, select articles, and designate some pinned items. This is human curation.
+- Publishing a topic replaces the previous topic. Historical picks are shown according to the curation data's update order.
+- Only active articles are shown, and authors currently restricted from discovery are excluded.
 
-## How content state affects visibility
+### Hottest articles
 
-If content is marked by staff, Community Watch, report thresholds, admins, or anti-abuse systems, it may be hidden, collapsed, demoted, or excluded from some surfaces. When restrictions affect user interests, Matters should provide understandable reasons and appeal channels.
+- A candidate pool is built from recent active articles. Primary engagement signals include unique readers, comments from people other than the author, and qualifying support transactions.
+- More recent engagement has greater influence. Author-size normalization reduces the advantage of an established follower base.
+- Candidates must also meet minimum engagement conditions. Staff may exclude a specific article from Hottest.
+- Spam, restricted authors, some exclusive campaign articles, and Complaint Area articles are excluded from the pool.
 
-Current appeal channels are listed on [Appeals and Remedies](/appeals).
+### Newest articles
+
+- Articles are primarily ordered from newest to oldest and do not use personalized engagement scores.
+- Articles routed to enabled topic channels generally do not also appear in the general Newest feed. This exclusion does not apply when the author has opted out of channel routing.
+- Spam, exclusive campaign articles, and authors restricted from discovery are excluded.
+
+### Following activity
+
+- Activity is ordered by time and includes articles and moments from followed authors, plus article activity for followed tags.
+- Blocked authors and the viewer's own activity are excluded.
+- When one author posts several moments in a short period, the interface may group them to keep one author from filling the feed.
+- This surface is primarily shaped by user follow choices and does not use the Hottest article engagement score.
+
+### Tags and channels
+
+- Tag articles can be shown by newest or hottest and may include manually pinned articles.
+- Topic channels route articles according to article-channel relevance. Only articles meeting the current relevance conditions enter. Staff may pin, reorder, or remove incorrect routing.
+- Curation channels are selected and ordered by staff and are therefore human-curated.
+- Topic channels currently have a separate spam filter enabled.
+
+### Hottest moments
+
+- This feature is currently enabled and builds a pool from recent active moments.
+- Primary signals are likes and comments from people other than the author, with more recent engagement carrying more influence.
+- The system limits how many moments from one author can enter within a time window to reduce flooding.
+- Candidates must come from authors approved for the moment feed. Content handled by Community Watch or restricted by account state is excluded.
+
+### Search and author pages
+
+- Search is driven by a user's query, and an author page is opened through a direct user choice. Neither is a personalized recommendation surface.
+- Search results are still affected by content state, account state, and anti-abuse exclusions.
+
+## Anti-abuse and content state
+
+Discovery surfaces generally include active content only. Article spam scores, staff review outcomes, spam-ring restrictions, frozen or archived accounts, and some Community Watch outcomes can remove content from candidate pools.
+
+Discovery probation was disabled on the review date and does not currently change visibility. See [Automation and Anti-Abuse Models](/transparency/automation) for model and automation roles.
 
 ## User controls
 
-Users can adjust their reading path through following, unfollowing, blocking, language settings, search, and direct visits to author pages. If more recommendation preference controls are added, this page and transparency reports should be updated.
+- Switch among Hottest, Newest, Following, tags, topic channels, and other entry points.
+- Follow or unfollow authors and tags.
+- Block a user so they do not appear in the viewer's Following activity.
+- Use search, visit an author page directly, or keep a direct link instead of relying on a recommendation surface.
+- Change interface language. Interface language is not currently a recommendation-weight preference.
 
-## Major changes
+There is currently no unified control for changing Hottest weights, seeing a per-item recommendation reason, or disabling all platform ranking. This page should be updated when such controls are added.
 
-When major entry points, recommendation logic, spam exclusion, or visibility rules change, Matters should explain the purpose, affected scope, and appeal channels in transparency reports or change logs.
+## Major changes since 2025
 
-## To be completed
+- January 2025, public code made spam exclusion part of the default Hottest article flow.
+- April 2025, author and tag recommendations moved to cached candidate pools built from recent engagement signals.
+- July 2025, Hottest articles moved to recent read, comment, and support signals with time decay and author-size normalization. Topic channels also gained hierarchy and pinning support.
+- August 2025, manual ordering and pinning were integrated across tag and curation channels.
+- June 2026, the Hottest moments candidate pool, engagement weighting, and per-author anti-flood limit were introduced and tuned.
+- July 2026, restricted-author exclusions were strengthened across Hottest, Newest, Picks, channels, and search. Discovery probation was prepared in a disabled state.
 
-- Summaries of actual ranking logic for hot, latest, following, and tag pages.
-- How spam exclusion and content state affect each surface.
-- Complete list of user controls.
-- Major ranking change logs.
+These dates are based on public code change records. Exact weights, thresholds, and routing details may change for anti-abuse reasons. Changes with material impact should be added to later transparency reports.
+
+## Appeals and corrections
+
+When anti-abuse classification or an account restriction removes content from discovery, users may request another review through [Appeals and Remedies](/appeals). Ordinary ranking positions change with time, engagement, and curation and do not guarantee fixed exposure for any item.
 
 ## Related pages
 
 - [Transparency Center](/transparency)
 - [Automation and Anti-Abuse Models](/transparency/automation)
-- [2026 H1 Transparency Report Skeleton](/transparency/2026-h1)
+- [2026 H1 Transparency Report](/transparency/2026-h1)
 - [Appeals and Remedies](/appeals)
 `
 

--- a/src/views/TransparencyAutomation/content.ts
+++ b/src/views/TransparencyAutomation/content.ts
@@ -1,9 +1,9 @@
 const zh_hant = `
-本頁說明 Matters 在內容治理與反濫用工作中，如何使用自動化、模型輔助與人工判斷。第一版先公開原則與邊界，實際模型版本、production flag 與統計數字仍需在透明度報告中定期更新。
+本頁說明 Matters 在內容治理與反濫用工作中，如何使用自動化、模型輔助與人工判斷。以下狀態依 2026 年 7 月 13 日的 production 設定整理。模型版本、功能開關與處理統計將隨透明度報告定期更新。
 
 ## 基本原則
 
-- 不以未經覆核的模型分數作為處理使用者的唯一依據。
+- 不以未經覆核的模型分數作為限制使用者帳號的唯一依據。
 - 明確區分模型提示、模型輔助、人工審查與自動化處理。
 - 影響內容可見性或帳號狀態時，應提供可理解的處理理由與申訴管道。
 - 不公開可被濫用來規避偵測的完整門檻、特徵或操作細節。
@@ -11,56 +11,87 @@ const zh_hant = `
 
 ## 自動化角色
 
-Matters 會用以下方式描述模型或自動化在個案中的角色。
+Matters 會用以下標籤描述模型或自動化在個案中的角色。
 
 - none 表示未使用模型或自動化。
 - suggested 表示模型只提供候選或提示，仍需人工判斷。
 - assisted 表示模型結果協助排序、分流或提示審查者。
 - automated 表示系統在符合條件時自動改變內容可見性或狀態。
 
-若某個功能目前只在 shadow、dry-run 或 notify-only 模式運作，透明度報告應明確標示。
+若某個功能只在 shadow、dry-run 或 notify-only 模式運作，透明度報告應明確標示。
+
+## 目前使用中的系統
+
+### 文章垃圾內容分類
+
+- production 部署識別碼為 article-spam-model-v20251229。
+- 使用範圍為文章發布時的垃圾內容評分、探索分發與主題頻道過濾。
+- 自動化角色為 automated。全站垃圾內容偵測與主題頻道過濾目前均已啟用。
+- 達到系統條件的文章可能不進入部分探索、搜尋索引或後續分發流程。管理員仍可覆核及更正判定。
+- 使用者可透過[申訴與救濟中心](/appeals)要求重新檢視。
+
+### 留言垃圾內容評分
+
+- production 部署識別碼為 spam-comment-model-service。
+- 使用範圍為留言垃圾內容評分與管理員審查通知。
+- 自動化角色為 assisted。評分與 notify-only 通知目前已啟用。
+- 自動收合目前未啟用，模型分數本身不會隱藏或刪除留言。採取處理措施前仍需人工判斷。
+- Community Watch 的處理範圍與權限另依其公開規則辦理。
+
+### 動態垃圾內容評分
+
+- production 部署識別碼為 moment-spam-model-service。
+- 使用範圍為動態垃圾內容評分與管理員審查排序。
+- 自動化角色為 assisted。模型分數本身不會自動隱藏、刪除或限制動態。
+- 是否採取處理措施由管理員依內容與相關證據判斷。
+
+### 協同行為與垃圾群組偵測
+
+- 本系統是規則與聚合流程，沒有單一模型版本。
+- 使用範圍為發現疑似協同垃圾行為，並將待審查成員暫時排除於部分探索頁面。
+- 自動化角色為 automated，且每個候選群組均須由管理員覆核。
+- 管理員可確認處理、排除誤判或解除限制。若同一成員仍屬於其他有效案件，相關限制可能繼續存在。
+
+### Discovery probation
+
+- 此功能開關截至本頁檢視日為停用狀態。
+- 停用期間不會透過此機制改變內容或帳號狀態。
 
 ## Community Watch
 
 Community Watch 第一階段由受託使用者處理明確垃圾留言，理由限於「色情廣告」與「濫發廣告」。規則明定 AI 不得直接刪除留言。AI 或模型若被使用，只能作為候選檢測、提示或後續評測資料來源。
 
-## Spam 與濫用偵測
-
-Matters 的反濫用工作可能使用留言、文章或動態相關訊號來協助發現 spam、廣告導流、重複內容或其他濫用行為。模型輸出可能用於告警、排序審查佇列、提供人工提示，或在特定功能開關啟用時影響內容可見性。
-
-正式透明度報告應揭露每期使用的模式、影響範圍、是否直接處理內容、人工審查角色、申訴數與恢復數。
-
 ## 使用者通知與申訴
 
 若內容或帳號因使用者檢舉、Community Watch、管理員處理、模型輔助或自動化而受到限制，通知應盡量說明處理來源、公開理由、可申訴管道與可補充資料。
 
-目前申訴管道請參考 [申訴與救濟中心](/appeals)。
+目前申訴管道請參考[申訴與救濟中心](/appeals)。
 
 ## 資料與隱私
 
 反濫用資料可能包含使用者內容、處理理由、覆核結果與時間戳。若資料用於訓練或評測，應盡量去識別化、避免散播垃圾連結或色情內容，並保留必要的人工理由與覆核結果。
 
-## 本頁尚待補齊
+## 後續定期揭露
 
-- 每個 production 模型的版本、用途與狀態。
-- 每期模型輔助與自動化處理比例。
-- 模型導致的誤判、申訴與恢復統計。
-- 重大模型或門檻變更紀錄。
+- 每期模型輔助與自動化處理的案件數及比例。
+- 模型相關誤判、申訴、維持原決定與恢復統計。
+- 重大模型、處理模式或門檻變更紀錄。
+- 統計期間、資料來源、低件數保護與資料限制。
 
 ## 相關頁面
 
 - [透明度中心](/transparency)
-- [2026 H1 透明度報告骨架](/transparency/2026-h1)
+- [2026 H1 透明度報告](/transparency/2026-h1)
 - [申訴與救濟中心](/appeals)
 - [Community Watch 規則](https://community-watch.matters.town/rules/)
 `
 
 const zh_hans = `
-本页说明 Matters 在内容治理与反滥用工作中，如何使用自动化、模型辅助与人工判断。第一版先公开原则与边界，实际模型版本、production flag 与统计数字仍需在透明度报告中定期更新。
+本页说明 Matters 在内容治理与反滥用工作中，如何使用自动化、模型辅助与人工判断。以下状态依 2026 年 7 月 13 日的 production 设置整理。模型版本、功能开关与处理统计将随透明度报告定期更新。
 
 ## 基本原则
 
-- 不以未经复核的模型分数作为处理使用者的唯一依据。
+- 不以未经复核的模型分数作为限制使用者帐号的唯一依据。
 - 明确区分模型提示、模型辅助、人工审查与自动化处理。
 - 影响内容可见性或帐号状态时，应提供可理解的处理理由与申诉管道。
 - 不公开可被滥用来规避侦测的完整门槛、特征或操作细节。
@@ -68,56 +99,87 @@ const zh_hans = `
 
 ## 自动化角色
 
-Matters 会用以下方式描述模型或自动化在个案中的角色。
+Matters 会用以下标签描述模型或自动化在个案中的角色。
 
 - none 表示未使用模型或自动化。
 - suggested 表示模型只提供候选或提示，仍需人工判断。
 - assisted 表示模型结果协助排序、分流或提示审查者。
 - automated 表示系统在符合条件时自动改变内容可见性或状态。
 
-若某个功能目前只在 shadow、dry-run 或 notify-only 模式运作，透明度报告应明确标示。
+若某个功能只在 shadow、dry-run 或 notify-only 模式运作，透明度报告应明确标示。
+
+## 目前使用中的系统
+
+### 文章垃圾内容分类
+
+- production 部署识别码为 article-spam-model-v20251229。
+- 使用范围为文章发布时的垃圾内容评分、探索分发与主题频道过滤。
+- 自动化角色为 automated。全站垃圾内容侦测与主题频道过滤目前均已启用。
+- 达到系统条件的文章可能不进入部分探索、搜索索引或后续分发流程。管理员仍可复核及更正判定。
+- 使用者可透过[申诉与救济中心](/appeals)要求重新检视。
+
+### 留言垃圾内容评分
+
+- production 部署识别码为 spam-comment-model-service。
+- 使用范围为留言垃圾内容评分与管理员审查通知。
+- 自动化角色为 assisted。评分与 notify-only 通知目前已启用。
+- 自动收合目前未启用，模型分数本身不会隐藏或删除留言。采取处理措施前仍需人工判断。
+- Community Watch 的处理范围与权限另依其公开规则办理。
+
+### 动态垃圾内容评分
+
+- production 部署识别码为 moment-spam-model-service。
+- 使用范围为动态垃圾内容评分与管理员审查排序。
+- 自动化角色为 assisted。模型分数本身不会自动隐藏、删除或限制动态。
+- 是否采取处理措施由管理员依内容与相关证据判断。
+
+### 协同行为与垃圾群组侦测
+
+- 本系统是规则与聚合流程，没有单一模型版本。
+- 使用范围为发现疑似协同垃圾行为，并将待审查成员暂时排除于部分探索页面。
+- 自动化角色为 automated，且每个候选群组均须由管理员复核。
+- 管理员可确认处理、排除误判或解除限制。若同一成员仍属于其他有效案件，相关限制可能继续存在。
+
+### Discovery probation
+
+- 此功能开关截至本页检视日为停用状态。
+- 停用期间不会透过此机制改变内容或帐号状态。
 
 ## Community Watch
 
 Community Watch 第一阶段由受托使用者处理明确垃圾留言，理由限于「色情广告」与「滥发广告」。规则明定 AI 不得直接删除留言。AI 或模型若被使用，只能作为候选检测、提示或后续评测资料来源。
 
-## Spam 与滥用侦测
-
-Matters 的反滥用工作可能使用留言、文章或动态相关讯号来协助发现 spam、广告导流、重复内容或其他滥用行为。模型输出可能用于告警、排序审查伫列、提供人工提示，或在特定功能开关启用时影响内容可见性。
-
-正式透明度报告应揭露每期使用的模式、影响范围、是否直接处理内容、人工审查角色、申诉数与恢复数。
-
 ## 使用者通知与申诉
 
 若内容或帐号因使用者举报、Community Watch、管理员处理、模型辅助或自动化而受到限制，通知应尽量说明处理来源、公开理由、可申诉管道与可补充资料。
 
-目前申诉管道请参考 [申诉与救济中心](/appeals)。
+目前申诉管道请参考[申诉与救济中心](/appeals)。
 
 ## 资料与隐私
 
 反滥用资料可能包含使用者内容、处理理由、复核结果与时间戳。若资料用于训练或评测，应尽量去识别化、避免散播垃圾连结或色情内容，并保留必要的人工理由与复核结果。
 
-## 本页尚待补齐
+## 后续定期揭露
 
-- 每个 production 模型的版本、用途与状态。
-- 每期模型辅助与自动化处理比例。
-- 模型导致的误判、申诉与恢复统计。
-- 重大模型或门槛变更记录。
+- 每期模型辅助与自动化处理的案件数及比例。
+- 模型相关误判、申诉、维持原决定与恢复统计。
+- 重大模型、处理模式或门槛变更记录。
+- 统计期间、资料来源、低件数保护与资料限制。
 
 ## 相关页面
 
 - [透明度中心](/transparency)
-- [2026 H1 透明度报告骨架](/transparency/2026-h1)
+- [2026 H1 透明度报告](/transparency/2026-h1)
 - [申诉与救济中心](/appeals)
 - [Community Watch 规则](https://community-watch.matters.town/rules/)
 `
 
 const en = `
-This page explains how Matters uses automation, model assistance, and human judgment in content governance and anti-abuse work. This first version publishes principles and boundaries. Actual model versions, production flags, and metrics should be updated through transparency reports.
+This page explains how Matters uses automation, model assistance, and human judgment in content governance and anti-abuse work. The statuses below reflect production configuration reviewed on July 13, 2026. Model versions, feature flags, and handling metrics will be updated through periodic transparency reports.
 
 ## Principles
 
-- Do not use unreviewed model scores as the sole basis for user-facing enforcement.
+- Do not use unreviewed model scores as the sole basis for restricting a user account.
 - Clearly distinguish model hints, model assistance, human review, and automated actions.
 - When content visibility or account state is affected, provide understandable reasons and appeal channels.
 - Do not disclose exact thresholds, features, or operational details that would help abuse.
@@ -134,15 +196,46 @@ Matters uses the following labels to describe the role of models or automation i
 
 If a feature is shadow-only, dry-run, or notify-only, the transparency report should state that clearly.
 
+## Systems currently in use
+
+### Article spam classification
+
+- Production deployment identifier is article-spam-model-v20251229.
+- The system scores articles during publication and informs discovery distribution and topic-channel filtering.
+- Its automation role is automated. Global spam detection and topic-channel filtering are currently enabled.
+- Articles meeting configured conditions may be withheld from some discovery, search indexing, or downstream distribution processes. Staff can review and correct the classification.
+- Users may request another review through [Appeals and Remedies](/appeals).
+
+### Comment spam scoring
+
+- Production deployment identifier is spam-comment-model-service.
+- The system scores comments and sends staff review alerts.
+- Its automation role is assisted. Scoring and notify-only alerts are currently enabled.
+- Automatic collapsing is not enabled. A model score alone does not hide or delete a comment, and staff judgment is required before enforcement.
+- Community Watch has separate published rules governing its scope and permissions.
+
+### Moment spam scoring
+
+- Production deployment identifier is moment-spam-model-service.
+- The system scores moments and helps order staff review.
+- Its automation role is assisted. A model score alone does not hide, delete, or restrict a moment.
+- Staff decide whether to act after reviewing the content and related evidence.
+
+### Coordinated behavior and spam-ring detection
+
+- This is a rules and aggregation pipeline, not a single versioned model.
+- It identifies suspected coordinated spam behavior and temporarily excludes pending members from some discovery surfaces.
+- Its automation role is automated, and every candidate ring requires staff review.
+- Staff can confirm action, dismiss a false positive, or lift restrictions. Restrictions may remain if the same member is still part of another active case.
+
+### Discovery probation
+
+- This feature flag was disabled on the review date.
+- While disabled, it does not change content or account state.
+
 ## Community Watch
 
 Community Watch is handled by trusted users in its first phase. The scope is limited to clear porn ads and spam ads. The rules state that AI may not directly remove comments. AI or models may only be used for candidate detection, hints, or later evaluation data.
-
-## Spam and abuse detection
-
-Matters anti-abuse work may use comment, article, or moment signals to help identify spam, ad routing, repeated content, or other abuse. Model output may be used for alerts, review queue ranking, human hints, or visibility changes when a specific feature flag is enabled.
-
-Formal transparency reports should disclose the mode used in each period, affected surfaces, whether content was directly handled, human review roles, appeals, and restorations.
 
 ## User notice and appeals
 
@@ -154,17 +247,17 @@ Current appeal channels are listed on [Appeals and Remedies](/appeals).
 
 Anti-abuse data may include user content, handling reasons, review outcomes, and timestamps. When used for training or evaluation, Matters should reduce identifiability, avoid spreading spam links or sexual content, and preserve necessary human reasons and review outcomes.
 
-## To be completed
+## Future periodic disclosures
 
-- Version, purpose, and status for each production model.
-- Model-assisted and automated action ratios for each reporting period.
-- Mistake, appeal, and restoration metrics related to models.
-- Major model or threshold change logs.
+- Counts and ratios of model-assisted and automated handling for each period.
+- Model-related mistakes, appeals, upheld decisions, and restorations.
+- Major model, handling-mode, or threshold change logs.
+- Reporting periods, data sources, low-count protections, and data limitations.
 
 ## Related pages
 
 - [Transparency Center](/transparency)
-- [2026 H1 Transparency Report Skeleton](/transparency/2026-h1)
+- [2026 H1 Transparency Report](/transparency/2026-h1)
 - [Appeals and Remedies](/appeals)
 - [Community Watch rules](https://community-watch.matters.town/rules/)
 `


### PR DESCRIPTION
## Summary

Promote the merged NCC P2 transparency copy from `develop` to `master`.

Initial scope at creation:
- automation and anti-abuse model roles
- recommendation and ranking transparency
- three languages

## Change boundary

The initial comparison contains only:
- `src/views/TransparencyAutomation/content.ts`
- `src/views/RecommendationTransparency/content.ts`

This changes public disclosure copy only. It does not change ranking behavior, model behavior, feature flags, thresholds, data structures, APIs, or admin permissions.

## Included PRs

- #6031
- #6032

## Production gate

Keep this PR as Draft until the current #6030 production rollout is complete and the merged pages have been verified on staging. Recheck the `develop` to `master` diff immediately before marking Ready or merging, because the head branch can move.