### PR TITLE
Add transparency entry to terms page

### DIFF
--- a/src/views/ToS/index.tsx
+++ b/src/views/ToS/index.tsx
@@ -1,8 +1,10 @@
 import { FormattedMessage, useIntl } from 'react-intl'
 
 import IMAGE_INTRO from '@/public/static/images/intro.jpg'
-import { Head, Layout } from '~/components'
+import { PATHS } from '~/common/enums'
+import { Button, Head, Layout, TextIcon, Translate } from '~/components'
 
+import styles from './styles.module.css'
 import { Term } from './Term'
 
 const ToS = () => {
@@ -30,6 +32,38 @@ const ToS = () => {
       />
 
       <Layout.Main.Spacing>
+        <section className={styles.transparencyEntry}>
+          <div>
+            <h2>
+              <Translate
+                zh_hant="平台治理與透明度"
+                zh_hans="平台治理与透明度"
+                en="Governance and Transparency"
+              />
+            </h2>
+            <p>
+              <Translate
+                zh_hant="查看內容治理、申訴機制、政府與個資請求統計，以及定期透明度報告。"
+                zh_hans="查看内容治理、申诉机制、政府与个人资料请求统计，以及定期透明度报告。"
+                en="Review content governance, appeals, government and privacy request metrics, and periodic transparency reports."
+              />
+            </p>
+          </div>
+          <Button
+            borderColor="green"
+            href={PATHS.TRANSPARENCY}
+            size={[null, '2.25rem']}
+            spacing={[0, 16]}
+          >
+            <TextIcon color="green" size={14} weight="medium">
+              <Translate
+                zh_hant="前往透明度中心"
+                zh_hans="前往透明度中心"
+                en="Open Transparency Center"
+              />
+            </TextIcon>
+          </Button>
+        </section>
         <Term />
       </Layout.Main.Spacing>
     </Layout.Main>

--- a/src/views/ToS/styles.module.css
+++ b/src/views/ToS/styles.module.css
@@ -1,0 +1,29 @@
+.transparencyEntry {
+  display: flex;
+  gap: var(--sp16);
+  align-items: center;
+  justify-content: space-between;
+  padding-bottom: var(--sp24);
+  margin-bottom: var(--sp24);
+  border-bottom: 1px solid var(--color-grey-lighter);
+
+  & h2 {
+    font-size: var(--font-size-18);
+  }
+
+  & p {
+    max-width: 36rem;
+    margin-top: var(--sp8);
+    font-size: var(--font-size-14);
+    color: var(--color-grey-darker);
+  }
+
+  & > a {
+    flex: 0 0 auto;
+  }
+
+  @media (--sm-down) {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}


### PR DESCRIPTION
## Summary

- add a compact governance and transparency entry above the terms content
- provide Traditional Chinese, Simplified Chinese, and English copy
- link to the existing `/transparency` route without changing terms content or data structures

## Verification

- `npm run lint:css`
- `npm run lint:ts`
- `npm run build`
- browser QA at 1280x800 and 390x844
- verified `/tos` link navigates to `/transparency`