### PR TITLE
feat: open Fediverse publishing to all authors

### DIFF
--- a/lang/default.json
+++ b/lang/default.json
@@ -2068,7 +2068,7 @@
   "Sj+TN8": {
     "defaultMessage": "Announcement"
   },
-  "Su1LcW": {
+  "2cnZc/": {
     "defaultMessage": "開啟後，新發佈的公開作品會自動送到 Fediverse。其他站台可能保留副本；關閉後將停止同步，並嘗試刪除先前內容。"
   },
   "SuRTsQ": {
@@ -2455,7 +2455,7 @@
     "defaultMessage": "Archived for violation.",
     "description": "src/views/ArticleDetail/StickyTopBanner/index.tsx"
   },
-  "ZAoAcG": {
+  "cY80V3": {
     "defaultMessage": "公開作品會自動送出，遠端站台可能保留副本"
   },
   "ZAs170": {

--- a/lang/default.json
+++ b/lang/default.json
@@ -2069,7 +2069,7 @@
     "defaultMessage": "Announcement"
   },
   "Su1LcW": {
-    "defaultMessage": "開啟後，新發佈作品預設可輸出到 Fediverse。"
+    "defaultMessage": "開啟後，新發佈的公開作品會自動送到 Fediverse。其他站台可能保留副本；關閉後將停止同步，並嘗試刪除先前內容。"
   },
   "SuRTsQ": {
     "defaultMessage": "Register for ISCN"
@@ -2456,7 +2456,7 @@
     "description": "src/views/ArticleDetail/StickyTopBanner/index.tsx"
   },
   "ZAoAcG": {
-    "defaultMessage": "Threads, Mastodon, Misskey 這些地方的粉絲也會看到"
+    "defaultMessage": "公開作品會自動送出，遠端站台可能保留副本"
   },
   "ZAs170": {
     "defaultMessage": "Profile",

--- a/lang/en.json
+++ b/lang/en.json
@@ -2069,7 +2069,7 @@
     "defaultMessage": "Announcement"
   },
   "Su1LcW": {
-    "defaultMessage": "開啟後，新發佈作品預設可輸出到 Fediverse。"
+    "defaultMessage": "When enabled, newly published public works are automatically sent to the Fediverse. Other servers may retain copies; disabling stops future sync and requests deletion of prior content."
   },
   "SuRTsQ": {
     "defaultMessage": "Register for ISCN"
@@ -2456,7 +2456,7 @@
     "description": "src/views/ArticleDetail/StickyTopBanner/index.tsx"
   },
   "ZAoAcG": {
-    "defaultMessage": "Threads, Mastodon, Misskey 這些地方的粉絲也會看到"
+    "defaultMessage": "Public works are sent automatically and remote servers may retain copies"
   },
   "ZAs170": {
     "defaultMessage": "Profile",

--- a/lang/en.json
+++ b/lang/en.json
@@ -2068,7 +2068,7 @@
   "Sj+TN8": {
     "defaultMessage": "Announcement"
   },
-  "Su1LcW": {
+  "2cnZc/": {
     "defaultMessage": "When enabled, newly published public works are automatically sent to the Fediverse. Other servers may retain copies; disabling stops future sync and requests deletion of prior content."
   },
   "SuRTsQ": {
@@ -2455,7 +2455,7 @@
     "defaultMessage": "Archived for violation.",
     "description": "src/views/ArticleDetail/StickyTopBanner/index.tsx"
   },
-  "ZAoAcG": {
+  "cY80V3": {
     "defaultMessage": "Public works are sent automatically and remote servers may retain copies"
   },
   "ZAs170": {

--- a/lang/zh-Hans.json
+++ b/lang/zh-Hans.json
@@ -2067,7 +2067,7 @@
   "Sj+TN8": {
     "defaultMessage": "公告"
   },
-  "Su1LcW": {
+  "2cnZc/": {
     "defaultMessage": "开启后，新发布的公开作品会自动发送到 Fediverse。其他站点可能保留副本；关闭后将停止同步，并尝试删除先前内容。"
   },
   "SuRTsQ": {
@@ -2454,7 +2454,7 @@
     "defaultMessage": "因违反用户协定而被封存，",
     "description": "src/views/ArticleDetail/StickyTopBanner/index.tsx"
   },
-  "ZAoAcG": {
+  "cY80V3": {
     "defaultMessage": "公开作品会自动发送，远程站点可能保留副本"
   },
   "ZAs170": {

--- a/lang/zh-Hans.json
+++ b/lang/zh-Hans.json
@@ -2068,7 +2068,7 @@
     "defaultMessage": "公告"
   },
   "Su1LcW": {
-    "defaultMessage": "開啟後，新發佈作品預設可輸出到 Fediverse。"
+    "defaultMessage": "开启后，新发布的公开作品会自动发送到 Fediverse。其他站点可能保留副本；关闭后将停止同步，并尝试删除先前内容。"
   },
   "SuRTsQ": {
     "defaultMessage": "注册 ISCN"
@@ -2455,7 +2455,7 @@
     "description": "src/views/ArticleDetail/StickyTopBanner/index.tsx"
   },
   "ZAoAcG": {
-    "defaultMessage": "Threads, Mastodon, Misskey 這些地方的粉絲也會看到"
+    "defaultMessage": "公开作品会自动发送，远程站点可能保留副本"
   },
   "ZAs170": {
     "defaultMessage": "基本资料",

--- a/lang/zh-Hant.json
+++ b/lang/zh-Hant.json
@@ -2067,7 +2067,7 @@
   "Sj+TN8": {
     "defaultMessage": "公告"
   },
-  "Su1LcW": {
+  "2cnZc/": {
     "defaultMessage": "開啟後，新發佈的公開作品會自動送到 Fediverse。其他站台可能保留副本；關閉後將停止同步，並嘗試刪除先前內容。"
   },
   "SuRTsQ": {
@@ -2454,7 +2454,7 @@
     "defaultMessage": "因違反用戶協定而被封存，",
     "description": "src/views/ArticleDetail/StickyTopBanner/index.tsx"
   },
-  "ZAoAcG": {
+  "cY80V3": {
     "defaultMessage": "公開作品會自動送出，遠端站台可能保留副本"
   },
   "ZAs170": {

--- a/lang/zh-Hant.json
+++ b/lang/zh-Hant.json
@@ -2068,7 +2068,7 @@
     "defaultMessage": "公告"
   },
   "Su1LcW": {
-    "defaultMessage": "開啟後，新發佈作品預設可輸出到 Fediverse。"
+    "defaultMessage": "開啟後，新發佈的公開作品會自動送到 Fediverse。其他站台可能保留副本；關閉後將停止同步，並嘗試刪除先前內容。"
   },
   "SuRTsQ": {
     "defaultMessage": "註冊 ISCN"
@@ -2455,7 +2455,7 @@
     "description": "src/views/ArticleDetail/StickyTopBanner/index.tsx"
   },
   "ZAoAcG": {
-    "defaultMessage": "Threads, Mastodon, Misskey 這些地方的粉絲也會看到"
+    "defaultMessage": "公開作品會自動送出，遠端站台可能保留副本"
   },
   "ZAs170": {
     "defaultMessage": "基本資料",

--- a/src/components/Editor/Sidebar/FederationSetting/index.tsx
+++ b/src/components/Editor/Sidebar/FederationSetting/index.tsx
@@ -181,7 +181,7 @@ const SidebarFederationSetting: React.FC<SidebarFederationSettingProps> = ({
       title={<FormattedMessage defaultMessage="分享到聯邦宇宙" id="tsUFZX" />}
       subtitle={
         <FormattedMessage
-          defaultMessage="Threads, Mastodon, Misskey 這些地方的粉絲也會看到"
+          defaultMessage="公開作品會自動送出，遠端站台可能保留副本"
           id="ZAoAcG"
         />
       }

--- a/src/components/Editor/Sidebar/FederationSetting/index.tsx
+++ b/src/components/Editor/Sidebar/FederationSetting/index.tsx
@@ -182,7 +182,7 @@ const SidebarFederationSetting: React.FC<SidebarFederationSettingProps> = ({
       subtitle={
         <FormattedMessage
           defaultMessage="公開作品會自動送出，遠端站台可能保留副本"
-          id="ZAoAcG"
+          id="cY80V3"
         />
       }
       rightButton={

--- a/src/views/ArticleDetail/Edit/OptionContent/index.tsx
+++ b/src/views/ArticleDetail/Edit/OptionContent/index.tsx
@@ -266,7 +266,6 @@ export const OptionContent = (
   const isSettings = tab === 'settings'
   const hasOwnCollections = (props.ownCollections?.length || 0) > 0
   const hasOwnCircle = props.ownCircles && props.ownCircles.length >= 1
-  const isFediverseBeta = !!props.viewerData?.viewer?.features.fediverseBeta
   const disabled = false
 
   return (
@@ -312,9 +311,7 @@ export const OptionContent = (
             <EditLicense {...props} disabled={disabled} />
             <EditCanComment {...props} disabled={disabled} />
             <EditSupportSetting {...props} disabled={disabled} />
-            {isFediverseBeta && (
-              <EditFederationSetting {...props} disabled={disabled} />
-            )}
+            <EditFederationSetting {...props} disabled={disabled} />
             <EditSensitive {...props} disabled={disabled} />
             {hasOwnCircle && !!props.article.access.circle && (
               <EditCircle {...props} disabled={disabled} />

--- a/src/views/Me/DraftDetail/OptionContent/index.tsx
+++ b/src/views/Me/DraftDetail/OptionContent/index.tsx
@@ -218,7 +218,6 @@ export const OptionContent = (
   const isPublished = props.draft.publishState === 'published'
   const disabled = isPending || isPublished
   const hasOwnCollections = (props.ownCollections?.length || 0) > 0
-  const isFediverseBeta = !!props.draftViewer?.viewer?.features.fediverseBeta
 
   return (
     <section>
@@ -268,7 +267,7 @@ export const OptionContent = (
             <EditDraftLicense {...props} disabled={disabled} />
             <EditDraftCanComment {...props} disabled={disabled} />
             <EditDraftSupportSetting {...props} disabled={disabled} />
-            {isFediverseBeta && <Sidebar.FederationSetting />}
+            <Sidebar.FederationSetting />
             <EditDraftSensitive {...props} disabled={disabled} />
           </>
         )}

--- a/src/views/Me/DraftDetail/gql.ts
+++ b/src/views/Me/DraftDetail/gql.ts
@@ -87,9 +87,6 @@ export const DRAFT_DETAIL_VIEWER = gql`
       }
       displayName
       avatar
-      features {
-        fediverseBeta
-      }
       collections(input: { first: 20, after: $collectionsAfter }) {
         pageInfo {
           hasNextPage

--- a/src/views/Me/Settings/Misc/FederationSetting.test.tsx
+++ b/src/views/Me/Settings/Misc/FederationSetting.test.tsx
@@ -30,7 +30,7 @@ describe('<FederationSetting>', () => {
     useQuery.mockReset()
   })
 
-  it('does not render before viewer feature eligibility is confirmed', () => {
+  it('renders for all signed-in viewers while settings are loading', () => {
     useQuery.mockReturnValue({ data: undefined, loading: true })
 
     render(
@@ -39,15 +39,14 @@ describe('<FederationSetting>', () => {
       </IntlProvider>
     )
 
-    expect(screen.queryByText('Fediverse 聯邦發佈')).not.toBeInTheDocument()
+    expect(screen.getByText('Fediverse 聯邦發佈')).toBeInTheDocument()
   })
 
-  it('renders for fediverse beta users', () => {
+  it('renders with the saved federation setting', () => {
     useQuery.mockReturnValue({
       data: {
         viewer: {
           id: '1',
-          features: { fediverseBeta: true },
           federationSetting: { state: 'disabled' },
         },
       },

--- a/src/views/Me/Settings/Misc/FederationSetting.tsx
+++ b/src/views/Me/Settings/Misc/FederationSetting.tsx
@@ -15,9 +15,6 @@ const VIEWER_FEDERATION_SETTING = gql`
   query ViewerFederationSetting {
     viewer {
       id
-      features {
-        fediverseBeta
-      }
       federationSetting {
         state
       }
@@ -49,17 +46,12 @@ const FederationSetting = () => {
   >(SET_VIEWER_FEDERATION_SETTING)
 
   const viewer = data?.viewer
-  const isFediverseBeta = !!viewer?.features.fediverseBeta
 
   useEffect(() => {
     if (viewer?.federationSetting?.state) {
       setSetting(viewer.federationSetting.state)
     }
   }, [viewer?.federationSetting?.state])
-
-  if (!isFediverseBeta) {
-    return null
-  }
 
   const enabled = setting === FederationAuthorSettingState.Enabled
 
@@ -107,7 +99,7 @@ const FederationSetting = () => {
       }
       subtitle={
         <FormattedMessage
-          defaultMessage="開啟後，新發佈作品預設可輸出到 Fediverse。"
+          defaultMessage="開啟後，新發佈的公開作品會自動送到 Fediverse。其他站台可能保留副本；關閉後將停止同步，並嘗試刪除先前內容。"
           id="Su1LcW"
         />
       }

--- a/src/views/Me/Settings/Misc/FederationSetting.tsx
+++ b/src/views/Me/Settings/Misc/FederationSetting.tsx
@@ -100,7 +100,7 @@ const FederationSetting = () => {
       subtitle={
         <FormattedMessage
           defaultMessage="開啟後，新發佈的公開作品會自動送到 Fediverse。其他站台可能保留副本；關閉後將停止同步，並嘗試刪除先前內容。"
-          id="Su1LcW"
+          id="2cnZc/"
         />
       }
       right={


### PR DESCRIPTION
## Summary

- remove the beta-only UI gates from account, draft, and article federation settings
- make the setting available to all signed-in authors
- clearly disclose that newly published public works are sent automatically and remote servers may retain copies
- keep author opt-in and per-article override behavior

## Dependency

- Server general-author and queue support: https://github.com/thematters/matters-server/pull/4951

## Verification

- FederationSetting tests: 2 passed
- git diff --check passed