### PR TITLE
feat(fediverse): add social interaction center

### DIFF
--- a/lang/default.json
+++ b/lang/default.json
@@ -84,6 +84,9 @@
   "+vVZ/G": {
     "defaultMessage": "Connect"
   },
+  "+wqFkx": {
+    "defaultMessage": "聯邦宇宙互動"
+  },
   "/0OJlF": {
     "defaultMessage": "No discussion yet",
     "description": "src/views/CampaignDetail/Discussion"
@@ -187,6 +190,9 @@
   "0ThOw1": {
     "defaultMessage": "Create collection",
     "description": "src/views/User/Collections/UserCollections.tsx"
+  },
+  "0XnomJ": {
+    "defaultMessage": "找不到這個聯邦帳號"
   },
   "0bTlm4": {
     "defaultMessage": "Are you sure you want to delete this moment?"
@@ -353,6 +359,9 @@
     "defaultMessage": "Edit",
     "description": "src/views/ArticleDetail/MetaInfo/index.tsx"
   },
+  "2cnZc/": {
+    "defaultMessage": "開啟後，新發佈的公開作品會自動送到 Fediverse。其他站台可能保留副本；關閉後將停止同步，並嘗試刪除先前內容。"
+  },
   "2ef/Xl": {
     "defaultMessage": "Block",
     "description": "src/views/Me/Settings/Blocked/ToggleBlockButton.tsx"
@@ -456,6 +465,9 @@
     "defaultMessage": "色情廣告",
     "description": "src/components/Comment/DropdownActions/CommunityWatchRemoveComment.tsx"
   },
+  "4GmeZE": {
+    "defaultMessage": "來自其他 Fediverse 站台的互動"
+  },
   "4KuZ0o": {
     "defaultMessage": "Asset not found",
     "description": "ASSET_NOT_FOUND"
@@ -516,6 +528,9 @@
     "defaultMessage": "liked your deleted moment",
     "description": "src/components/Notice/MomentNotice/MomentLiked.tsx"
   },
+  "5UgS3k": {
+    "defaultMessage": "封鎖"
+  },
   "5UglrB": {
     "defaultMessage": "Successfully delivered"
   },
@@ -534,6 +549,9 @@
   },
   "5jlQTx": {
     "defaultMessage": "Manage Invitation"
+  },
+  "5kX6Qk": {
+    "defaultMessage": "檢舉"
   },
   "5mu8HJ": {
     "defaultMessage": "Moment deleted"
@@ -605,6 +623,9 @@
   },
   "6Sj2lN": {
     "defaultMessage": "Claim"
+  },
+  "6UaJbf": {
+    "defaultMessage": "送出"
   },
   "6Vznnt": {
     "defaultMessage": "left a comment in your circle",
@@ -978,6 +999,9 @@
     "defaultMessage": "Provide support funds to",
     "description": "src/components/Forms/PaymentForm/PaymentInfo/index.tsx"
   },
+  "ByvxDL": {
+    "defaultMessage": "追蹤中的作者"
+  },
   "C/4nS6": {
     "defaultMessage": "Connect and claim"
   },
@@ -1348,6 +1372,9 @@
     "defaultMessage": "Your schedule article has been published",
     "description": "src/components/Notice/ArticleNotice/ScheduledArticlePublishedNotice.tsx"
   },
+  "HFBocb": {
+    "defaultMessage": "追蹤遠端作者後，最新內容會出現在這裡"
+  },
   "HFVDeB": {
     "defaultMessage": "Related Tags",
     "description": "src/views/TagDetail/RelatedTags/index.tsx"
@@ -1429,6 +1456,9 @@
     "defaultMessage": "Unlink",
     "description": "src/components/Editor"
   },
+  "IK6Mk7": {
+    "defaultMessage": "查看原文"
+  },
   "IKPYe9": {
     "defaultMessage": "View",
     "description": "src/components/Dialogs/CollectionSelectDialog/index.tsx"
@@ -1458,6 +1488,9 @@
   },
   "IjNYll": {
     "defaultMessage": "Let me think about it"
+  },
+  "InCosw": {
+    "defaultMessage": "搜尋"
   },
   "IpMWC4": {
     "defaultMessage": "You’ve posted several times in a short period. Please take a break."
@@ -1714,6 +1747,9 @@
     "defaultMessage": "Supports",
     "description": "src/views/Me/Transactions/index.tsx"
   },
+  "NDG8qY": {
+    "defaultMessage": "喜歡"
+  },
   "NDV5Mq": {
     "defaultMessage": "Options"
   },
