### PR TITLE
Correct 2026 H1 privacy request totals

### DIFF
--- a/public/transparency/aggregate-transparency-metrics-2026-H1.public.json
+++ b/public/transparency/aggregate-transparency-metrics-2026-H1.public.json
@@ -12,7 +12,8 @@
     "notes": [
       "Legacy moderation and appeal records before the structured case schema are only partially covered.",
       "Only aggregated counts are exported; user ids, emails, IPs, original content, internal notes, and legal document contents are excluded.",
-      "The maintainer reviewed the known private legal and compliance history through 2025-07 and confirmed that no later government, legal, or privacy-rights request records exist for 2026 H1.",
+      "The maintainer reviewed the known private legal and compliance history through 2025-07 and completed a supplemental read-only review of the official inbox on 2026-07-24.",
+      "The official-inbox review confirmed 0 government or legal requests and identified 5 user-initiated account deletion requests in 2026 H1.",
       "Change logs are derived from merged public pull requests and were reviewed for final publication."
     ],
     "review_required_fields": []
@@ -67,10 +68,10 @@
       "not_recorded": false
     },
     "privacy_requests": {
-      "total": 0,
+      "total": 5,
       "access": 0,
       "correction": 0,
-      "deletion": 0,
+      "deletion": 5,
       "restriction": 0,
       "not_recorded": false
     },
@@ -148,5 +149,5 @@
     ]
   },
   "source_generated_at": "2026-07-14T18:23:47+08:00",
-  "external_metrics_reviewed_at": "2026-07-14T20:02:46+08:00"
+  "external_metrics_reviewed_at": "2026-07-24T16:51:52+08:00"
 }

--- a/src/views/Transparency/content.ts
+++ b/src/views/Transparency/content.ts
@@ -5,7 +5,7 @@ const zh_hant = `
 
 - [2026 H1 透明度報告](/transparency/2026-h1)
 
-2026 H1 報告已於 2026-07-14 完成核定。報告公開 717 件 Community Watch 治理動作、結構化案件與申訴的資料限制、政府與個資權利請求零件數，以及本期重大政策、模型與推薦變更。
+2026 H1 報告已於 2026-07-14 完成核定，並於 2026-07-24 完成正式收件信箱補充複核。報告公開 717 件 Community Watch 治理動作、結構化案件與申訴的資料限制、政府與法律請求 0 件、個資刪除請求 5 件，以及本期重大政策、模型與推薦變更。
 
 ## 主題說明
 
@@ -39,7 +39,7 @@ const zh_hans = `
 
 - [2026 H1 透明度报告](/transparency/2026-h1)
 
-2026 H1 报告已于 2026-07-14 完成核定。报告公开 717 件 Community Watch 治理动作、结构化案件与申诉的资料限制、政府与个资权利请求零件数，以及本期重大政策、模型与推荐变更。
+2026 H1 报告已于 2026-07-14 完成核定，并于 2026-07-24 完成正式收件信箱补充复核。报告公开 717 件 Community Watch 治理动作、结构化案件与申诉的资料限制、政府与法律请求 0 件、个人资料删除请求 5 件，以及本期重大政策、模型与推荐变更。
 
 ## 主题说明
 
@@ -73,7 +73,7 @@ This page collects public information about Matters content governance, appeals,
 
 - [2026 H1 Transparency Report](/transparency/2026-h1)
 
-The 2026 H1 report was approved on 2026-07-14. It publishes 717 Community Watch governance actions, coverage limits for structured cases and appeals, confirmed zero counts for government and privacy-rights requests, and material policy, model, and recommendation changes.
+The 2026 H1 report was approved on 2026-07-14 and supplemented by a direct review of the official inbox on 2026-07-24. It publishes 717 Community Watch governance actions, coverage limits for structured cases and appeals, 0 government and legal requests, 5 personal-data deletion requests, and material policy, model, and recommendation changes.
 
 ## Topic pages
 