@@ -1758,6 +1794,9 @@
   },
   "NmhF45": {
     "defaultMessage": "Adding tags helps readers find your articles. Add or create new tags."
+  },
+  "Nw8VNu": {
+    "defaultMessage": "聯邦宇宙互動中心"
   },
   "O0MQs/": {
     "defaultMessage": "Please add email first",
@@ -1863,6 +1902,9 @@
   "PXAur5": {
     "defaultMessage": "Withdraw"
   },
+  "PbBsp5": {
+    "defaultMessage": "目前還沒有聯邦宇宙回覆"
+  },
   "PesLat": {
     "defaultMessage": "Publishing..."
   },
@@ -1899,8 +1941,14 @@
   "Q8Qw5B": {
     "defaultMessage": "Description"
   },
+  "Q8g2+W": {
+    "defaultMessage": "全部已讀"
+  },
   "QHRze5": {
     "defaultMessage": "Moments"
+  },
+  "QJd23B": {
+    "defaultMessage": "Fediverse 帳號"
   },
   "QKJWqd": {
     "defaultMessage": "Bookmark",
@@ -1952,6 +2000,9 @@
   "R410ei": {
     "defaultMessage": "Incorrect verification code",
     "description": "CODE_INVALID"
+  },
+  "R6sMIX": {
+    "defaultMessage": "Fediverse"
   },
   "R7yHDl": {
     "defaultMessage": "Circle Revenue",
@@ -2068,11 +2119,11 @@
   "Sj+TN8": {
     "defaultMessage": "Announcement"
   },
-  "2cnZc/": {
-    "defaultMessage": "開啟後，新發佈的公開作品會自動送到 Fediverse。其他站台可能保留副本；關閉後將停止同步，並嘗試刪除先前內容。"
-  },
   "SuRTsQ": {
     "defaultMessage": "Register for ISCN"
+  },
+  "SyxunU": {
+    "defaultMessage": "聯邦宇宙操作已送出"
   },
   "Szd1tH": {
     "defaultMessage": "Failed to log out, please try again."
@@ -2227,6 +2278,9 @@
     "defaultMessage": "Ended",
     "description": "src/views/Campaigns/Feeds/Tabs/index.tsx"
   },
+  "VWeoZC": {
+    "defaultMessage": "目前沒有通知"
+  },
   "VZsE96": {
     "defaultMessage": "Collection Name"
   },
@@ -2268,6 +2322,9 @@
   "W0sZaX": {
     "defaultMessage": "Last 3 months",
     "description": "src/views/Me/Analytics/SelectPeriod/index.tsx"
+  },
+  "W1j+F0": {
+    "defaultMessage": "請簡述檢舉原因"
   },
   "W3hNBA": {
     "defaultMessage": "Free Write in 7 days Grand Badge"
@@ -2345,6 +2402,9 @@
   },
   "XTRqqT": {
     "defaultMessage": "Add to event"
+  },
+  "XTkPen": {
+    "defaultMessage": "來自其他 Fediverse 站台的回應"
   },
   "XTyKFR": {
     "defaultMessage": "Adding articles to a collection helps readers find your articles."
@@ -2454,9 +2514,6 @@
   "Z7JXlF": {
     "defaultMessage": "Archived for violation.",
     "description": "src/views/ArticleDetail/StickyTopBanner/index.tsx"
-  },
-  "cY80V3": {
-    "defaultMessage": "公開作品會自動送出，遠端站台可能保留副本"
   },
   "ZAs170": {
     "defaultMessage": "Profile",
@@ -2586,6 +2643,9 @@
   "b6x6lm": {
     "defaultMessage": "Enter a clear and concise title"
   },
+  "b8/cFV": {
+    "defaultMessage": "聯邦宇宙"
+  },
   "b8LMpq": {
     "defaultMessage": "View all {count} comments",
     "description": "src/views/CampaignDetail/Discussion"
@@ -2615,6 +2675,9 @@
   },
   "beLe/F": {
     "defaultMessage": "Broadcast"
+  },
+  "bmR7T4": {
+    "defaultMessage": "轉發"
   },
   "bv9UzQ": {
     "defaultMessage": "See all quotes"
@@ -2662,6 +2725,9 @@
   "cQYXjl": {
     "defaultMessage": "Currency",
     "description": "src/views/Me/Settings/Misc/Currency/index.tsx"
+  },
+  "cY80V3": {
+    "defaultMessage": "公開作品會自動送出，遠端站台可能保留副本"
   },
   "cYvIpp": {
     "defaultMessage": "Already subscribed to this circle.",
@@ -2947,6 +3013,9 @@
     "defaultMessage": "The payment amount is invalid, please re-enter.",
     "description": "PAYMENT_AMOUNT_INVALID"
   },
+  "glsBoL": {
+    "defaultMessage": "聯邦通知"
+  },
   "gsZ/aj": {
     "defaultMessage": "Comments allowed, cannot be closed once published",
     "description": "src/components/Editor/Sidebar/CanComment/index.tsx"
@@ -3033,6 +3102,9 @@
     "defaultMessage": "Number of readers",
     "description": "src/components/ArticleDigest/Published/FooterActions/index.tsx"
   },
+  "hyDCe8": {
+    "defaultMessage": "位追蹤者"
+  },
   "i4OBEw": {
     "defaultMessage": "\"{name}\" is invalid."
   },
@@ -3065,6 +3137,9 @@
   },
   "ieGrWo": {
     "defaultMessage": "Follow"
+  },
+  "ih+UCV": {
+    "defaultMessage": "回覆內容"
   },
   "imXsmo": {
     "defaultMessage": "back to latest",
@@ -3105,6 +3180,9 @@
   "jOgBV9": {
     "defaultMessage": "replied you",
     "description": "src/components/Notice/CommentCommentNotice/CommentNewReplyNotice.tsx"
+  },
+  "jWwn1K": {
+    "defaultMessage": "尋找遠端作者"
   },
   "jiB0Z2": {
     "defaultMessage": "Unable to bind wallet",
@@ -3159,6 +3237,9 @@
   "kHMa3H": {
     "defaultMessage": "The new password and confirmation password do not match."
   },
+  "kOStiL": {
+    "defaultMessage": "輸入完整帳號，例如 @alice@example.social"
+  },
   "kS3vTS": {
     "defaultMessage": "Liker ID",
     "description": "src/views/Me/Settings/Misc/LikerID.tsx"
@@ -3169,6 +3250,9 @@
   },
   "kc79d3": {
     "defaultMessage": "Topics"
+  },
+  "kggbxQ": {
+    "defaultMessage": "追蹤"
   },
   "kkZioy": {
     "defaultMessage": "Remove",
@@ -3188,6 +3272,9 @@
     "defaultMessage": "Please enter new transaction password",
     "description": "src/components/Forms/PaymentForm/ResetPassword/Confirm.tsx"
   },
+  "kw8J39": {
+    "defaultMessage": "回覆到聯邦宇宙"
+  },
   "l/f7bu": {
     "defaultMessage": "Want to know more? Check the",
     "description": "src/views/Me/Analytics/EmptyAnalytics/index.tsx"
@@ -3202,6 +3289,9 @@
   "l31hCd": {
     "defaultMessage": "Preview",
     "description": "src/components/Editor/MoreSettings/SupportSettingDialog/Content.tsx"
+  },
+  "lDTamI": {
+    "defaultMessage": "回覆"
   },
   "lFi0TA": {
     "defaultMessage": "Add to Collection"
@@ -3320,6 +3410,9 @@
   },
   "me1nR+": {
     "defaultMessage": "Copy Address"
+  },
+  "miEMcG": {
+    "defaultMessage": "追蹤中"
   },
   "mij/rJ": {
     "defaultMessage": "Delete draft"
@@ -3614,6 +3707,9 @@
   "rfz/fN": {
     "defaultMessage": "Recommended size: 1600px x 900px"
   },
+  "rjEc9z": {
+    "defaultMessage": "取消追蹤"
+  },
   "rqS2aA": {
     "defaultMessage": "Sign in to that account to unlink it then try again",
     "description": "src/components/AuthMethodFeed/AuthWalletFeed.tsx"
@@ -3625,8 +3721,14 @@
   "ruZqtT": {
     "defaultMessage": "Must be between {MIN_USER_DISPLAY_NAME_LENGTH}-{MAX_USER_DISPLAY_NAME_LENGTH} characters long."
   },
+  "rudmDY": {
+    "defaultMessage": "追蹤遠端作者、閱讀聯邦動態，並管理回覆與通知"
+  },
   "s2s6tx": {
     "defaultMessage": "The article has been successfully published and will be synced to IPFS soon."
+  },
+  "sAB+vZ": {
+    "defaultMessage": "等待核准"
   },
   "sE2Ui3": {
     "defaultMessage": "Account Frozen"
@@ -3669,9 +3771,15 @@
   "syEQFE": {
     "defaultMessage": "Publish"
   },
+  "t0kvjC": {
+    "defaultMessage": "查看全部"
+  },
   "t1wXVG": {
     "defaultMessage": "Say something? Someone might listen.",
     "description": "MOMENT_FORM"
+  },
+  "t1yrE4": {
+    "defaultMessage": "最多追蹤 {maxFollowing} 個帳號，動態保留 {days} 天，上限 {items} 筆"
   },
   "t2EpN/": {
     "defaultMessage": "Request on {network} network will be confirmed and synced to Matters in a bit"
@@ -4097,6 +4205,9 @@
   "zE51j6": {
     "defaultMessage": "Failed to publish, please try again."
   },
+  "zK82DU": {
+    "defaultMessage": "追蹤動態"
+  },
   "zKOr2x": {
     "defaultMessage": "Conversion Rate of Followers",
     "description": "src/views/Circle/Analytics/FollowerAnalytics/index.tsx"
@@ -4113,6 +4224,9 @@
   },
   "zWXgmM": {
     "defaultMessage": "Return and continue"
+  },
+  "zWonDB": {
+    "defaultMessage": "尚未追蹤任何遠端作者"
   },
   "zaY8Cu": {
     "defaultMessage": "Enter transaction password",

--- a/lang/en.json
+++ b/lang/en.json
@@ -84,6 +84,9 @@
   "+vVZ/G": {
     "defaultMessage": "Connect"
   },
+  "+wqFkx": {
+    "defaultMessage": "聯邦宇宙互動"
+  },
   "/0OJlF": {
     "defaultMessage": "No discussion yet",
     "description": "src/views/CampaignDetail/Discussion"
@@ -187,6 +190,9 @@
   "0ThOw1": {
     "defaultMessage": "Create collection",
     "description": "src/views/User/Collections/UserCollections.tsx"
+  },
+  "0XnomJ": {
+    "defaultMessage": "找不到這個聯邦帳號"
   },
   "0bTlm4": {
     "defaultMessage": "Are you sure you want to delete this moment?"
@@ -353,6 +359,9 @@
     "defaultMessage": "Edit",
     "description": "src/views/ArticleDetail/MetaInfo/index.tsx"
   },
+  "2cnZc/": {
+    "defaultMessage": "When enabled, newly published public works are automatically sent to the Fediverse. Other servers may retain copies; disabling stops future sync and requests deletion of prior content."
+  },
   "2ef/Xl": {
     "defaultMessage": "Block",
     "description": "src/views/Me/Settings/Blocked/ToggleBlockButton.tsx"
@@ -456,6 +465,9 @@
     "defaultMessage": "色情廣告",
     "description": "src/components/Comment/DropdownActions/CommunityWatchRemoveComment.tsx"
   },
+  "4GmeZE": {
+    "defaultMessage": "來自其他 Fediverse 站台的互動"
+  },
   "4KuZ0o": {
     "defaultMessage": "Asset not found",
     "description": "ASSET_NOT_FOUND"
@@ -516,6 +528,9 @@
     "defaultMessage": "liked your deleted moment",
     "description": "src/components/Notice/MomentNotice/MomentLiked.tsx"
   },
+  "5UgS3k": {
+    "defaultMessage": "封鎖"
+  },
   "5UglrB": {
     "defaultMessage": "Successfully delivered"
   },
@@ -534,6 +549,9 @@
   },
   "5jlQTx": {
     "defaultMessage": "Manage Invitation"
+  },
+  "5kX6Qk": {
+    "defaultMessage": "檢舉"
   },
   "5mu8HJ": {
     "defaultMessage": "Moment deleted"
@@ -605,6 +623,9 @@
   },
   "6Sj2lN": {
     "defaultMessage": "Claim"
+  },
+  "6UaJbf": {
+    "defaultMessage": "送出"
   },
   "6Vznnt": {
     "defaultMessage": "left a comment in your circle",
@@ -978,6 +999,9 @@
     "defaultMessage": "Provide support funds to",
     "description": "src/components/Forms/PaymentForm/PaymentInfo/index.tsx"
   },
+  "ByvxDL": {
+    "defaultMessage": "追蹤中的作者"
+  },
   "C/4nS6": {
     "defaultMessage": "Connect and claim"
   },
@@ -1348,6 +1372,9 @@
     "defaultMessage": "Your schedule article has been published",
     "description": "src/components/Notice/ArticleNotice/ScheduledArticlePublishedNotice.tsx"
   },
+  "HFBocb": {
+    "defaultMessage": "追蹤遠端作者後，最新內容會出現在這裡"
+  },
   "HFVDeB": {
     "defaultMessage": "Related Tags",
     "description": "src/views/TagDetail/RelatedTags/index.tsx"
@@ -1429,6 +1456,9 @@
     "defaultMessage": "Unlink",
     "description": "src/components/Editor"
   },
+  "IK6Mk7": {
+    "defaultMessage": "查看原文"
+  },
   "IKPYe9": {
     "defaultMessage": "View",
     "description": "src/components/Dialogs/CollectionSelectDialog/index.tsx"
@@ -1458,6 +1488,9 @@
   },
   "IjNYll": {
     "defaultMessage": "Let me think about it"
+  },
+  "InCosw": {
+    "defaultMessage": "搜尋"
   },
   "IpMWC4": {
     "defaultMessage": "You’ve posted several times in a short period. Please take a break."
@@ -1714,6 +1747,9 @@
     "defaultMessage": "Supports",
     "description": "src/views/Me/Transactions/index.tsx"
   },
+  "NDG8qY": {
+    "defaultMessage": "喜歡"
+  },
   "NDV5Mq": {
     "defaultMessage": "Options"
   },
@@ -1758,6 +1794,9 @@
   },
   "NmhF45": {
     "defaultMessage": "Adding tags helps readers find your articles. Add or create new tags."
+  },
+  "Nw8VNu": {
+    "defaultMessage": "聯邦宇宙互動中心"
   },
   "O0MQs/": {
     "defaultMessage": "Please add email first",
@@ -1863,6 +1902,9 @@
   "PXAur5": {
     "defaultMessage": "Withdraw"
   },
+  "PbBsp5": {
+    "defaultMessage": "目前還沒有聯邦宇宙回覆"
+  },
   "PesLat": {
     "defaultMessage": "Publishing..."
   },
@@ -1899,8 +1941,14 @@
   "Q8Qw5B": {
     "defaultMessage": "Description"
   },
+  "Q8g2+W": {
+    "defaultMessage": "全部已讀"
+  },
   "QHRze5": {
     "defaultMessage": "Moments"
+  },
+  "QJd23B": {
+    "defaultMessage": "Fediverse 帳號"
   },
   "QKJWqd": {
     "defaultMessage": "Bookmark",
@@ -1952,6 +2000,9 @@
   "R410ei": {
     "defaultMessage": "Incorrect verification code",
     "description": "CODE_INVALID"
+  },
+  "R6sMIX": {
+    "defaultMessage": "Fediverse"
   },
   "R7yHDl": {
     "defaultMessage": "Circle Revenue",
@@ -2068,11 +2119,11 @@
   "Sj+TN8": {
     "defaultMessage": "Announcement"
   },
-  "2cnZc/": {
-    "defaultMessage": "When enabled, newly published public works are automatically sent to the Fediverse. Other servers may retain copies; disabling stops future sync and requests deletion of prior content."
-  },
   "SuRTsQ": {
     "defaultMessage": "Register for ISCN"
+  },
+  "SyxunU": {
+    "defaultMessage": "聯邦宇宙操作已送出"
   },
   "Szd1tH": {
     "defaultMessage": "Failed to log out, please try again."
@@ -2227,6 +2278,9 @@
     "defaultMessage": "Ended",
     "description": "src/views/Campaigns/Feeds/Tabs/index.tsx"
   },
+  "VWeoZC": {
+    "defaultMessage": "目前沒有通知"
+  },
   "VZsE96": {
     "defaultMessage": "Collection Name"
   },
@@ -2268,6 +2322,9 @@
   "W0sZaX": {
     "defaultMessage": "Last 3 months",
     "description": "src/views/Me/Analytics/SelectPeriod/index.tsx"
+  },
+  "W1j+F0": {
+    "defaultMessage": "請簡述檢舉原因"
   },
   "W3hNBA": {
     "defaultMessage": "Free Write in 7 days Grand Badge"
@@ -2345,6 +2402,9 @@
   },
   "XTRqqT": {
     "defaultMessage": "Add to event"
+  },
+  "XTkPen": {
+    "defaultMessage": "來自其他 Fediverse 站台的回應"
   },
   "XTyKFR": {
     "defaultMessage": "Adding articles to a collection helps readers find your articles."
@@ -2454,9 +2514,6 @@
   "Z7JXlF": {
     "defaultMessage": "Archived for violation.",
     "description": "src/views/ArticleDetail/StickyTopBanner/index.tsx"
-  },
-  "cY80V3": {
-    "defaultMessage": "Public works are sent automatically and remote servers may retain copies"
   },
   "ZAs170": {
     "defaultMessage": "Profile",
@@ -2586,6 +2643,9 @@
   "b6x6lm": {
     "defaultMessage": "Enter a clear and concise title"
   },
+  "b8/cFV": {
+    "defaultMessage": "聯邦宇宙"
+  },
   "b8LMpq": {
     "defaultMessage": "View all {count} comments",
     "description": "src/views/CampaignDetail/Discussion"
@@ -2615,6 +2675,9 @@
   },
   "beLe/F": {
     "defaultMessage": "Broadcast"
+  },
+  "bmR7T4": {
+    "defaultMessage": "轉發"
   },
   "bv9UzQ": {
     "defaultMessage": "See all quotes"
@@ -2662,6 +2725,9 @@
   "cQYXjl": {
     "defaultMessage": "Currency",
     "description": "src/views/Me/Settings/Misc/Currency/index.tsx"
+  },
+  "cY80V3": {
+    "defaultMessage": "Public works are sent automatically and remote servers may retain copies"
   },
   "cYvIpp": {
     "defaultMessage": "Already subscribed to this circle.",
@@ -2947,6 +3013,9 @@
     "defaultMessage": "The payment amount is invalid, please re-enter.",
     "description": "PAYMENT_AMOUNT_INVALID"
   },
+  "glsBoL": {
+    "defaultMessage": "聯邦通知"
+  },
   "gsZ/aj": {
     "defaultMessage": "Comments allowed, cannot be closed once published",
     "description": "src/components/Editor/Sidebar/CanComment/index.tsx"
@@ -3033,6 +3102,9 @@
     "defaultMessage": "Number of readers",
     "description": "src/components/ArticleDigest/Published/FooterActions/index.tsx"
   },
+  "hyDCe8": {
+    "defaultMessage": "位追蹤者"
+  },
   "i4OBEw": {
     "defaultMessage": "\"{name}\" is invalid."
   },
@@ -3065,6 +3137,9 @@
   },
   "ieGrWo": {
     "defaultMessage": "Follow"
+  },
+  "ih+UCV": {
+    "defaultMessage": "回覆內容"
   },
   "imXsmo": {
     "defaultMessage": "back to latest",
@@ -3105,6 +3180,9 @@
   "jOgBV9": {
     "defaultMessage": "replied you",
     "description": "src/components/Notice/CommentCommentNotice/CommentNewReplyNotice.tsx"
+  },
+  "jWwn1K": {
+    "defaultMessage": "尋找遠端作者"
   },
   "jiB0Z2": {
     "defaultMessage": "Unable to bind wallet",
@@ -3159,6 +3237,9 @@
   "kHMa3H": {
     "defaultMessage": "The new password and confirmation password do not match."
   },
+  "kOStiL": {
+    "defaultMessage": "輸入完整帳號，例如 @alice@example.social"
+  },
   "kS3vTS": {
     "defaultMessage": "Liker ID",
     "description": "src/views/Me/Settings/Misc/LikerID.tsx"
@@ -3169,6 +3250,9 @@
   },
   "kc79d3": {
     "defaultMessage": "Topics"
+  },
+  "kggbxQ": {
+    "defaultMessage": "追蹤"
   },
   "kkZioy": {
     "defaultMessage": "Remove",
@@ -3188,6 +3272,9 @@
     "defaultMessage": "Please enter new transaction password",
     "description": "src/components/Forms/PaymentForm/ResetPassword/Confirm.tsx"
   },
+  "kw8J39": {
+    "defaultMessage": "回覆到聯邦宇宙"
+  },
   "l/f7bu": {
     "defaultMessage": "Want to know more? Check the",
     "description": "src/views/Me/Analytics/EmptyAnalytics/index.tsx"
@@ -3202,6 +3289,9 @@
   "l31hCd": {
     "defaultMessage": "Preview",
     "description": "src/components/Editor/MoreSettings/SupportSettingDialog/Content.tsx"
+  },
+  "lDTamI": {
+    "defaultMessage": "回覆"
   },
   "lFi0TA": {
     "defaultMessage": "Add to Collection"
@@ -3320,6 +3410,9 @@
   },
   "me1nR+": {
     "defaultMessage": "Copy Address"
+  },
+  "miEMcG": {
+    "defaultMessage": "追蹤中"
   },
   "mij/rJ": {
     "defaultMessage": "Delete draft"
@@ -3614,6 +3707,9 @@
   "rfz/fN": {
     "defaultMessage": "Recommended size: 1600px x 900px"
   },
+  "rjEc9z": {
+    "defaultMessage": "取消追蹤"
+  },
   "rqS2aA": {
     "defaultMessage": "Sign in to that account to unlink it then try again",
     "description": "src/components/AuthMethodFeed/AuthWalletFeed.tsx"
@@ -3625,8 +3721,14 @@
   "ruZqtT": {
     "defaultMessage": "Must be between {MIN_USER_DISPLAY_NAME_LENGTH}-{MAX_USER_DISPLAY_NAME_LENGTH} characters long."
   },
+  "rudmDY": {
+    "defaultMessage": "追蹤遠端作者、閱讀聯邦動態，並管理回覆與通知"
+  },
   "s2s6tx": {
     "defaultMessage": "The article has been successfully published and will be synced to IPFS soon."
+  },
+  "sAB+vZ": {
+    "defaultMessage": "等待核准"
   },
   "sE2Ui3": {
     "defaultMessage": "Account Frozen"
@@ -3669,9 +3771,15 @@
   "syEQFE": {
     "defaultMessage": "Publish"
   },
+  "t0kvjC": {
+    "defaultMessage": "查看全部"
+  },
   "t1wXVG": {
     "defaultMessage": "Say something? Someone might listen.",
     "description": "MOMENT_FORM"
+  },
+  "t1yrE4": {
+    "defaultMessage": "最多追蹤 {maxFollowing} 個帳號，動態保留 {days} 天，上限 {items} 筆"
   },
   "t2EpN/": {
     "defaultMessage": "Request on {network} network will be confirmed and synced to Matters in a bit"
@@ -4097,6 +4205,9 @@
   "zE51j6": {
     "defaultMessage": "Failed to publish, please try again."
   },
+  "zK82DU": {
+    "defaultMessage": "追蹤動態"
+  },
   "zKOr2x": {
     "defaultMessage": "Conversion Rate of Followers",
     "description": "src/views/Circle/Analytics/FollowerAnalytics/index.tsx"
@@ -4113,6 +4224,9 @@
   },
   "zWXgmM": {
     "defaultMessage": "Return and continue"
+  },
+  "zWonDB": {
+    "defaultMessage": "尚未追蹤任何遠端作者"
   },
   "zaY8Cu": {
     "defaultMessage": "Enter transaction password",

--- a/lang/zh-Hans.json
+++ b/lang/zh-Hans.json
@@ -84,6 +84,9 @@
   "+vVZ/G": {
     "defaultMessage": "绑定"
   },
+  "+wqFkx": {
+    "defaultMessage": "聯邦宇宙互動"
+  },
   "/0OJlF": {
     "defaultMessage": "还没有人留言",
     "description": "src/views/CampaignDetail/Discussion"
@@ -187,6 +190,9 @@
   "0ThOw1": {
     "defaultMessage": "新建选集",
     "description": "src/views/User/Collections/UserCollections.tsx"
+  },
+  "0XnomJ": {
+    "defaultMessage": "找不到這個聯邦帳號"
   },
   "0bTlm4": {
     "defaultMessage": "确认要删除该动态吗？"
@@ -353,6 +359,9 @@
     "defaultMessage": "修改",
     "description": "src/views/ArticleDetail/MetaInfo/index.tsx"
   },
+  "2cnZc/": {
+    "defaultMessage": "开启后，新发布的公开作品会自动发送到 Fediverse。其他站点可能保留副本；关闭后将停止同步，并尝试删除先前内容。"
+  },
   "2ef/Xl": {
     "defaultMessage": "屏蔽",
     "description": "src/views/Me/Settings/Blocked/ToggleBlockButton.tsx"
@@ -456,6 +465,9 @@
     "defaultMessage": "色情廣告",
     "description": "src/components/Comment/DropdownActions/CommunityWatchRemoveComment.tsx"
   },
+  "4GmeZE": {
+    "defaultMessage": "來自其他 Fediverse 站台的互動"
+  },
   "4KuZ0o": {
     "defaultMessage": "资源不存在",
     "description": "ASSET_NOT_FOUND"
@@ -515,6 +527,9 @@
     "defaultMessage": "喜欢你已删除的动态",
     "description": "src/components/Notice/MomentNotice/MomentLiked.tsx"
   },
+  "5UgS3k": {
+    "defaultMessage": "封鎖"
+  },
   "5UglrB": {
     "defaultMessage": "送出成功"
   },
@@ -533,6 +548,9 @@
   },
   "5jlQTx": {
     "defaultMessage": "邀请管理"
+  },
+  "5kX6Qk": {
+    "defaultMessage": "檢舉"
   },
   "5mu8HJ": {
     "defaultMessage": "动态已删除"
@@ -604,6 +622,9 @@
   },
   "6Sj2lN": {
     "defaultMessage": "提领支持"
+  },
+  "6UaJbf": {
+    "defaultMessage": "送出"
   },
   "6Vznnt": {
     "defaultMessage": "在你的围炉中留言",
@@ -977,6 +998,9 @@
     "defaultMessage": "递出支持资金给",
     "description": "src/components/Forms/PaymentForm/PaymentInfo/index.tsx"
   },
+  "ByvxDL": {
+    "defaultMessage": "追蹤中的作者"
+  },
   "C/4nS6": {
     "defaultMessage": "绑定并提领"
   },
@@ -1347,6 +1371,9 @@
     "defaultMessage": "你的定时发布作品已发布成功",
     "description": "src/components/Notice/ArticleNotice/ScheduledArticlePublishedNotice.tsx"
   },
+  "HFBocb": {
+    "defaultMessage": "追蹤遠端作者後，最新內容會出現在這裡"
+  },
   "HFVDeB": {
     "defaultMessage": "相关标签",
     "description": "src/views/TagDetail/RelatedTags/index.tsx"
@@ -1428,6 +1455,9 @@
     "defaultMessage": "取消链接",
     "description": "src/components/Editor"
   },
+  "IK6Mk7": {
+    "defaultMessage": "查看原文"
+  },
   "IKPYe9": {
     "defaultMessage": "查看",
     "description": "src/components/Dialogs/CollectionSelectDialog/index.tsx"
@@ -1457,6 +1487,9 @@
   },
   "IjNYll": {
     "defaultMessage": "等等再说"
+  },
+  "InCosw": {
+    "defaultMessage": "搜尋"
   },
   "IpMWC4": {
     "defaultMessage": "短时间内已发布多条动态，请先休息一会吧～"
@@ -1713,6 +1746,9 @@
     "defaultMessage": "支持",
     "description": "src/views/Me/Transactions/index.tsx"
   },
+  "NDG8qY": {
+    "defaultMessage": "喜歡"
+  },
   "NDV5Mq": {
     "defaultMessage": "选项"
   },
@@ -1757,6 +1793,9 @@
   },
   "NmhF45": {
     "defaultMessage": "通过添加标签帮助读者更好地找到你的作品。如果没有合适的标签，你可以创建新的。"
+  },
+  "Nw8VNu": {
+    "defaultMessage": "聯邦宇宙互動中心"
   },
   "O0MQs/": {
     "defaultMessage": "请先绑定邮箱",
@@ -1862,6 +1901,9 @@
   "PXAur5": {
     "defaultMessage": "提现"
   },
+  "PbBsp5": {
+    "defaultMessage": "目前還沒有聯邦宇宙回覆"
+  },
   "PesLat": {
     "defaultMessage": "正在发布，马上就好"
   },
@@ -1898,8 +1940,14 @@
   "Q8Qw5B": {
     "defaultMessage": "描述"
   },
+  "Q8g2+W": {
+    "defaultMessage": "全部已讀"
+  },
   "QHRze5": {
     "defaultMessage": "闲聊"
+  },
+  "QJd23B": {
+    "defaultMessage": "Fediverse 帳號"
   },
   "QKJWqd": {
     "defaultMessage": "收藏",
@@ -1951,6 +1999,9 @@
   "R410ei": {
     "defaultMessage": "验证码错误",
     "description": "CODE_INVALID"
+  },
+  "R6sMIX": {
+    "defaultMessage": "Fediverse"
   },
   "R7yHDl": {
     "defaultMessage": "围炉营收",
@@ -2067,11 +2118,11 @@
   "Sj+TN8": {
     "defaultMessage": "公告"
   },
-  "2cnZc/": {
-    "defaultMessage": "开启后，新发布的公开作品会自动发送到 Fediverse。其他站点可能保留副本；关闭后将停止同步，并尝试删除先前内容。"
-  },
   "SuRTsQ": {
     "defaultMessage": "注册 ISCN"
+  },
+  "SyxunU": {
+    "defaultMessage": "聯邦宇宙操作已送出"
   },
   "Szd1tH": {
     "defaultMessage": "登出失败，再来一次"
@@ -2226,6 +2277,9 @@
     "defaultMessage": "过往活动",
     "description": "src/views/Campaigns/Feeds/Tabs/index.tsx"
   },
+  "VWeoZC": {
+    "defaultMessage": "目前沒有通知"
+  },
   "VZsE96": {
     "defaultMessage": "选集名称"
   },
@@ -2267,6 +2321,9 @@
   "W0sZaX": {
     "defaultMessage": "最近 3 个月",
     "description": "src/views/Me/Analytics/SelectPeriod/index.tsx"
+  },
+  "W1j+F0": {
+    "defaultMessage": "請簡述檢舉原因"
   },
   "W3hNBA": {
     "defaultMessage": "七日书大满贯"
@@ -2344,6 +2401,9 @@
   },
   "XTRqqT": {
     "defaultMessage": "投稿活动"
+  },
+  "XTkPen": {
+    "defaultMessage": "來自其他 Fediverse 站台的回應"
   },
   "XTyKFR": {
     "defaultMessage": "精挑细选作品，帮助读者更容易发现优质内容"
@@ -2453,9 +2513,6 @@
   "Z7JXlF": {
     "defaultMessage": "因违反用户协定而被封存，",
     "description": "src/views/ArticleDetail/StickyTopBanner/index.tsx"
-  },
-  "cY80V3": {
-    "defaultMessage": "公开作品会自动发送，远程站点可能保留副本"
   },
   "ZAs170": {
     "defaultMessage": "基本资料",
@@ -2585,6 +2642,9 @@
   "b6x6lm": {
     "defaultMessage": "输入简单明了的标题"
   },
+  "b8/cFV": {
+    "defaultMessage": "聯邦宇宙"
+  },
   "b8LMpq": {
     "defaultMessage": "查看全部 {count} 则留言",
     "description": "src/views/CampaignDetail/Discussion"
@@ -2614,6 +2674,9 @@
   },
   "beLe/F": {
     "defaultMessage": "广播"
+  },
+  "bmR7T4": {
+    "defaultMessage": "轉發"
   },
   "bv9UzQ": {
     "defaultMessage": "查看全部金句"
@@ -2661,6 +2724,9 @@
   "cQYXjl": {
     "defaultMessage": "汇率币别",
     "description": "src/views/Me/Settings/Misc/Currency/index.tsx"
+  },
+  "cY80V3": {
+    "defaultMessage": "公开作品会自动发送，远程站点可能保留副本"
   },
   "cYvIpp": {
     "defaultMessage": "无需重复订阅此围炉",
@@ -2946,6 +3012,9 @@
     "defaultMessage": "支付金额无效，请重新输入",
     "description": "PAYMENT_AMOUNT_INVALID"
   },
+  "glsBoL": {
+    "defaultMessage": "聯邦通知"
+  },
   "gsZ/aj": {
     "defaultMessage": "允许评论后，一经发布后无法关闭",
     "description": "src/components/Editor/Sidebar/CanComment/index.tsx"
@@ -3032,6 +3101,9 @@
     "defaultMessage": "读者数量",
     "description": "src/components/ArticleDigest/Published/FooterActions/index.tsx"
   },
+  "hyDCe8": {
+    "defaultMessage": "位追蹤者"
+  },
   "i4OBEw": {
     "defaultMessage": "不能使用 “{name}”"
   },
@@ -3064,6 +3136,9 @@
   },
   "ieGrWo": {
     "defaultMessage": "关注"
+  },
+  "ih+UCV": {
+    "defaultMessage": "回覆內容"
   },
   "imXsmo": {
     "defaultMessage": "回到作品页",
@@ -3104,6 +3179,9 @@
   "jOgBV9": {
     "defaultMessage": "回复了你",
     "description": "src/components/Notice/CommentCommentNotice/CommentNewReplyNotice.tsx"
+  },
+  "jWwn1K": {
+    "defaultMessage": "尋找遠端作者"
   },
   "jiB0Z2": {
     "defaultMessage": "无法绑定钱包",
@@ -3158,6 +3236,9 @@
   "kHMa3H": {
     "defaultMessage": "密码不一致"
   },
+  "kOStiL": {
+    "defaultMessage": "輸入完整帳號，例如 @alice@example.social"
+  },
   "kS3vTS": {
     "defaultMessage": "Liker ID",
     "description": "src/views/Me/Settings/Misc/LikerID.tsx"
@@ -3168,6 +3249,9 @@
   },
   "kc79d3": {
     "defaultMessage": "热门标签"
+  },
+  "kggbxQ": {
+    "defaultMessage": "追蹤"
   },
   "kkZioy": {
     "defaultMessage": "确认移出",
@@ -3187,6 +3271,9 @@
     "defaultMessage": "请输入新交易密码",
     "description": "src/components/Forms/PaymentForm/ResetPassword/Confirm.tsx"
   },
+  "kw8J39": {
+    "defaultMessage": "回覆到聯邦宇宙"
+  },
   "l/f7bu": {
     "defaultMessage": "想了解更多？詳見 ",
     "description": "src/views/Me/Analytics/EmptyAnalytics/index.tsx"
@@ -3201,6 +3288,9 @@
   "l31hCd": {
     "defaultMessage": "预览",
     "description": "src/components/Editor/MoreSettings/SupportSettingDialog/Content.tsx"
+  },
+  "lDTamI": {
+    "defaultMessage": "回覆"
   },
   "lFi0TA": {
     "defaultMessage": "加入选集"
@@ -3318,6 +3408,9 @@
   },
   "me1nR+": {
     "defaultMessage": "复制地址"
+  },
+  "miEMcG": {
+    "defaultMessage": "追蹤中"
   },
   "mij/rJ": {
     "defaultMessage": "删除草稿"
@@ -3612,6 +3705,9 @@
   "rfz/fN": {
     "defaultMessage": "建議尺寸 1600 x 900 像素"
   },
+  "rjEc9z": {
+    "defaultMessage": "取消追蹤"
+  },
   "rqS2aA": {
     "defaultMessage": "请登录该帐户解绑钱包后再试",
     "description": "src/components/AuthMethodFeed/AuthWalletFeed.tsx"
@@ -3623,8 +3719,14 @@
   "ruZqtT": {
     "defaultMessage": "仅供输入 {MIN_USER_DISPLAY_NAME_LENGTH}-{MAX_USER_DISPLAY_NAME_LENGTH} 个字符"
   },
+  "rudmDY": {
+    "defaultMessage": "追蹤遠端作者、閱讀聯邦動態，並管理回覆與通知"
+  },
   "s2s6tx": {
     "defaultMessage": "作品已成功发布，稍后将同步到 IPFS"
+  },
+  "sAB+vZ": {
+    "defaultMessage": "等待核准"
   },
   "sE2Ui3": {
     "defaultMessage": "账号已冻结"
@@ -3667,9 +3769,15 @@
   "syEQFE": {
     "defaultMessage": "发布"
   },
+  "t0kvjC": {
+    "defaultMessage": "查看全部"
+  },
   "t1wXVG": {
     "defaultMessage": "说说看？也许有人听",
     "description": "MOMENT_FORM"
+  },
+  "t1yrE4": {
+    "defaultMessage": "最多追蹤 {maxFollowing} 個帳號，動態保留 {days} 天，上限 {items} 筆"
   },
   "t2EpN/": {
     "defaultMessage": "持续与 {network} 网络同步，稍后更新至 Matters"
@@ -4095,6 +4203,9 @@
   "zE51j6": {
     "defaultMessage": "发布失败"
   },
+  "zK82DU": {
+    "defaultMessage": "追蹤動態"
+  },
   "zKOr2x": {
     "defaultMessage": "已关注用户占总观看人数比例",
     "description": "src/views/Circle/Analytics/FollowerAnalytics/index.tsx"
@@ -4111,6 +4222,9 @@
   },
   "zWXgmM": {
     "defaultMessage": "请回到原页面继续操作"
+  },
+  "zWonDB": {
+    "defaultMessage": "尚未追蹤任何遠端作者"
   },
   "zaY8Cu": {
     "defaultMessage": "输入交易密码",

--- a/lang/zh-Hant.json
+++ b/lang/zh-Hant.json
@@ -84,6 +84,9 @@
   "+vVZ/G": {
     "defaultMessage": "綁定"
   },
+  "+wqFkx": {
+    "defaultMessage": "聯邦宇宙互動"
+  },
   "/0OJlF": {
     "defaultMessage": "還沒有人留言",
     "description": "src/views/CampaignDetail/Discussion"
@@ -187,6 +190,9 @@
   "0ThOw1": {
     "defaultMessage": "新建選集",
     "description": "src/views/User/Collections/UserCollections.tsx"
+  },
+  "0XnomJ": {
+    "defaultMessage": "找不到這個聯邦帳號"
   },
   "0bTlm4": {
     "defaultMessage": "確認要刪除該動態嗎？"
@@ -353,6 +359,9 @@
     "defaultMessage": "修改",
     "description": "src/views/ArticleDetail/MetaInfo/index.tsx"
   },
+  "2cnZc/": {
+    "defaultMessage": "開啟後，新發佈的公開作品會自動送到 Fediverse。其他站台可能保留副本；關閉後將停止同步，並嘗試刪除先前內容。"
+  },
   "2ef/Xl": {
     "defaultMessage": "封鎖",
     "description": "src/views/Me/Settings/Blocked/ToggleBlockButton.tsx"
@@ -456,6 +465,9 @@
     "defaultMessage": "色情廣告",
     "description": "src/components/Comment/DropdownActions/CommunityWatchRemoveComment.tsx"
   },
+  "4GmeZE": {
+    "defaultMessage": "來自其他 Fediverse 站台的互動"
+  },
   "4KuZ0o": {
     "defaultMessage": "資源不存在",
     "description": "ASSET_NOT_FOUND"
@@ -515,6 +527,9 @@
     "defaultMessage": "喜歡你已刪除的動態",
     "description": "src/components/Notice/MomentNotice/MomentLiked.tsx"
   },
+  "5UgS3k": {
+    "defaultMessage": "封鎖"
+  },
   "5UglrB": {
     "defaultMessage": "送出成功"
   },
@@ -533,6 +548,9 @@
   },
   "5jlQTx": {
     "defaultMessage": "邀請管理"
+  },
+  "5kX6Qk": {
+    "defaultMessage": "檢舉"
   },
   "5mu8HJ": {
     "defaultMessage": "動態已刪除"
@@ -604,6 +622,9 @@
   },
   "6Sj2lN": {
     "defaultMessage": "提領支持"
+  },
+  "6UaJbf": {
+    "defaultMessage": "送出"
   },
   "6Vznnt": {
     "defaultMessage": "在你的圍爐中留言",
@@ -977,6 +998,9 @@
     "defaultMessage": "遞出支持資金給",
     "description": "src/components/Forms/PaymentForm/PaymentInfo/index.tsx"
   },
+  "ByvxDL": {
+    "defaultMessage": "追蹤中的作者"
+  },
   "C/4nS6": {
     "defaultMessage": "綁定並提領"
   },
@@ -1347,6 +1371,9 @@
     "defaultMessage": "你的排程作品已發布成功",
     "description": "src/components/Notice/ArticleNotice/ScheduledArticlePublishedNotice.tsx"
   },
+  "HFBocb": {
+    "defaultMessage": "追蹤遠端作者後，最新內容會出現在這裡"
+  },
   "HFVDeB": {
     "defaultMessage": "相關標籤",
     "description": "src/views/TagDetail/RelatedTags/index.tsx"
@@ -1428,6 +1455,9 @@
     "defaultMessage": "取消連結",
     "description": "src/components/Editor"
   },
+  "IK6Mk7": {
+    "defaultMessage": "查看原文"
+  },
   "IKPYe9": {
     "defaultMessage": "查看",
     "description": "src/components/Dialogs/CollectionSelectDialog/index.tsx"
@@ -1457,6 +1487,9 @@
   },
   "IjNYll": {
     "defaultMessage": "等等再說"
+  },
+  "InCosw": {
+    "defaultMessage": "搜尋"
   },
   "IpMWC4": {
     "defaultMessage": "短時間內已發布多條動態，請先休息一會吧～"
@@ -1713,6 +1746,9 @@
     "defaultMessage": "支持",
     "description": "src/views/Me/Transactions/index.tsx"
   },
+  "NDG8qY": {
+    "defaultMessage": "喜歡"
+  },
   "NDV5Mq": {
     "defaultMessage": "選項"
   },
@@ -1757,6 +1793,9 @@
   },
   "NmhF45": {
     "defaultMessage": "通過添加標籤幫助讀者更好地找到你的作品。如果沒有合適的標籤，你可以創建新的。"
+  },
+  "Nw8VNu": {
+    "defaultMessage": "聯邦宇宙互動中心"
   },
   "O0MQs/": {
     "defaultMessage": "請先綁定郵箱",
@@ -1862,6 +1901,9 @@
   "PXAur5": {
     "defaultMessage": "提現"
   },
+  "PbBsp5": {
+    "defaultMessage": "目前還沒有聯邦宇宙回覆"
+  },
   "PesLat": {
     "defaultMessage": "正在發布，馬上就好"
   },
@@ -1898,8 +1940,14 @@
   "Q8Qw5B": {
     "defaultMessage": "描述"
   },
+  "Q8g2+W": {
+    "defaultMessage": "全部已讀"
+  },
   "QHRze5": {
     "defaultMessage": "閒聊"
+  },
+  "QJd23B": {
+    "defaultMessage": "Fediverse 帳號"
   },
   "QKJWqd": {
     "defaultMessage": "收藏",
@@ -1951,6 +1999,9 @@
   "R410ei": {
     "defaultMessage": "驗證碼錯誤",
     "description": "CODE_INVALID"
+  },
+  "R6sMIX": {
+    "defaultMessage": "Fediverse"
   },
   "R7yHDl": {
     "defaultMessage": "圍爐營收",
@@ -2067,11 +2118,11 @@
   "Sj+TN8": {
     "defaultMessage": "公告"
   },
-  "2cnZc/": {
-    "defaultMessage": "開啟後，新發佈的公開作品會自動送到 Fediverse。其他站台可能保留副本；關閉後將停止同步，並嘗試刪除先前內容。"
-  },
   "SuRTsQ": {
     "defaultMessage": "註冊 ISCN"
+  },
+  "SyxunU": {
+    "defaultMessage": "聯邦宇宙操作已送出"
   },
   "Szd1tH": {
     "defaultMessage": "登出失敗，請重試"
@@ -2226,6 +2277,9 @@
     "defaultMessage": "過往活動",
     "description": "src/views/Campaigns/Feeds/Tabs/index.tsx"
   },
+  "VWeoZC": {
+    "defaultMessage": "目前沒有通知"
+  },
   "VZsE96": {
     "defaultMessage": "選集名稱"
   },
@@ -2267,6 +2321,9 @@
   "W0sZaX": {
     "defaultMessage": "最近 3 個月",
     "description": "src/views/Me/Analytics/SelectPeriod/index.tsx"
+  },
+  "W1j+F0": {
+    "defaultMessage": "請簡述檢舉原因"
   },
   "W3hNBA": {
     "defaultMessage": "七日書大滿貫"
@@ -2344,6 +2401,9 @@
   },
   "XTRqqT": {
     "defaultMessage": "投稿活動"
+  },
+  "XTkPen": {
+    "defaultMessage": "來自其他 Fediverse 站台的回應"
   },
   "XTyKFR": {
     "defaultMessage": "精挑細選作品，幫助讀者更容易發現優質內容"
@@ -2453,9 +2513,6 @@
   "Z7JXlF": {
     "defaultMessage": "因違反用戶協定而被封存，",
     "description": "src/views/ArticleDetail/StickyTopBanner/index.tsx"
-  },
-  "cY80V3": {
-    "defaultMessage": "公開作品會自動送出，遠端站台可能保留副本"
   },
   "ZAs170": {
     "defaultMessage": "基本資料",
@@ -2585,6 +2642,9 @@
   "b6x6lm": {
     "defaultMessage": "輸入簡單明瞭的標題"
   },
+  "b8/cFV": {
+    "defaultMessage": "聯邦宇宙"
+  },
   "b8LMpq": {
     "defaultMessage": "查看全部 {count} 則留言",
     "description": "src/views/CampaignDetail/Discussion"
@@ -2614,6 +2674,9 @@
   },
   "beLe/F": {
     "defaultMessage": "廣播"
+  },
+  "bmR7T4": {
+    "defaultMessage": "轉發"
   },
   "bv9UzQ": {
     "defaultMessage": "查看全部金句"
@@ -2661,6 +2724,9 @@
   "cQYXjl": {
     "defaultMessage": "匯率幣別",
     "description": "src/views/Me/Settings/Misc/Currency/index.tsx"
+  },
+  "cY80V3": {
+    "defaultMessage": "公開作品會自動送出，遠端站台可能保留副本"
   },
   "cYvIpp": {
     "defaultMessage": "無需重複訂閱此圍爐",
@@ -2946,6 +3012,9 @@
     "defaultMessage": "支付金額無效，請重新輸入",
     "description": "PAYMENT_AMOUNT_INVALID"
   },
+  "glsBoL": {
+    "defaultMessage": "聯邦通知"
+  },
   "gsZ/aj": {
     "defaultMessage": "允許評論後，一經發布後無法關閉",
     "description": "src/components/Editor/Sidebar/CanComment/index.tsx"
@@ -3032,6 +3101,9 @@
     "defaultMessage": "讀者數量",
     "description": "src/components/ArticleDigest/Published/FooterActions/index.tsx"
   },
+  "hyDCe8": {
+    "defaultMessage": "位追蹤者"
+  },
   "i4OBEw": {
     "defaultMessage": "不能使用「{name}」"
   },
@@ -3064,6 +3136,9 @@
   },
   "ieGrWo": {
     "defaultMessage": "追蹤"
+  },
+  "ih+UCV": {
+    "defaultMessage": "回覆內容"
   },
   "imXsmo": {
     "defaultMessage": "回到作品頁",
@@ -3104,6 +3179,9 @@
   "jOgBV9": {
     "defaultMessage": "回覆了你",
     "description": "src/components/Notice/CommentCommentNotice/CommentNewReplyNotice.tsx"
+  },
+  "jWwn1K": {
+    "defaultMessage": "尋找遠端作者"
   },
   "jiB0Z2": {
     "defaultMessage": "無法綁定錢包",
@@ -3158,6 +3236,9 @@
   "kHMa3H": {
     "defaultMessage": "密碼不一致"
   },
+  "kOStiL": {
+    "defaultMessage": "輸入完整帳號，例如 @alice@example.social"
+  },
   "kS3vTS": {
     "defaultMessage": "Liker ID",
     "description": "src/views/Me/Settings/Misc/LikerID.tsx"
@@ -3168,6 +3249,9 @@
   },
   "kc79d3": {
     "defaultMessage": "熱門標籤"
+  },
+  "kggbxQ": {
+    "defaultMessage": "追蹤"
   },
   "kkZioy": {
     "defaultMessage": "確認移出",
@@ -3187,6 +3271,9 @@
     "defaultMessage": "請輸入新交易密碼",
     "description": "src/components/Forms/PaymentForm/ResetPassword/Confirm.tsx"
   },
+  "kw8J39": {
+    "defaultMessage": "回覆到聯邦宇宙"
+  },
   "l/f7bu": {
     "defaultMessage": "想了解更多？詳見 ",
     "description": "src/views/Me/Analytics/EmptyAnalytics/index.tsx"
@@ -3201,6 +3288,9 @@
   "l31hCd": {
     "defaultMessage": "預覽",
     "description": "src/components/Editor/MoreSettings/SupportSettingDialog/Content.tsx"
+  },
+  "lDTamI": {
+    "defaultMessage": "回覆"
   },
   "lFi0TA": {
     "defaultMessage": "加入選集"
@@ -3318,6 +3408,9 @@
   },
   "me1nR+": {
     "defaultMessage": "複製地址"
+  },
+  "miEMcG": {
+    "defaultMessage": "追蹤中"
   },
   "mij/rJ": {
     "defaultMessage": "刪除草稿"
@@ -3612,6 +3705,9 @@
   "rfz/fN": {
     "defaultMessage": "建議尺寸 1600 x 900 像素"
   },
+  "rjEc9z": {
+    "defaultMessage": "取消追蹤"
+  },
   "rqS2aA": {
     "defaultMessage": "請登入該帳戶解綁錢包後再試",
     "description": "src/components/AuthMethodFeed/AuthWalletFeed.tsx"
@@ -3623,8 +3719,14 @@
   "ruZqtT": {
     "defaultMessage": "僅供輸入 {MIN_USER_DISPLAY_NAME_LENGTH}-{MAX_USER_DISPLAY_NAME_LENGTH} 個字元"
   },
+  "rudmDY": {
+    "defaultMessage": "追蹤遠端作者、閱讀聯邦動態，並管理回覆與通知"
+  },
   "s2s6tx": {
     "defaultMessage": "已成功發布作品，稍後同步到 IPFS"
+  },
+  "sAB+vZ": {
+    "defaultMessage": "等待核准"
   },
   "sE2Ui3": {
     "defaultMessage": "帳號已凍結"
@@ -3667,9 +3769,15 @@
   "syEQFE": {
     "defaultMessage": "發布"
   },
+  "t0kvjC": {
+    "defaultMessage": "查看全部"
+  },
   "t1wXVG": {
     "defaultMessage": "說說看？也許有人聽",
     "description": "MOMENT_FORM"
+  },
+  "t1yrE4": {
+    "defaultMessage": "最多追蹤 {maxFollowing} 個帳號，動態保留 {days} 天，上限 {items} 筆"
   },
   "t2EpN/": {
     "defaultMessage": "持續與 {network} 網絡同步，稍後更新至 Matters"
@@ -4095,6 +4203,9 @@
   "zE51j6": {
     "defaultMessage": "發布失敗"
   },
+  "zK82DU": {
+    "defaultMessage": "追蹤動態"
+  },
   "zKOr2x": {
     "defaultMessage": "已追蹤用戶佔總觀看人數比例",
     "description": "src/views/Circle/Analytics/FollowerAnalytics/index.tsx"
@@ -4111,6 +4222,9 @@
   },
   "zWXgmM": {
     "defaultMessage": "請回到原頁面繼續操作"
+  },
+  "zWonDB": {
+    "defaultMessage": "尚未追蹤任何遠端作者"
   },
   "zaY8Cu": {
     "defaultMessage": "輸入交易密碼",

--- a/src/common/enums/route.ts
+++ b/src/common/enums/route.ts
@@ -53,6 +53,7 @@ type ROUTE_KEY =
   | 'ME_HISTORY_LIKES_SENT'
   | 'ME_HISTORY_LIKES_RECEIVED'
   | 'ME_NOTIFICATIONS'
+  | 'ME_FEDIVERSE'
   | 'ME_ANALYTICS'
   | 'ME_WALLET'
   | 'ME_WALLET_TRANSACTIONS'
@@ -106,6 +107,7 @@ export const PROTECTED_ROUTES: {
   { key: 'ME_HISTORY_LIKES_SENT', pathname: '/me/history/likes/sent' },
   { key: 'ME_HISTORY_LIKES_RECEIVED', pathname: '/me/history/likes/received' },
   { key: 'ME_NOTIFICATIONS', pathname: '/me/notifications' },
+  { key: 'ME_FEDIVERSE', pathname: '/me/fediverse' },
   { key: 'ME_WALLET', pathname: '/me/wallet' },
   { key: 'ME_WALLET_TRANSACTIONS', pathname: '/me/wallet/transactions' },
   { key: 'ME_ANALYTICS', pathname: '/me/analytics' },

--- a/src/common/utils/types/index.ts
+++ b/src/common/utils/types/index.ts
@@ -105,6 +105,125 @@ export default gql`
     ): ArticleFederationSetting!
   }
 
+  extend type Query {
+    viewerFediverse: FediverseProfile!
+    fediverseArticle(input: FediverseArticleInput!): FediverseArticle!
+    fediverseRemoteActor(
+      input: FediverseRemoteActorInput!
+    ): FediverseRemoteActor!
+  }
+
+  extend type Mutation {
+    actFediverse(input: FediverseActionInput!): FediverseActionResult!
+    refreshFediverseProfile: Boolean!
+  }
+
+  type FediverseProfile {
+    actorId: String!
+    handle: String!
+    account: String!
+    displayName: String!
+    summary: String!
+    profileUrl: String!
+    avatarUrl: String
+    headerUrl: String
+    followersCount: Int!
+    followingCount: Int!
+    pendingFollowingCount: Int!
+    unreadNotificationsCount: Int!
+    maxFollowing: Int!
+    retentionDays: Int!
+    timelineMaxItems: Int!
+    following: [FediverseRemoteActor!]!
+    notifications: [FediverseNotification!]!
+    timeline: [FediversePost!]!
+  }
+
+  type FediverseRemoteActor {
+    actorId: String!
+    account: String
+    preferredUsername: String
+    name: String
+    summary: String!
+    url: String!
+    avatarUrl: String
+    status: String
+  }
+
+  type FediverseNotification {
+    id: ID!
+    category: String!
+    contentId: String
+    objectId: String
+    remoteActorIds: [String!]!
+    headline: String
+    preview: String
+    eventCount: Int!
+    unreadCount: Int!
+    publishedAt: DateTime
+  }
+
+  type FediversePost {
+    objectId: String!
+    content: String!
+    summary: String!
+    url: String
+    inReplyTo: String
+    publishedAt: DateTime
+    remoteActor: FediverseRemoteActor!
+  }
+
+  type FediverseArticle {
+    contentId: String
+    repliesCount: Int!
+    likesCount: Int!
+    announcesCount: Int!
+    notificationsCount: Int!
+    unreadNotificationsCount: Int!
+    replies: [FediversePost!]!
+  }
+
+  type FediverseActionResult {
+    status: String!
+    mapping: String
+    activityId: String
+    remoteActorId: String
+  }
+
+  enum FediverseAction {
+    follow
+    unfollow
+    reply
+    like
+    unlike
+    announce
+    unannounce
+    block
+    unblock
+    report
+    mark_read
+  }
+
+  input FediverseArticleInput {
+    id: ID!
+  }
+
+  input FediverseRemoteActorInput {
+    account: String
+    actorId: String
+  }
+
+  input FediverseActionInput {
+    action: FediverseAction!
+    account: String
+    remoteActorId: String
+    objectId: String
+    content: String
+    activityId: String
+    notificationIds: [ID!]
+    reason: String
+  }
+
   enum CommunityWatchRemoveCommentReason {
     porn_ad
     spam_ad

--- a/src/components/Context/Viewer/index.tsx
+++ b/src/components/Context/Viewer/index.tsx
@@ -60,6 +60,9 @@ const ViewerFragments = {
         followers(input: { first: 0 }) {
           totalCount
         }
+        federationSetting {
+          state
+        }
       }
     `,
     private: gql`

--- a/src/components/Layout/GlobalNav/MeMenu/index.tsx
+++ b/src/components/Layout/GlobalNav/MeMenu/index.tsx
@@ -14,6 +14,7 @@ import IconProfile from '@/public/static/icons/24px/profile.svg'
 import IconSave from '@/public/static/icons/24px/save.svg'
 import IconSettings from '@/public/static/icons/24px/settings.svg'
 import IconWallet from '@/public/static/icons/24px/wallet.svg'
+import IconWorld from '@/public/static/icons/24px/world.svg'
 import {
   COOKIE_TOKEN_NAME,
   COOKIE_USER_GROUP,
@@ -137,6 +138,13 @@ const MeMenu: React.FC = () => {
         text={<FormattedMessage defaultMessage="Stats" id="U86B6w" />}
         icon={<Icon icon={IconData} size={20} />}
         href={PATHS.ME_ANALYTICS}
+        is="link"
+      />
+
+      <Menu.Item
+        text={<FormattedMessage defaultMessage="Fediverse" id="R6sMIX" />}
+        icon={<Icon icon={IconWorld} size={20} />}
+        href={PATHS.ME_FEDIVERSE}
         is="link"
       />
 

--- a/src/components/Layout/GlobalNav/UnreadIcon/Notification.tsx
+++ b/src/components/Layout/GlobalNav/UnreadIcon/Notification.tsx
@@ -1,5 +1,6 @@
 import { useQuery } from '@apollo/client'
 import classNames from 'classnames'
+import gql from 'graphql-tag'
 import { useContext, useEffect } from 'react'
 
 import IconNavNotifications from '@/public/static/icons/24px/nav-notifications.svg'
@@ -15,6 +16,14 @@ interface UnreadIconProps {
   iconSize?: 24 | 26 | 28 | 30
 }
 
+const FEDIVERSE_UNREAD_COUNT = gql`
+  query FediverseUnreadCount {
+    viewerFediverse {
+      unreadNotificationsCount
+    }
+  }
+`
+
 const NotificationUnreadIcon: React.FC<UnreadIconProps> = ({
   active,
   iconSize = 24,
@@ -28,15 +37,30 @@ const NotificationUnreadIcon: React.FC<UnreadIconProps> = ({
       skip: !viewer.isAuthed || typeof window === 'undefined',
     }
   )
+  const federationEnabled = viewer.federationSetting?.state === 'enabled'
+  const { data: federationData, startPolling: startFederationPolling } =
+    useQuery<{
+      viewerFediverse: { unreadNotificationsCount: number }
+    }>(FEDIVERSE_UNREAD_COUNT, {
+      errorPolicy: 'ignore',
+      fetchPolicy: 'network-only',
+      skip:
+        !viewer.isAuthed || !federationEnabled || typeof window === 'undefined',
+    })
 
   // FIXME: https://github.com/apollographql/apollo-client/issues/3775
   useEffect(() => {
     if (viewer.isAuthed) {
       startPolling(1000 * 20) // 20s
+      if (federationEnabled) {
+        startFederationPolling(1000 * 20)
+      }
     }
-  }, [])
+  }, [federationEnabled])
 
-  const unread = (data?.viewer?.status?.unreadNoticeCount || 0) >= 1
+  const unread =
+    (data?.viewer?.status?.unreadNoticeCount || 0) >= 1 ||
+    (federationData?.viewerFediverse.unreadNotificationsCount || 0) >= 1
   const iconClasses = classNames({
     [styles.unreadIcon]: true,
     [styles.unread]: unread,

--- a/src/components/Layout/Header/MeButton/SideDrawerNav/DrawerContent/MeMenu/index.tsx
+++ b/src/components/Layout/Header/MeButton/SideDrawerNav/DrawerContent/MeMenu/index.tsx
@@ -14,6 +14,7 @@ import IconProfile from '@/public/static/icons/24px/profile.svg'
 import IconSave from '@/public/static/icons/24px/save.svg'
 import IconSettings from '@/public/static/icons/24px/settings.svg'
 import IconWallet from '@/public/static/icons/24px/wallet.svg'
+import IconWorld from '@/public/static/icons/24px/world.svg'
 import {
   COOKIE_TOKEN_NAME,
   COOKIE_USER_GROUP,
@@ -107,6 +108,14 @@ const Top: React.FC = () => {
         text={<FormattedMessage defaultMessage="Stats" id="U86B6w" />}
         icon={<Icon icon={IconData} size={24} />}
         href={PATHS.ME_ANALYTICS}
+        is="link"
+      />
+
+      <Menu.Item
+        {...menuItemProps}
+        text={<FormattedMessage defaultMessage="Fediverse" id="R6sMIX" />}
+        icon={<Icon icon={IconWorld} size={24} />}
+        href={PATHS.ME_FEDIVERSE}
         is="link"
       />
     </Menu>

--- a/src/pages/me/fediverse.tsx
+++ b/src/pages/me/fediverse.tsx
@@ -1,0 +1,10 @@
+import { Protected } from '~/components'
+import Fediverse from '~/views/Me/Fediverse'
+
+const ProtectedFediverse = () => (
+  <Protected>
+    <Fediverse />
+  </Protected>
+)
+
+export default ProtectedFediverse

--- a/src/views/ArticleDetail/FediverseInteractions/index.tsx
+++ b/src/views/ArticleDetail/FediverseInteractions/index.tsx
@@ -1,0 +1,300 @@
+import { useMutation, useQuery } from '@apollo/client'
+import gql from 'graphql-tag'
+import { useState } from 'react'
+import { FormattedMessage, useIntl } from 'react-intl'
+
+import { Button, toast } from '~/components'
+
+import styles from './styles.module.css'
+
+const ARTICLE_FEDIVERSE = gql`
+  query ArticleFediverse($input: FediverseArticleInput!) {
+    fediverseArticle(input: $input) {
+      contentId
+      repliesCount
+      likesCount
+      announcesCount
+      notificationsCount
+      unreadNotificationsCount
+      replies {
+        objectId
+        content
+        summary
+        url
+        publishedAt
+        remoteActor {
+          actorId
+          account
+          preferredUsername
+          name
+          avatarUrl
+        }
+      }
+    }
+  }
+`
+
+const ACT_ARTICLE_FEDIVERSE = gql`
+  mutation ActArticleFediverse($input: FediverseActionInput!) {
+    actFediverse(input: $input) {
+      status
+      activityId
+    }
+  }
+`
+
+type ArticleFediverseData = {
+  fediverseArticle: {
+    repliesCount: number
+    likesCount: number
+    announcesCount: number
+    notificationsCount: number
+    unreadNotificationsCount: number
+    replies: Array<{
+      objectId: string
+      content: string
+      summary: string
+      url?: string | null
+      remoteActor: {
+        actorId: string
+        account?: string | null
+        preferredUsername?: string | null
+        name?: string | null
+        avatarUrl?: string | null
+      }
+    }>
+  }
+}
+
+const plainText = (html: string) =>
+  html
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/<[^>]*>/g, '')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .trim()
+
+const FediverseInteractions = ({
+  articleId,
+  enabled,
+}: {
+  articleId: string
+  enabled: boolean
+}) => {
+  const intl = useIntl()
+  const [replyDrafts, setReplyDrafts] = useState<Record<string, string>>({})
+  const [busy, setBusy] = useState<string | null>(null)
+  const { data, loading, error, refetch } = useQuery<ArticleFediverseData>(
+    ARTICLE_FEDIVERSE,
+    {
+      variables: { input: { id: articleId } },
+      skip: !enabled,
+      fetchPolicy: 'network-only',
+    }
+  )
+  const [act] = useMutation(ACT_ARTICLE_FEDIVERSE)
+
+  if (!enabled || loading || error || !data?.fediverseArticle) {
+    return null
+  }
+
+  const social = data.fediverseArticle
+
+  const runAction = async ({
+    key,
+    input,
+  }: {
+    key: string
+    input: Record<string, unknown>
+  }) => {
+    setBusy(key)
+    try {
+      await act({ variables: { input } })
+      await refetch()
+      toast.success({
+        message: intl.formatMessage({
+          defaultMessage: '聯邦宇宙操作已送出',
+          id: 'SyxunU',
+        }),
+      })
+      return true
+    } catch {
+      toast.error({
+        message: intl.formatMessage({
+          defaultMessage: '操作失敗，請稍後再試',
+          id: 'vXgChH',
+        }),
+      })
+      return false
+    } finally {
+      setBusy(null)
+    }
+  }
+
+  return (
+    <section className={styles.container}>
+      <header>
+        <div>
+          <h2>
+            <FormattedMessage defaultMessage="聯邦宇宙互動" id="+wqFkx" />
+          </h2>
+          <p>
+            <FormattedMessage
+              defaultMessage="來自其他 Fediverse 站台的回應"
+              id="XTkPen"
+            />
+          </p>
+        </div>
+        {social.unreadNotificationsCount > 0 && (
+          <span className={styles.badge}>
+            {social.unreadNotificationsCount} new
+          </span>
+        )}
+      </header>
+      <div className={styles.metrics}>
+        <span>
+          <strong>{social.repliesCount}</strong>
+          <FormattedMessage defaultMessage="回覆" id="lDTamI" />
+        </span>
+        <span>
+          <strong>{social.likesCount}</strong>
+          <FormattedMessage defaultMessage="喜歡" id="NDG8qY" />
+        </span>
+        <span>
+          <strong>{social.announcesCount}</strong>
+          <FormattedMessage defaultMessage="轉發" id="bmR7T4" />
+        </span>
+      </div>
+      {social.replies.length === 0 ? (
+        <p className={styles.empty}>
+          <FormattedMessage
+            defaultMessage="目前還沒有聯邦宇宙回覆"
+            id="PbBsp5"
+          />
+        </p>
+      ) : (
+        social.replies.map((reply) => {
+          const actor = reply.remoteActor
+          const name =
+            actor.name ||
+            actor.preferredUsername ||
+            actor.account ||
+            actor.actorId
+          const draft = replyDrafts[reply.objectId] || ''
+
+          return (
+            <article className={styles.reply} key={reply.objectId}>
+              <div className={styles.author}>
+                <span
+                  className={styles.avatar}
+                  style={
+                    actor.avatarUrl
+                      ? { backgroundImage: `url("${actor.avatarUrl}")` }
+                      : undefined
+                  }
+                >
+                  {!actor.avatarUrl && name.slice(0, 1).toUpperCase()}
+                </span>
+                <div>
+                  <strong>{name}</strong>
+                  <small>{actor.account || actor.actorId}</small>
+                </div>
+              </div>
+              <p>{plainText(reply.content || reply.summary)}</p>
+              <div className={styles.actions}>
+                <Button
+                  disabled={busy === `like:${reply.objectId}`}
+                  onClick={() =>
+                    runAction({
+                      key: `like:${reply.objectId}`,
+                      input: {
+                        action: 'like',
+                        objectId: reply.objectId,
+                        remoteActorId: actor.actorId,
+                      },
+                    })
+                  }
+                  textColor="green"
+                >
+                  <FormattedMessage defaultMessage="喜歡" id="NDG8qY" />
+                </Button>
+                <Button
+                  disabled={busy === `announce:${reply.objectId}`}
+                  onClick={() =>
+                    runAction({
+                      key: `announce:${reply.objectId}`,
+                      input: {
+                        action: 'announce',
+                        objectId: reply.objectId,
+                        remoteActorId: actor.actorId,
+                      },
+                    })
+                  }
+                  textColor="green"
+                >
+                  <FormattedMessage defaultMessage="轉發" id="bmR7T4" />
+                </Button>
+              </div>
+              <form
+                className={styles.replyForm}
+                onSubmit={async (event) => {
+                  event.preventDefault()
+                  if (!draft.trim()) {
+                    return
+                  }
+                  const sent = await runAction({
+                    key: `reply:${reply.objectId}`,
+                    input: {
+                      action: 'reply',
+                      objectId: reply.objectId,
+                      remoteActorId: actor.actorId,
+                      content: draft.trim(),
+                    },
+                  })
+                  if (sent) {
+                    setReplyDrafts((current) => ({
+                      ...current,
+                      [reply.objectId]: '',
+                    }))
+                  }
+                }}
+              >
+                <input
+                  aria-label={intl.formatMessage({
+                    defaultMessage: '回覆內容',
+                    id: 'ih+UCV',
+                  })}
+                  maxLength={500}
+                  onChange={(event) =>
+                    setReplyDrafts((current) => ({
+                      ...current,
+                      [reply.objectId]: event.target.value,
+                    }))
+                  }
+                  placeholder={intl.formatMessage({
+                    defaultMessage: '回覆到聯邦宇宙',
+                    id: 'kw8J39',
+                  })}
+                  value={draft}
+                />
+                <Button
+                  bgColor="green"
+                  disabled={busy === `reply:${reply.objectId}` || !draft.trim()}
+                  spacing={[8, 16]}
+                  textColor="white"
+                  type="submit"
+                >
+                  <FormattedMessage defaultMessage="送出" id="6UaJbf" />
+                </Button>
+              </form>
+            </article>
+          )
+        })
+      )}
+    </section>
+  )
+}
+
+export default FediverseInteractions

--- a/src/views/ArticleDetail/FediverseInteractions/styles.module.css
+++ b/src/views/ArticleDetail/FediverseInteractions/styles.module.css
@@ -1,0 +1,120 @@
+.container {
+  padding: var(--sp20);
+  margin-top: var(--sp24);
+  border: 1px solid var(--color-grey-lighter);
+  border-radius: 0.75rem;
+
+  & > header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+
+    & h2 {
+      font-size: var(--font-size-18);
+    }
+
+    & p {
+      margin-top: var(--sp4);
+      font-size: var(--font-size-14);
+      color: var(--color-grey-darker);
+    }
+  }
+}
+
+.badge {
+  padding: var(--sp4) var(--sp8);
+  font-size: var(--font-size-12);
+  color: var(--color-white);
+  background: var(--color-red);
+  border-radius: 5rem;
+}
+
+.metrics {
+  display: flex;
+  gap: var(--sp24);
+  padding: var(--sp16) 0;
+  margin-top: var(--sp16);
+  border-top: 1px solid var(--color-grey-lighter);
+  border-bottom: 1px solid var(--color-grey-lighter);
+
+  & span {
+    display: flex;
+    gap: var(--sp4);
+    color: var(--color-grey-darker);
+  }
+
+  & strong {
+    color: var(--color-black);
+  }
+}
+
+.empty {
+  padding-top: var(--sp16);
+  color: var(--color-grey-darker);
+}
+
+.reply {
+  padding: var(--sp20) 0;
+  border-bottom: 1px solid var(--color-grey-lighter);
+
+  &:last-child {
+    padding-bottom: 0;
+    border-bottom: 0;
+  }
+
+  & > p {
+    margin: var(--sp12) 0;
+    white-space: pre-wrap;
+  }
+}
+
+.author {
+  display: flex;
+  gap: var(--sp12);
+  align-items: center;
+
+  & > div {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+  }
+
+  & small {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    color: var(--color-grey-darker);
+    white-space: nowrap;
+  }
+}
+
+.avatar {
+  @mixin flex-center-all;
+
+  flex: 0 0 auto;
+  width: 2.5rem;
+  height: 2.5rem;
+  color: var(--color-white);
+  background: var(--color-green);
+  background-position: center;
+  background-size: cover;
+  border-radius: 50%;
+}
+
+.actions {
+  display: flex;
+  gap: var(--sp16);
+}
+
+.replyForm {
+  display: flex;
+  gap: var(--sp8);
+  margin-top: var(--sp12);
+
+  & input {
+    flex: 1;
+    min-width: 0;
+    padding: var(--sp8) var(--sp12);
+    border: 1px solid var(--color-grey-light);
+    border-radius: 0.5rem;
+  }
+}

--- a/src/views/ArticleDetail/index.tsx
+++ b/src/views/ArticleDetail/index.tsx
@@ -57,6 +57,7 @@ import { CommentsDialog } from './Comments/CommentsDialog'
 import { Placeholder as CommentsPlaceholder } from './Comments/Placeholder'
 import Content from './Content'
 import CustomizedSummary from './CustomizedSummary'
+import FediverseInteractions from './FediverseInteractions'
 import {
   ARTICLE_AVAILABLE_TRANSLATIONS,
   ARTICLE_DETAIL_PRIVATE,
@@ -378,6 +379,8 @@ const BaseArticleDetail = ({
         <License license={article.license} />
 
         <Channel article={article} privateFetched={privateFetched} />
+
+        <FediverseInteractions articleId={article.id} enabled={isAuthor} />
 
         {features.payment && (
           <DynamicSupportWidget

--- a/src/views/Me/Fediverse/gql.ts
+++ b/src/views/Me/Fediverse/gql.ts
@@ -1,0 +1,89 @@
+import gql from 'graphql-tag'
+
+export const REMOTE_ACTOR_FIELDS = gql`
+  fragment FediverseRemoteActorFields on FediverseRemoteActor {
+    actorId
+    account
+    preferredUsername
+    name
+    summary
+    url
+    avatarUrl
+    status
+  }
+`
+
+export const VIEWER_FEDIVERSE = gql`
+  query ViewerFediverse {
+    viewerFediverse {
+      actorId
+      handle
+      account
+      displayName
+      summary
+      profileUrl
+      avatarUrl
+      headerUrl
+      followersCount
+      followingCount
+      pendingFollowingCount
+      unreadNotificationsCount
+      maxFollowing
+      retentionDays
+      timelineMaxItems
+      following {
+        ...FediverseRemoteActorFields
+      }
+      notifications {
+        id
+        category
+        contentId
+        objectId
+        remoteActorIds
+        headline
+        preview
+        eventCount
+        unreadCount
+        publishedAt
+      }
+      timeline {
+        objectId
+        content
+        summary
+        url
+        inReplyTo
+        publishedAt
+        remoteActor {
+          ...FediverseRemoteActorFields
+        }
+      }
+    }
+  }
+  ${REMOTE_ACTOR_FIELDS}
+`
+
+export const FEDIVERSE_REMOTE_ACTOR = gql`
+  query FediverseRemoteActor($input: FediverseRemoteActorInput!) {
+    fediverseRemoteActor(input: $input) {
+      ...FediverseRemoteActorFields
+    }
+  }
+  ${REMOTE_ACTOR_FIELDS}
+`
+
+export const ACT_FEDIVERSE = gql`
+  mutation ActFediverse($input: FediverseActionInput!) {
+    actFediverse(input: $input) {
+      status
+      mapping
+      activityId
+      remoteActorId
+    }
+  }
+`
+
+export const REFRESH_FEDIVERSE_PROFILE = gql`
+  mutation RefreshFediverseProfile {
+    refreshFediverseProfile
+  }
+`

--- a/src/views/Me/Fediverse/index.tsx
+++ b/src/views/Me/Fediverse/index.tsx
@@ -1,0 +1,627 @@
+import { useLazyQuery, useMutation, useQuery } from '@apollo/client'
+import { useEffect, useState } from 'react'
+import { FormattedMessage, useIntl } from 'react-intl'
+
+import {
+  Button,
+  Head,
+  Layout,
+  QueryError,
+  SpinnerBlock,
+  toast,
+} from '~/components'
+
+import {
+  ACT_FEDIVERSE,
+  FEDIVERSE_REMOTE_ACTOR,
+  REFRESH_FEDIVERSE_PROFILE,
+  VIEWER_FEDIVERSE,
+} from './gql'
+import styles from './styles.module.css'
+
+type RemoteActor = {
+  actorId: string
+  account?: string | null
+  preferredUsername?: string | null
+  name?: string | null
+  summary: string
+  url: string
+  avatarUrl?: string | null
+  status?: string | null
+}
+
+type FediversePost = {
+  objectId: string
+  content: string
+  summary: string
+  url?: string | null
+  inReplyTo?: string | null
+  publishedAt?: string | null
+  remoteActor: RemoteActor
+}
+
+type FediverseNotification = {
+  id: string
+  category: string
+  headline?: string | null
+  preview?: string | null
+  eventCount: number
+  unreadCount: number
+  publishedAt?: string | null
+}
+
+type ViewerFediverseData = {
+  viewerFediverse: {
+    actorId: string
+    handle: string
+    account: string
+    displayName: string
+    summary: string
+    profileUrl: string
+    avatarUrl?: string | null
+    headerUrl?: string | null
+    followersCount: number
+    followingCount: number
+    pendingFollowingCount: number
+    unreadNotificationsCount: number
+    maxFollowing: number
+    retentionDays: number
+    timelineMaxItems: number
+    following: RemoteActor[]
+    notifications: FediverseNotification[]
+    timeline: FediversePost[]
+  }
+}
+
+type RemoteActorData = {
+  fediverseRemoteActor: RemoteActor
+}
+
+type FediverseAction =
+  | 'follow'
+  | 'unfollow'
+  | 'reply'
+  | 'like'
+  | 'announce'
+  | 'block'
+  | 'report'
+  | 'mark_read'
+
+type ActionInput = {
+  action: FediverseAction
+  account?: string
+  remoteActorId?: string
+  objectId?: string
+  content?: string
+  notificationIds?: string[]
+  reason?: string
+}
+
+const plainText = (html: string) =>
+  html
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/<[^>]*>/g, '')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .trim()
+
+const actorLabel = (actor: RemoteActor) =>
+  actor.name || actor.preferredUsername || actor.account || actor.actorId
+
+const ActorAvatar = ({ actor }: { actor: RemoteActor }) => (
+  <span
+    aria-hidden
+    className={styles.avatar}
+    style={
+      actor.avatarUrl
+        ? { backgroundImage: `url("${actor.avatarUrl}")` }
+        : undefined
+    }
+  >
+    {!actor.avatarUrl && actorLabel(actor).slice(0, 1).toUpperCase()}
+  </span>
+)
+
+const Fediverse = () => {
+  const intl = useIntl()
+  const [search, setSearch] = useState('')
+  const [replyDrafts, setReplyDrafts] = useState<Record<string, string>>({})
+  const [busyKey, setBusyKey] = useState<string | null>(null)
+  const { data, loading, error, refetch } = useQuery<ViewerFediverseData>(
+    VIEWER_FEDIVERSE,
+    { fetchPolicy: 'network-only' }
+  )
+  const [resolveActor, actorResult] = useLazyQuery<RemoteActorData>(
+    FEDIVERSE_REMOTE_ACTOR,
+    { fetchPolicy: 'network-only' }
+  )
+  const [act] = useMutation(ACT_FEDIVERSE)
+  const [refreshProfile] = useMutation(REFRESH_FEDIVERSE_PROFILE)
+
+  useEffect(() => {
+    refreshProfile()
+      .then(() => refetch())
+      .catch(() => undefined)
+  }, [])
+
+  const runAction = async (input: ActionInput, key: string) => {
+    setBusyKey(key)
+    try {
+      await act({ variables: { input } })
+      await refetch()
+      toast.success({
+        message: intl.formatMessage({
+          defaultMessage: '聯邦宇宙操作已送出',
+          id: 'SyxunU',
+        }),
+      })
+      return true
+    } catch {
+      toast.error({
+        message: intl.formatMessage({
+          defaultMessage: '操作失敗，請稍後再試',
+          id: 'vXgChH',
+        }),
+      })
+      return false
+    } finally {
+      setBusyKey(null)
+    }
+  }
+
+  const searchActor = async (event: React.FormEvent) => {
+    event.preventDefault()
+    const account = search.trim()
+    if (!account) {
+      return
+    }
+    await resolveActor({ variables: { input: { account } } })
+  }
+
+  const markNotificationsRead = async () => {
+    const ids =
+      data?.viewerFediverse.notifications
+        .filter((notification) => notification.unreadCount > 0)
+        .map((notification) => notification.id) ?? []
+    if (ids.length === 0) {
+      return
+    }
+    await runAction(
+      { action: 'mark_read', notificationIds: ids },
+      'notifications'
+    )
+  }
+
+  const reportPost = async (post: FediversePost) => {
+    const reason = window.prompt(
+      intl.formatMessage({
+        defaultMessage: '請簡述檢舉原因',
+        id: 'W1j+F0',
+      })
+    )
+    if (!reason?.trim()) {
+      return
+    }
+    await runAction(
+      {
+        action: 'report',
+        remoteActorId: post.remoteActor.actorId,
+        objectId: post.objectId,
+        reason: reason.trim(),
+      },
+      `report:${post.objectId}`
+    )
+  }
+
+  const Header = () => (
+    <>
+      <Layout.Header
+        left={
+          <Layout.Header.Title>
+            <FormattedMessage defaultMessage="聯邦宇宙" id="b8/cFV" />
+          </Layout.Header.Title>
+        }
+      />
+      <Head
+        title={intl.formatMessage({
+          defaultMessage: '聯邦宇宙',
+          id: 'b8/cFV',
+        })}
+      />
+    </>
+  )
+
+  if (loading) {
+    return (
+      <Layout.Main>
+        <Header />
+        <SpinnerBlock />
+      </Layout.Main>
+    )
+  }
+
+  if (error || !data?.viewerFediverse) {
+    return (
+      <Layout.Main>
+        <Header />
+        {error ? <QueryError error={error} /> : null}
+      </Layout.Main>
+    )
+  }
+
+  const profile = data.viewerFediverse
+  const foundActor = actorResult.data?.fediverseRemoteActor
+
+  return (
+    <Layout.Main>
+      <Header />
+      <Layout.Main.Spacing>
+        <section className={styles.profile}>
+          <div
+            className={styles.headerImage}
+            style={
+              profile.headerUrl
+                ? { backgroundImage: `url("${profile.headerUrl}")` }
+                : undefined
+            }
+          />
+          <div className={styles.profileBody}>
+            <span
+              className={styles.profileAvatar}
+              style={
+                profile.avatarUrl
+                  ? { backgroundImage: `url("${profile.avatarUrl}")` }
+                  : undefined
+              }
+            >
+              {!profile.avatarUrl &&
+                profile.displayName.slice(0, 1).toUpperCase()}
+            </span>
+            <div className={styles.profileText}>
+              <h2>{profile.displayName}</h2>
+              <a href={profile.profileUrl} rel="noreferrer" target="_blank">
+                @{profile.account}
+              </a>
+              {profile.summary && <p>{plainText(profile.summary)}</p>}
+            </div>
+          </div>
+          <div className={styles.metrics}>
+            <span>
+              <strong>{profile.followersCount}</strong>
+              <FormattedMessage defaultMessage="位追蹤者" id="hyDCe8" />
+            </span>
+            <span>
+              <strong>{profile.followingCount}</strong>
+              <FormattedMessage defaultMessage="追蹤中" id="miEMcG" />
+            </span>
+            <span>
+              <strong>{profile.pendingFollowingCount}</strong>
+              <FormattedMessage defaultMessage="等待核准" id="sAB+vZ" />
+            </span>
+          </div>
+        </section>
+
+        <section className={styles.section}>
+          <h2>
+            <FormattedMessage defaultMessage="尋找遠端作者" id="jWwn1K" />
+          </h2>
+          <p className={styles.hint}>
+            <FormattedMessage
+              defaultMessage="輸入完整帳號，例如 @alice@example.social"
+              id="kOStiL"
+            />
+          </p>
+          <form className={styles.search} onSubmit={searchActor}>
+            <input
+              aria-label={intl.formatMessage({
+                defaultMessage: 'Fediverse 帳號',
+                id: 'QJd23B',
+              })}
+              onChange={(event) => setSearch(event.target.value)}
+              placeholder="@alice@example.social"
+              value={search}
+            />
+            <Button
+              bgColor="green"
+              disabled={actorResult.loading || !search.trim()}
+              spacing={[10, 20]}
+              textColor="white"
+              type="submit"
+            >
+              <FormattedMessage defaultMessage="搜尋" id="InCosw" />
+            </Button>
+          </form>
+          {actorResult.error && (
+            <p className={styles.error}>
+              <FormattedMessage
+                defaultMessage="找不到這個聯邦帳號"
+                id="0XnomJ"
+              />
+            </p>
+          )}
+          {foundActor && (
+            <div className={styles.actorRow}>
+              <ActorAvatar actor={foundActor} />
+              <div className={styles.actorText}>
+                <strong>{actorLabel(foundActor)}</strong>
+                <span>{foundActor.account || foundActor.actorId}</span>
+              </div>
+              <Button
+                borderColor="green"
+                disabled={busyKey === `follow:${foundActor.actorId}`}
+                onClick={() =>
+                  runAction(
+                    {
+                      action: 'follow',
+                      account: foundActor.account || search.trim(),
+                      remoteActorId: foundActor.actorId,
+                    },
+                    `follow:${foundActor.actorId}`
+                  )
+                }
+                spacing={[8, 16]}
+                textColor="green"
+              >
+                <FormattedMessage defaultMessage="追蹤" id="kggbxQ" />
+              </Button>
+            </div>
+          )}
+        </section>
+
+        <section className={styles.section}>
+          <h2>
+            <FormattedMessage defaultMessage="追蹤中的作者" id="ByvxDL" />
+          </h2>
+          {profile.following.length === 0 ? (
+            <p className={styles.empty}>
+              <FormattedMessage
+                defaultMessage="尚未追蹤任何遠端作者"
+                id="zWonDB"
+              />
+            </p>
+          ) : (
+            profile.following.map((actor) => (
+              <div className={styles.actorRow} key={actor.actorId}>
+                <ActorAvatar actor={actor} />
+                <div className={styles.actorText}>
+                  <strong>{actorLabel(actor)}</strong>
+                  <span>{actor.account || actor.actorId}</span>
+                </div>
+                <Button
+                  borderColor="grey"
+                  disabled={busyKey === `unfollow:${actor.actorId}`}
+                  onClick={() =>
+                    runAction(
+                      {
+                        action: 'unfollow',
+                        remoteActorId: actor.actorId,
+                      },
+                      `unfollow:${actor.actorId}`
+                    )
+                  }
+                  spacing={[8, 16]}
+                  textColor="greyDarker"
+                >
+                  <FormattedMessage defaultMessage="取消追蹤" id="rjEc9z" />
+                </Button>
+              </div>
+            ))
+          )}
+        </section>
+
+        <section className={styles.section}>
+          <div className={styles.sectionHeader}>
+            <h2>
+              <FormattedMessage defaultMessage="聯邦通知" id="glsBoL" />
+              {profile.unreadNotificationsCount > 0 && (
+                <span className={styles.badge}>
+                  {profile.unreadNotificationsCount}
+                </span>
+              )}
+            </h2>
+            {profile.unreadNotificationsCount > 0 && (
+              <Button
+                disabled={busyKey === 'notifications'}
+                onClick={markNotificationsRead}
+                textColor="green"
+              >
+                <FormattedMessage defaultMessage="全部已讀" id="Q8g2+W" />
+              </Button>
+            )}
+          </div>
+          {profile.notifications.length === 0 ? (
+            <p className={styles.empty}>
+              <FormattedMessage defaultMessage="目前沒有通知" id="VWeoZC" />
+            </p>
+          ) : (
+            profile.notifications.map((notification) => (
+              <div className={styles.notification} key={notification.id}>
+                <div>
+                  <strong>
+                    {notification.headline || notification.category}
+                  </strong>
+                  {notification.preview && (
+                    <p>{plainText(notification.preview)}</p>
+                  )}
+                </div>
+                <span>
+                  {notification.eventCount}
+                  {notification.unreadCount > 0 && ' · new'}
+                </span>
+              </div>
+            ))
+          )}
+        </section>
+
+        <section className={styles.section}>
+          <h2>
+            <FormattedMessage defaultMessage="追蹤動態" id="zK82DU" />
+          </h2>
+          {profile.timeline.length === 0 ? (
+            <p className={styles.empty}>
+              <FormattedMessage
+                defaultMessage="追蹤遠端作者後，最新內容會出現在這裡"
+                id="HFBocb"
+              />
+            </p>
+          ) : (
+            profile.timeline.map((post) => (
+              <article className={styles.post} key={post.objectId}>
+                <header>
+                  <ActorAvatar actor={post.remoteActor} />
+                  <div className={styles.actorText}>
+                    <strong>{actorLabel(post.remoteActor)}</strong>
+                    <span>
+                      {post.remoteActor.account || post.remoteActor.actorId}
+                    </span>
+                  </div>
+                </header>
+                <p className={styles.postContent}>
+                  {plainText(post.content || post.summary)}
+                </p>
+                {post.url && (
+                  <a
+                    className={styles.postLink}
+                    href={post.url}
+                    rel="noreferrer"
+                    target="_blank"
+                  >
+                    <FormattedMessage defaultMessage="查看原文" id="IK6Mk7" />
+                  </a>
+                )}
+                <div className={styles.actions}>
+                  <Button
+                    disabled={busyKey === `like:${post.objectId}`}
+                    onClick={() =>
+                      runAction(
+                        {
+                          action: 'like',
+                          objectId: post.objectId,
+                          remoteActorId: post.remoteActor.actorId,
+                        },
+                        `like:${post.objectId}`
+                      )
+                    }
+                    textColor="green"
+                  >
+                    <FormattedMessage defaultMessage="喜歡" id="NDG8qY" />
+                  </Button>
+                  <Button
+                    disabled={busyKey === `announce:${post.objectId}`}
+                    onClick={() =>
+                      runAction(
+                        {
+                          action: 'announce',
+                          objectId: post.objectId,
+                          remoteActorId: post.remoteActor.actorId,
+                        },
+                        `announce:${post.objectId}`
+                      )
+                    }
+                    textColor="green"
+                  >
+                    <FormattedMessage defaultMessage="轉發" id="bmR7T4" />
+                  </Button>
+                  <Button
+                    disabled={busyKey === `block:${post.remoteActor.actorId}`}
+                    onClick={() =>
+                      runAction(
+                        {
+                          action: 'block',
+                          remoteActorId: post.remoteActor.actorId,
+                          reason: 'Blocked by local user',
+                        },
+                        `block:${post.remoteActor.actorId}`
+                      )
+                    }
+                    textColor="greyDarker"
+                  >
+                    <FormattedMessage defaultMessage="封鎖" id="5UgS3k" />
+                  </Button>
+                  <Button
+                    disabled={busyKey === `report:${post.objectId}`}
+                    onClick={() => reportPost(post)}
+                    textColor="red"
+                  >
+                    <FormattedMessage defaultMessage="檢舉" id="5kX6Qk" />
+                  </Button>
+                </div>
+                <form
+                  className={styles.reply}
+                  onSubmit={async (event) => {
+                    event.preventDefault()
+                    const content = replyDrafts[post.objectId]?.trim()
+                    if (!content) {
+                      return
+                    }
+                    const sent = await runAction(
+                      {
+                        action: 'reply',
+                        objectId: post.objectId,
+                        remoteActorId: post.remoteActor.actorId,
+                        content,
+                      },
+                      `reply:${post.objectId}`
+                    )
+                    if (sent) {
+                      setReplyDrafts((current) => ({
+                        ...current,
+                        [post.objectId]: '',
+                      }))
+                    }
+                  }}
+                >
+                  <input
+                    aria-label={intl.formatMessage({
+                      defaultMessage: '回覆內容',
+                      id: 'ih+UCV',
+                    })}
+                    maxLength={500}
+                    onChange={(event) =>
+                      setReplyDrafts((current) => ({
+                        ...current,
+                        [post.objectId]: event.target.value,
+                      }))
+                    }
+                    placeholder={intl.formatMessage({
+                      defaultMessage: '回覆到聯邦宇宙',
+                      id: 'kw8J39',
+                    })}
+                    value={replyDrafts[post.objectId] || ''}
+                  />
+                  <Button
+                    bgColor="green"
+                    disabled={
+                      busyKey === `reply:${post.objectId}` ||
+                      !replyDrafts[post.objectId]?.trim()
+                    }
+                    spacing={[8, 16]}
+                    textColor="white"
+                    type="submit"
+                  >
+                    <FormattedMessage defaultMessage="送出" id="6UaJbf" />
+                  </Button>
+                </form>
+              </article>
+            ))
+          )}
+          <p className={styles.retention}>
+            <FormattedMessage
+              defaultMessage="最多追蹤 {maxFollowing} 個帳號，動態保留 {days} 天，上限 {items} 筆"
+              id="t1yrE4"
+              values={{
+                days: profile.retentionDays,
+                items: profile.timelineMaxItems,
+                maxFollowing: profile.maxFollowing,
+              }}
+            />
+          </p>
+        </section>
+      </Layout.Main.Spacing>
+    </Layout.Main>
+  )
+}
+
+export default Fediverse

--- a/src/views/Me/Fediverse/styles.module.css
+++ b/src/views/Me/Fediverse/styles.module.css
@@ -1,0 +1,247 @@
+.profile,
+.section {
+  margin-bottom: var(--sp24);
+  overflow: hidden;
+  background: var(--color-white);
+  border: 1px solid var(--color-grey-lighter);
+  border-radius: 0.75rem;
+}
+
+.headerImage {
+  height: 8rem;
+  background-color: var(--color-green-lighter);
+  background-position: center;
+  background-size: cover;
+}
+
+.profileBody {
+  display: flex;
+  gap: var(--sp16);
+  align-items: flex-start;
+  padding: 0 var(--sp20) var(--sp20);
+}
+
+.profileAvatar {
+  @mixin flex-center-all;
+
+  flex: 0 0 auto;
+  width: 5rem;
+  height: 5rem;
+  margin-top: -2.5rem;
+  overflow: hidden;
+  font-size: 2rem;
+  color: var(--color-white);
+  background-color: var(--color-green);
+  background-position: center;
+  background-size: cover;
+  border: 4px solid var(--color-white);
+  border-radius: 50%;
+}
+
+.profileText {
+  min-width: 0;
+  padding-top: var(--sp12);
+
+  & h2 {
+    font-size: var(--font-size-18);
+  }
+
+  & a,
+  & span {
+    color: var(--color-grey-darker);
+    overflow-wrap: anywhere;
+  }
+
+  & p {
+    margin-top: var(--sp8);
+    white-space: pre-wrap;
+  }
+}
+
+.metrics {
+  display: flex;
+  gap: var(--sp24);
+  padding: var(--sp16) var(--sp20);
+  border-top: 1px solid var(--color-grey-lighter);
+
+  & span {
+    display: flex;
+    gap: var(--sp4);
+    font-size: var(--font-size-14);
+    color: var(--color-grey-darker);
+  }
+
+  & strong {
+    color: var(--color-black);
+  }
+}
+
+.section {
+  padding: var(--sp20);
+
+  & > h2,
+  & .sectionHeader h2 {
+    font-size: var(--font-size-18);
+  }
+}
+
+.sectionHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.hint,
+.empty,
+.retention {
+  margin-top: var(--sp8);
+  font-size: var(--font-size-14);
+  color: var(--color-grey-darker);
+}
+
+.search,
+.reply {
+  display: flex;
+  gap: var(--sp8);
+  margin-top: var(--sp12);
+
+  & input {
+    flex: 1;
+    min-width: 0;
+    padding: var(--sp10) var(--sp12);
+    background: var(--color-white);
+    border: 1px solid var(--color-grey-light);
+    border-radius: 0.5rem;
+  }
+}
+
+.error {
+  margin-top: var(--sp8);
+  color: var(--color-red);
+}
+
+.actorRow {
+  display: flex;
+  gap: var(--sp12);
+  align-items: center;
+  padding: var(--sp16) 0;
+  border-bottom: 1px solid var(--color-grey-lighter);
+
+  &:last-child {
+    padding-bottom: 0;
+    border-bottom: 0;
+  }
+}
+
+.avatar {
+  @mixin flex-center-all;
+
+  flex: 0 0 auto;
+  width: 2.75rem;
+  height: 2.75rem;
+  color: var(--color-white);
+  background-color: var(--color-green);
+  background-position: center;
+  background-size: cover;
+  border-radius: 50%;
+}
+
+.actorText {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-width: 0;
+
+  & strong,
+  & span {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  & span {
+    font-size: var(--font-size-12);
+    color: var(--color-grey-darker);
+  }
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.25rem;
+  height: 1.25rem;
+  padding: 0 var(--sp4);
+  margin-left: var(--sp8);
+  font-size: var(--font-size-12);
+  color: var(--color-white);
+  background: var(--color-red);
+  border-radius: 5rem;
+}
+
+.notification {
+  display: flex;
+  gap: var(--sp16);
+  justify-content: space-between;
+  padding: var(--sp16) 0;
+  border-bottom: 1px solid var(--color-grey-lighter);
+
+  & p {
+    margin-top: var(--sp4);
+    color: var(--color-grey-darker);
+  }
+
+  & > span {
+    color: var(--color-green);
+    white-space: nowrap;
+  }
+}
+
+.post {
+  padding: var(--sp20) 0;
+  border-bottom: 1px solid var(--color-grey-lighter);
+
+  & header {
+    display: flex;
+    gap: var(--sp12);
+    align-items: center;
+  }
+}
+
+.postContent {
+  margin: var(--sp12) 0;
+  white-space: pre-wrap;
+}
+
+.postLink {
+  font-size: var(--font-size-14);
+  color: var(--color-green);
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--sp16);
+  margin-top: var(--sp12);
+}
+
+.retention {
+  padding-top: var(--sp16);
+  text-align: center;
+}
+
+@media (--sm-down) {
+  .metrics {
+    gap: var(--sp12);
+    justify-content: space-between;
+
+    & span {
+      flex-direction: column;
+      gap: 0;
+    }
+  }
+
+  .section {
+    padding: var(--sp16);
+  }
+}

--- a/src/views/Me/Notifications/index.tsx
+++ b/src/views/Me/Notifications/index.tsx
@@ -3,8 +3,10 @@ import gql from 'graphql-tag'
 import { useContext, useEffect } from 'react'
 import { FormattedMessage, useIntl } from 'react-intl'
 
+import { PATHS } from '~/common/enums'
 import { mergeConnections, shouldRenderNode } from '~/common/utils'
 import {
+  Button,
   EmptyNotice,
   Head,
   InfiniteScroll,
@@ -24,6 +26,8 @@ import {
   MarkAllNoticesAsReadMutation,
   MeNotificationsQuery,
 } from '~/gql/graphql'
+
+import styles from './styles.module.css'
 
 const renderableTypes = new Set([
   'ArticleArticleNotice',
@@ -77,8 +81,34 @@ const MARK_ALL_NOTICES_AS_READ = gql`
   }
 `
 
+const FEDIVERSE_NOTIFICATIONS = gql`
+  query FediverseNotificationsDigest {
+    viewerFediverse {
+      unreadNotificationsCount
+      notifications {
+        id
+        category
+        headline
+        preview
+        eventCount
+        unreadCount
+        publishedAt
+      }
+    }
+  }
+`
+
+const MARK_FEDIVERSE_NOTIFICATIONS_READ = gql`
+  mutation MarkFediverseNotificationsRead($input: FediverseActionInput!) {
+    actFediverse(input: $input) {
+      status
+    }
+  }
+`
+
 const BaseNotifications = () => {
   const viewer = useContext(ViewerContext)
+  const federationEnabled = viewer.federationSetting?.state === 'enabled'
 
   const [markAllNoticesAsRead] = useMutation<MarkAllNoticesAsReadMutation>(
     MARK_ALL_NOTICES_AS_READ,
@@ -102,10 +132,47 @@ const BaseNotifications = () => {
   >(ME_NOTIFICATIONS, {
     fetchPolicy: 'network-only',
   })
+  const { data: federationData } = useQuery<{
+    viewerFediverse: {
+      unreadNotificationsCount: number
+      notifications: Array<{
+        id: string
+        category: string
+        headline?: string | null
+        preview?: string | null
+        eventCount: number
+        unreadCount: number
+      }>
+    }
+  }>(FEDIVERSE_NOTIFICATIONS, {
+    errorPolicy: 'ignore',
+    fetchPolicy: 'network-only',
+    skip: !federationEnabled,
+  })
+  const [markFediverseNotificationsRead] = useMutation(
+    MARK_FEDIVERSE_NOTIFICATIONS_READ
+  )
 
   useEffect(() => {
     markAllNoticesAsRead()
   }, [])
+
+  useEffect(() => {
+    const ids =
+      federationData?.viewerFediverse.notifications
+        .filter((notification) => notification.unreadCount > 0)
+        .map((notification) => notification.id) ?? []
+    if (ids.length > 0) {
+      markFediverseNotificationsRead({
+        variables: {
+          input: {
+            action: 'mark_read',
+            notificationIds: ids,
+          },
+        },
+      })
+    }
+  }, [federationData?.viewerFediverse.notifications])
 
   const connectionPath = 'viewer.notices'
   const { edges, pageInfo } = data?.viewer?.notices || {}
@@ -114,12 +181,21 @@ const BaseNotifications = () => {
     return <SpinnerBlock />
   }
 
-  if (!edges || edges.length <= 0 || !pageInfo) {
+  const federationNotifications =
+    federationData?.viewerFediverse.notifications ?? []
+
+  if (
+    (!edges || edges.length <= 0 || !pageInfo) &&
+    federationNotifications.length === 0
+  ) {
     return <EmptyNotice />
   }
 
-  const loadMore = () =>
-    fetchMore({
+  const loadMore = () => {
+    if (!pageInfo) {
+      return Promise.resolve()
+    }
+    return fetchMore({
       variables: { first: 20, after: pageInfo.endCursor },
       updateQuery: (previousResult, { fetchMoreResult }) =>
         mergeConnections({
@@ -128,20 +204,60 @@ const BaseNotifications = () => {
           path: connectionPath,
         }),
     })
+  }
 
   return (
-    <InfiniteScroll hasNextPage={pageInfo.hasNextPage} loadMore={loadMore} eof>
-      <List spacing={['xxxloose', 0]} hasBorder={false}>
-        {edges.map(
-          ({ node }) =>
-            shouldRenderNode(node, renderableTypes) && (
-              <List.Item key={node.id}>
-                <Notice notice={node} />
-              </List.Item>
-            )
-        )}
-      </List>
-    </InfiniteScroll>
+    <>
+      {federationNotifications.length > 0 && (
+        <section className={styles.fediverse}>
+          <header>
+            <div>
+              <h2>
+                <FormattedMessage defaultMessage="聯邦通知" id="glsBoL" />
+              </h2>
+              <p>
+                <FormattedMessage
+                  defaultMessage="來自其他 Fediverse 站台的互動"
+                  id="4GmeZE"
+                />
+              </p>
+            </div>
+            <Button href={PATHS.ME_FEDIVERSE} textColor="green">
+              <FormattedMessage defaultMessage="查看全部" id="t0kvjC" />
+            </Button>
+          </header>
+          {federationNotifications.slice(0, 5).map((notification) => (
+            <div className={styles.fediverseItem} key={notification.id}>
+              <div>
+                <strong>
+                  {notification.headline || notification.category}
+                </strong>
+                {notification.preview && <p>{notification.preview}</p>}
+              </div>
+              <span>{notification.eventCount}</span>
+            </div>
+          ))}
+        </section>
+      )}
+      {edges && pageInfo && (
+        <InfiniteScroll
+          hasNextPage={pageInfo.hasNextPage}
+          loadMore={loadMore}
+          eof
+        >
+          <List spacing={['xxxloose', 0]} hasBorder={false}>
+            {edges.map(
+              ({ node }) =>
+                shouldRenderNode(node, renderableTypes) && (
+                  <List.Item key={node.id}>
+                    <Notice notice={node} />
+                  </List.Item>
+                )
+            )}
+          </List>
+        </InfiniteScroll>
+      )}
+    </>
   )
 }
 

--- a/src/views/Me/Notifications/styles.module.css
+++ b/src/views/Me/Notifications/styles.module.css
@@ -1,0 +1,40 @@
+.fediverse {
+  padding: var(--sp16);
+  margin-bottom: var(--sp24);
+  border: 1px solid var(--color-grey-lighter);
+  border-radius: 0.75rem;
+
+  & > header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    margin-bottom: var(--sp8);
+
+    & h2 {
+      font-size: var(--font-size-18);
+    }
+
+    & p {
+      margin-top: var(--sp4);
+      font-size: var(--font-size-14);
+      color: var(--color-grey-darker);
+    }
+  }
+}
+
+.fediverseItem {
+  display: flex;
+  gap: var(--sp16);
+  justify-content: space-between;
+  padding: var(--sp12) 0;
+  border-top: 1px solid var(--color-grey-lighter);
+
+  & p {
+    margin-top: var(--sp4);
+    color: var(--color-grey-darker);
+  }
+
+  & > span {
+    color: var(--color-green);
+  }
+}

--- a/src/views/Me/Settings/Misc/FederationSetting.tsx
+++ b/src/views/Me/Settings/Misc/FederationSetting.tsx
@@ -3,6 +3,7 @@ import gql from 'graphql-tag'
 import { useEffect, useState } from 'react'
 import { FormattedMessage, useIntl } from 'react-intl'
 
+import { PATHS } from '~/common/enums'
 import { Switch, TableView, toast, useMutation } from '~/components'
 import {
   FederationAuthorSettingState,
@@ -93,28 +94,48 @@ const FederationSetting = () => {
   }
 
   return (
-    <TableView.Cell
-      title={
-        <FormattedMessage defaultMessage="Fediverse 聯邦發佈" id="YC2b3b" />
-      }
-      subtitle={
-        <FormattedMessage
-          defaultMessage="開啟後，新發佈的公開作品會自動送到 Fediverse。其他站台可能保留副本；關閉後將停止同步，並嘗試刪除先前內容。"
-          id="2cnZc/"
-        />
-      }
-      right={
-        <Switch
-          name="fediverse-federation-setting"
-          label={
-            <FormattedMessage defaultMessage="Fediverse 聯邦發佈" id="YC2b3b" />
+    <>
+      <TableView.Cell
+        title={
+          <FormattedMessage defaultMessage="Fediverse 聯邦發佈" id="YC2b3b" />
+        }
+        subtitle={
+          <FormattedMessage
+            defaultMessage="開啟後，新發佈的公開作品會自動送到 Fediverse。其他站台可能保留副本；關閉後將停止同步，並嘗試刪除先前內容。"
+            id="2cnZc/"
+          />
+        }
+        right={
+          <Switch
+            name="fediverse-federation-setting"
+            label={
+              <FormattedMessage
+                defaultMessage="Fediverse 聯邦發佈"
+                id="YC2b3b"
+              />
+            }
+            checked={enabled}
+            loading={loading || saving}
+            onChange={updateSetting}
+          />
+        }
+      />
+      {enabled && (
+        <TableView.Cell
+          role="link"
+          title={
+            <FormattedMessage defaultMessage="聯邦宇宙互動中心" id="Nw8VNu" />
           }
-          checked={enabled}
-          loading={loading || saving}
-          onChange={updateSetting}
+          subtitle={
+            <FormattedMessage
+              defaultMessage="追蹤遠端作者、閱讀聯邦動態，並管理回覆與通知"
+              id="rudmDY"
+            />
+          }
+          href={PATHS.ME_FEDIVERSE}
         />
-      }
-    />
+      )}
+    </>
   )
 }
 


### PR DESCRIPTION
## Summary

- add `/me/fediverse` for profile refresh, account discovery, following, timeline and remote interactions
- show Fediverse activity in the global unread state and Matters notification center
- add author-only reply, like and announce controls to federated articles
- expose the interaction center from desktop and mobile navigation plus federation settings
- refresh actor avatar and header when an enabled author enters the interaction center

## Dependency

- Server API: https://github.com/thematters/matters-server/pull/4954

## Validation

- production Next.js build passed and includes `/me/fediverse`
- TypeScript, ESLint and Stylelint passed
- GraphQL client types and i18n catalogs regenerated
- 2 targeted federation setting tests passed

## Rollout

This PR does not deploy production. Merge after the Server API contract is accepted.