--- a/src/views/TransparencyReport/content2026H1.ts
+++ b/src/views/TransparencyReport/content2026H1.ts
@@ -1,11 +1,11 @@
 const zh_hant = `
-本頁是 Matters 2026 H1 透明度報告。報告期間為 2026-01-01 至 2026-06-30，時區為 Asia/Taipei。統計於 2026-07-14 完成匯出與核定。
+本頁是 Matters 2026 H1 透明度報告。報告期間為 2026-01-01 至 2026-06-30，時區為 Asia/Taipei。統計於 2026-07-14 完成匯出與核定，並於 2026-07-24 完成正式收件信箱補充複核。
 
 公開數字只包含聚合結果，不包含姓名、電子郵件、IP、內容原文、案件編號、內部備註、法律文件或附件。正數低於 5 件時統一顯示為 \`<5\`，降低從交叉分類反推出單一個案的風險。
 
 ## 1. 資料來源與範圍
 
-站內統計由 production 唯讀資料庫的固定期間匯出產生。政府、法律與個資權利請求由私有法律及合規歷史底稿補充，公開政策、模型與推薦變更則依已合併的 GitHub PR 整理。
+站內統計由 production 唯讀資料庫的固定期間匯出產生。政府、法律與個資權利請求由私有法律及合規歷史底稿與正式收件信箱的唯讀搜尋補充，公開政策、模型與推薦變更則依已合併的 GitHub PR 整理。
 
 一般內容檢舉與申訴的新案件資料模型尚未完整涵蓋舊制紀錄，因此相關 0 件只能解讀為本期結構化來源沒有可計入案件。Community Watch 公開紀錄的涵蓋較完整，可作為本期治理活動的主要量化資料。
 
@@ -46,7 +46,9 @@ Matters 的治理由使用者檢舉、Community Watch、站方管理員與反濫
 
 ## 7. 個人資料權利請求
 
-2026 H1 個資權利請求為 0 件。查詢、閱覽或複製，更正，刪除，以及停止蒐集、處理或利用均為 0 件。
+2026 H1 個資權利請求為 5 件，全部屬於使用者主動提出的帳號刪除或註銷請求。查詢、閱覽或複製為 0 件，更正為 0 件，刪除為 5 件，停止蒐集、處理或利用為 0 件。
+
+補充複核使用固定期間與中英文權利請求關鍵詞搜尋正式收件信箱，以不同會話群組去重。公開報告只揭露聚合數字，不公開寄件者、帳號、主旨、往來內容或內部處理紀錄。
 
 權利內容與聯絡管道請參考 [隱私政策與使用者協議](/tos) 及 [申訴與救濟中心](/appeals)。
 
@@ -74,8 +76,8 @@ Matters 的治理由使用者檢舉、Community Watch、站方管理員與反濫
 
 - 舊制檢舉與 email 申訴沒有完整回填，無法提供完整成立率與處理時間。
 - 結構化案件資料模型在本期後段才完成，需持續累積才能進行趨勢比較。
-- 政府、法律與個資權利請求已完成本期零件數核定，後續應直接使用固定登錄表，減少期末人工回溯。
-- ObservableHQ 可在取得編輯權限後作為非阻塞的獨立交叉核對，不影響本期報告核定。
+- 政府與法律請求已核定為 0 件；個資權利請求經正式收件信箱補充複核後修正為 5 件刪除請求。
+- 後續應直接使用固定登錄表記錄政府、法律與個資權利請求，減少期末人工回溯。
 
 ## 機器可讀資料與相關頁面
 
@@ -89,13 +91,13 @@ Matters 的治理由使用者檢舉、Community Watch、站方管理員與反濫
 `
 
 const zh_hans = `
-本页是 Matters 2026 H1 透明度报告。报告期间为 2026-01-01 至 2026-06-30，时区为 Asia/Taipei。统计于 2026-07-14 完成汇出与核定。
+本页是 Matters 2026 H1 透明度报告。报告期间为 2026-01-01 至 2026-06-30，时区为 Asia/Taipei。统计于 2026-07-14 完成汇出与核定，并于 2026-07-24 完成正式收件信箱补充复核。
 
 公开数字只包含聚合结果，不包含姓名、电子邮件、IP、内容原文、案件编号、内部备注、法律文件或附件。正数低于 5 件时统一显示为 \`<5\`，降低从交叉分类反推出单一个案的风险。
 
 ## 1. 资料来源与范围
 
-站内统计由 production 只读资料库的固定期间汇出产生。政府、法律与个资权利请求由私有法律及合规历史底稿补充，公开政策、模型与推荐变更则依已合并的 GitHub PR 整理。
+站内统计由 production 只读资料库的固定期间汇出产生。政府、法律与个人资料权利请求由私有法律及合规历史底稿与正式收件信箱的只读搜寻补充，公开政策、模型与推荐变更则依已合并的 GitHub PR 整理。
 
 一般内容举报与申诉的新案件资料模型尚未完整涵盖旧制记录，因此相关 0 件只能解读为本期结构化来源没有可计入案件。Community Watch 公开记录的涵盖较完整，可作为本期治理活动的主要量化资料。
 
@@ -136,7 +138,9 @@ Matters 的治理由使用者举报、Community Watch、站方管理员与反滥
 
 ## 7. 个人资料权利请求
 
-2026 H1 个资权利请求为 0 件。查询、阅览或复制，更正，删除，以及停止搜集、处理或利用均为 0 件。
+2026 H1 个人资料权利请求为 5 件，全部属于使用者主动提出的帐号删除或注销请求。查询、阅览或复制为 0 件，更正为 0 件，删除为 5 件，停止搜集、处理或利用为 0 件。
+
+补充复核使用固定期间与中英文权利请求关键词搜寻正式收件信箱，以不同会话群组去重。公开报告只揭露聚合数字，不公开寄件者、帐号、主旨、往来内容或内部处理记录。
 
 权利内容与联系管道请参考 [隐私政策与使用者协议](/tos) 及 [申诉与救济中心](/appeals)。
 
@@ -164,8 +168,8 @@ Matters 的治理由使用者举报、Community Watch、站方管理员与反滥
 
 - 旧制举报与 email 申诉没有完整回填，无法提供完整成立率与处理时间。
 - 结构化案件资料模型在本期后段才完成，需持续累积才能进行趋势比较。
-- 政府、法律与个资权利请求已完成本期零件数核定，后续应直接使用固定登录表，减少期末人工回溯。
-- ObservableHQ 可在取得编辑权限后作为非阻塞的独立交叉核对，不影响本期报告核定。
+- 政府与法律请求已核定为 0 件；个人资料权利请求经正式收件信箱补充复核后修正为 5 件删除请求。
+- 后续应直接使用固定登录表记录政府、法律与个人资料权利请求，减少期末人工回溯。
 
 ## 机器可读资料与相关页面
 
@@ -179,13 +183,13 @@ Matters 的治理由使用者举报、Community Watch、站方管理员与反滥
 `
 
 const en = `
-This is the Matters 2026 H1 Transparency Report. The reporting period is 2026-01-01 through 2026-06-30 in Asia/Taipei. Export and review were completed on 2026-07-14.
+This is the Matters 2026 H1 Transparency Report. The reporting period is 2026-01-01 through 2026-06-30 in Asia/Taipei. Export and review were completed on 2026-07-14, followed by a supplemental review of the official inbox on 2026-07-24.
 
 Published figures contain aggregate results only. They exclude names, email addresses, IP addresses, original content, case identifiers, internal notes, legal documents, and attachments. Positive counts below 5 are shown as \`<5\` to reduce re-identification risk across categories.
 
 ## 1. Sources and scope
 
-On-platform metrics come from a fixed-period export of the read-only production database. Government, legal, and privacy-rights request counts are supplemented by the private legal and compliance history. Public policy, model, and recommendation changes are compiled from merged GitHub pull requests.
+On-platform metrics come from a fixed-period export of the read-only production database. Government, legal, and privacy-rights request counts are supplemented by the private legal and compliance history and read-only searches of the official inbox. Public policy, model, and recommendation changes are compiled from merged GitHub pull requests.
 
 The new case schema for ordinary reports and appeals does not fully cover legacy records. A zero in those sections only means that the structured source contains no countable cases for this period. Community Watch public records have stronger coverage and provide the primary quantitative account of governance activity.
 
@@ -226,7 +230,9 @@ The review covered the known private legal and compliance history. Its latest en
 
 ## 7. Personal data rights requests
 
-Personal data rights requests in 2026 H1: 0. Access or copy, correction, deletion, and restriction requests are all 0.
+Personal data rights requests in 2026 H1: 5. All were user-initiated account deletion or closure requests. Access or copy: 0; correction: 0; deletion: 5; restriction: 0.
+
+The supplemental review used fixed-period searches for Chinese and English rights-request terms and deduplicated results by conversation thread. The public report discloses aggregate counts only and excludes senders, account identifiers, subjects, message content, and internal handling records.
 
 See the [Privacy Policy and Terms](/tos) and [Appeals and Remedies](/appeals) for rights and contact channels.
 
@@ -254,8 +260,8 @@ The reviewed change log contains 3 policy changes, 4 model and automation change
 
 - Legacy reports and email appeals were not fully backfilled, so complete outcome rates and handling times are unavailable.
 - The structured case schema was completed late in the period and needs continued accumulation before trend comparisons are meaningful.
-- Government, legal, and privacy-rights requests were confirmed as zero for this period. Future requests should enter a fixed register as they arrive to reduce end-of-period reconstruction.
-- ObservableHQ can provide a non-blocking independent cross-check after edit access is granted. It does not block this report's approval.
+- Government and legal requests were confirmed as 0. The supplemental official-inbox review corrected personal data rights requests to 5 deletion requests.
+- Future government, legal, and privacy-rights requests should enter a fixed register as they arrive to reduce end-of-period reconstruction.
 
 ## Machine-readable data and related pages
 


### PR DESCRIPTION
## Summary

- correct the 2026 H1 personal-data request total from 0 to 5
- classify all five requests as user-initiated account deletion or closure requests
- document the 2026-07-24 read-only review of the official inbox
- remove the cancelled ObservableHQ follow-up from the public report

## Privacy boundary

Only aggregate counts and review methodology are published. The report excludes senders, account identifiers, subjects, message content, and internal handling records.

## Validation

- pre-commit format, TypeScript, Next.js lint, and stylelint
- production build
- public count suppression threshold remains 5; a count of 5 is published exactly

## Follow-up

After merge and deployment, verify the three-language H1 page, transparency hub, and public JSON in production.